### PR TITLE
fix(config): fail loud on invalid config instead of silently using defaults

### DIFF
--- a/App/memmy-agent/src/config/loader.ts
+++ b/App/memmy-agent/src/config/loader.ts
@@ -7,6 +7,12 @@ import { Config, FileMemoryConfig } from "./schema.js";
 
 let configPathOverride: string | null = null;
 
+/** Base class for config values that fail to load or resolve. Callers should treat these as fatal. */
+export class ConfigError extends Error {}
+
+/** The config file exists but could not be parsed as YAML or failed schema validation. */
+export class ConfigLoadError extends ConfigError {}
+
 function expandHome(value: string): string {
   return value === "~" || value.startsWith("~/") ? path.join(os.homedir(), value.slice(2)) : value;
 }
@@ -25,12 +31,13 @@ export function resolveConfigEnvVars(config: Config): Config {
 }
 
 function resolveInPlace(obj: any): any {
-  if (typeof obj === "string") return obj.replace(/\$\{([A-Z0-9_]+)(?::([^}]*))?\}/gi, (fullMatch, key, fallback) => {
-    void fullMatch;
-    const value = process.env[key] ?? fallback;
-    if (value == null) throw new EnvValueError(`Environment variable ${key} is not set`);
-    return value;
-  });
+  if (typeof obj === "string")
+    return obj.replace(/\$\{([A-Z0-9_]+)(?::([^}]*))?\}/gi, (fullMatch, key, fallback) => {
+      void fullMatch;
+      const value = process.env[key] ?? fallback;
+      if (value == null) throw new EnvValueError(`Environment variable ${key} is not set`);
+      return value;
+    });
   if (Array.isArray(obj)) return obj.map(resolveInPlace);
   if (obj && typeof obj === "object") {
     for (const [key, value] of Object.entries(obj)) obj[key] = resolveInPlace(value);
@@ -38,7 +45,7 @@ function resolveInPlace(obj: any): any {
   return obj;
 }
 
-class EnvValueError extends Error {}
+export class EnvValueError extends ConfigError {}
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
@@ -67,32 +74,30 @@ export function migrateConfig(data: any): any {
 
 export function loadConfig(configPath?: string | null): Config {
   const target = expandHome(configPath ?? getConfigPath());
-  let config = new Config();
   if (!fs.existsSync(target)) {
+    const config = new Config();
     configureSsrfWhitelist(config.tools.ssrfWhitelist);
     return config;
   }
   const raw = fs.readFileSync(target, "utf8");
-  let parsed: any;
+  let config: Config;
   try {
-    parsed = raw.trim() ? YAML.parse(raw) : {};
-  } catch (error) {
-    console.warn(`Failed to load config from ${target}: ${errorMessage(error)}\nUsing default configuration.`);
-    configureSsrfWhitelist(config.tools.ssrfWhitelist);
-    return config;
-  }
-  if (
-    parsed &&
-    typeof parsed === "object" &&
-    !Array.isArray(parsed) &&
-    Object.prototype.hasOwnProperty.call(parsed, "fileMemory")
-  ) {
-    new FileMemoryConfig(parsed.fileMemory);
-  }
-  try {
+    const parsed = raw.trim() ? YAML.parse(raw) : {};
+    if (
+      parsed &&
+      typeof parsed === "object" &&
+      !Array.isArray(parsed) &&
+      Object.prototype.hasOwnProperty.call(parsed, "fileMemory")
+    ) {
+      new FileMemoryConfig(parsed.fileMemory);
+    }
     config = new Config(migrateConfig(parsed));
   } catch (error) {
-    console.warn(`Failed to load config from ${target}: ${errorMessage(error)}\nUsing default configuration.`);
+    // The config file exists but is unusable (bad YAML or a value that fails schema
+    // validation). Silently falling back to defaults here would run the agent on a
+    // configuration the user never asked for (e.g. dropping BYOK credentials), so this
+    // must fail loud instead of warning and continuing.
+    throw new ConfigLoadError(`Failed to load config from ${target}: ${errorMessage(error)}`);
   }
   configureSsrfWhitelist(config.tools.ssrfWhitelist);
   return config;

--- a/App/memmy-agent/src/main.ts
+++ b/App/memmy-agent/src/main.ts
@@ -2,5 +2,15 @@
 // Must load first: inject MEMMY_CLOUD_SERVICE from the repository root .env into process.env for later module evaluation.
 import "./load-env.js";
 import { main } from "./entrypoints/cli/commands.js";
+import { ConfigError } from "./config/loader.js";
 
-await main();
+try {
+  await main();
+} catch (error) {
+  if (!(error instanceof ConfigError)) throw error;
+  // Config load/validation failures are expected user-facing errors (bad YAML, invalid
+  // field, missing env var reference) — report them as a concise fatal message instead of
+  // an unhandled-rejection stack trace, and exit non-zero so scripts can detect the failure.
+  console.error(`memmy: ${error.message}`);
+  process.exitCode = 1;
+}

--- a/App/memmy-agent/tests/config/config-migration.test.ts
+++ b/App/memmy-agent/tests/config/config-migration.test.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import YAML from "yaml";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { onboard } from "../../src/entrypoints/cli/commands.js";
-import { loadConfig, saveConfig } from "../../src/config/loader.js";
+import { ConfigLoadError, loadConfig, saveConfig } from "../../src/config/loader.js";
 import { Config } from "../../src/config/schema.js";
 import { validateUrlTarget } from "../../src/security/network.js";
 
@@ -127,12 +127,12 @@ describe("config migrations", () => {
     const configPath = tmpConfig({
       uuid: "legacy-top-level-cloud-uuid",
       identity: {
-        userId: "legacy-identity-user"
+        userId: "legacy-identity-user",
       },
       memmyMemory: {
         enabled: true,
-        userId: "legacy-memory-user"
-      }
+        userId: "legacy-memory-user",
+      },
     });
 
     const config = loadConfig(configPath);
@@ -154,7 +154,7 @@ describe("config migrations", () => {
         enabled: true,
         activeProfile: "byok",
         storage: {
-          endpoint: "http://127.0.0.1:18888"
+          endpoint: "http://127.0.0.1:18888",
         },
         profiles: {
           byok: {
@@ -163,23 +163,23 @@ describe("config migrations", () => {
               provider: "openai_compatible",
               endpoint: "https://api.example.com/v1",
               model: "gpt-4o",
-              apiKey: "sk-memory"
+              apiKey: "sk-memory",
             },
             evolution: {
               provider: "openai_compatible",
               endpoint: "https://api.example.com/v1",
               model: "gpt-4o-mini",
-              apiKey: "sk-skill"
+              apiKey: "sk-skill",
             },
             embedding: {
               provider: "openai_compatible",
               endpoint: "https://embedding.example.com/v1",
               model: "text-embedding-3-small",
-              apiKey: "sk-embedding"
-            }
-          }
-        }
-      }
+              apiKey: "sk-embedding",
+            },
+          },
+        },
+      },
     });
 
     saveConfig(loadConfig(configPath), configPath);
@@ -191,19 +191,19 @@ describe("config migrations", () => {
       provider: "openai_compatible",
       endpoint: "https://api.example.com/v1",
       model: "gpt-4o",
-      apiKey: "sk-memory"
+      apiKey: "sk-memory",
     });
     expect(saved.memmyMemory.profiles.byok.evolution).toEqual({
       provider: "openai_compatible",
       endpoint: "https://api.example.com/v1",
       model: "gpt-4o-mini",
-      apiKey: "sk-skill"
+      apiKey: "sk-skill",
     });
     expect(saved.memmyMemory.profiles.byok.embedding).toEqual({
       provider: "openai_compatible",
       endpoint: "https://embedding.example.com/v1",
       model: "text-embedding-3-small",
-      apiKey: "sk-embedding"
+      apiKey: "sk-embedding",
     });
     expect(saved.memmyMemory.storage.endpoint).toBe("http://127.0.0.1:18888");
   });
@@ -211,7 +211,7 @@ describe("config migrations", () => {
   it("preserves account memory profile fields across load and save", () => {
     const configPath = tmpConfig({
       app: {
-        userId: "user-1"
+        userId: "user-1",
       },
       memmyMemory: {
         activeProfile: "account",
@@ -221,21 +221,21 @@ describe("config migrations", () => {
             summary: {
               endpoint: "https://apigw.example.com/api/agentExternal/v1",
               model: "memory_summary",
-              apiKey: "cloud-uuid"
+              apiKey: "cloud-uuid",
             },
             evolution: {
               endpoint: "https://apigw.example.com/api/agentExternal/v1",
               model: "memory_evolution",
-              apiKey: "cloud-uuid"
+              apiKey: "cloud-uuid",
             },
             embedding: {
               endpoint: "https://apigw.example.com/api/agentExternal/v1",
               model: "embedding",
-              apiKey: "cloud-uuid"
-            }
-          }
-        }
-      }
+              apiKey: "cloud-uuid",
+            },
+          },
+        },
+      },
     });
 
     saveConfig(loadConfig(configPath), configPath);
@@ -257,17 +257,17 @@ describe("config migrations", () => {
         summary: {
           provider: "openai_compatible",
           endpoint: "https://api.example.com/v1",
-          model: "gpt-4o"
+          model: "gpt-4o",
         },
         evolution: {
           provider: "openai_compatible",
           endpoint: "https://api.example.com/v1",
-          model: "gpt-4o-mini"
+          model: "gpt-4o-mini",
         },
         embedding: {
-          provider: "local"
-        }
-      }
+          provider: "local",
+        },
+      },
     });
 
     saveConfig(loadConfig(configPath), configPath);
@@ -355,27 +355,29 @@ describe("config migrations", () => {
     expect(ok).toBe(false);
   });
 
-  it("falls back to defaults when the config file cannot be parsed", () => {
-    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+  it("throws instead of silently using defaults when the config file cannot be parsed", () => {
+    const configPath = tmpRawConfig("{");
 
-    const config = loadConfig(tmpRawConfig("{"));
-
-    expect(config.agents.defaults.model).toBe(new Config().agents.defaults.model);
-    expect(config.channels.sendMaxRetries).toBe(3);
-    expect(warn).toHaveBeenCalledWith(expect.stringContaining("Using default configuration."));
+    expect(() => loadConfig(configPath)).toThrow(ConfigLoadError);
+    try {
+      loadConfig(configPath);
+      expect.unreachable("loadConfig should have thrown");
+    } catch (error) {
+      expect((error as Error).message).toContain(configPath);
+    }
   });
 
-  it("falls back to defaults when schema validation fails", () => {
-    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+  it("throws instead of silently using defaults when schema validation fails", () => {
+    const configPath = tmpConfig({ channels: { sendMaxRetries: 99 } });
 
-    const config = loadConfig(tmpConfig({ channels: { sendMaxRetries: 99 } }));
-
-    expect(config.channels.sendMaxRetries).toBe(3);
-    expect(warn).toHaveBeenCalledWith(expect.stringContaining("sendMaxRetries"));
+    expect(() => loadConfig(configPath)).toThrow(ConfigLoadError);
+    expect(() => loadConfig(configPath)).toThrow(/sendMaxRetries/);
+    expect(() => loadConfig(configPath)).toThrow(
+      new RegExp(configPath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")),
+    );
   });
 
-  it("resets SSRF whitelist when a bad config falls back to defaults", async () => {
-    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+  it("does not silently reset the SSRF whitelist when a bad config fails to load", async () => {
     const whitelisted = tmpConfig({ tools: { ssrfWhitelist: ["100.64.0.0/10"] } });
     const bad = tmpConfig({
       tools: { ssrfWhitelist: ["100.64.0.0/10"] },
@@ -385,11 +387,21 @@ describe("config migrations", () => {
     loadConfig(whitelisted);
     await expect(validateUrlTarget("http://100.100.1.1/api")).resolves.toEqual([true, ""]);
 
-    const config = loadConfig(bad);
+    expect(() => loadConfig(bad)).toThrow(ConfigLoadError);
+    // The failed load must not have touched any global state (like the SSRF whitelist):
+    // the last successfully loaded config stays in effect until a valid config loads.
     const [ok] = await validateUrlTarget("http://100.100.1.1/api");
+    expect(ok).toBe(true);
+  });
 
-    expect(config.tools.ssrfWhitelist).toEqual([]);
-    expect(ok).toBe(false);
-    expect(warn).toHaveBeenCalledWith(expect.stringContaining("Using default configuration."));
+  it("still loads defaults when the config file does not exist", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "memmy-config-migration-"));
+    roots.push(root);
+    const missingPath = path.join(root, "does-not-exist", "config.yaml");
+
+    const config = loadConfig(missingPath);
+
+    expect(config.agents.defaults.model).toBe(new Config().agents.defaults.model);
+    expect(config.channels.sendMaxRetries).toBe(3);
   });
 });


### PR DESCRIPTION
## 问题

配置文件**存在但非法**时（YAML 语法错误 / 字段校验失败 / `${ENV}` 引用缺失），`loadConfig()` 只 `console.warn` 一句就**静默换用默认配置继续运行**，退出码为 0。

真实复现：把 `providers.custom.apiType` 写成非法值后跑 `memmy status`——警告一闪而过，然后显示默认模型 `anthropic/claude-opus-4-5`、`Custom: not set`。用户的 BYOK key 被静默丢弃，接下来 agent 会拿完全错误的配置运行。这与项目 README 明确宣称的 fail-loud 哲学（"当记忆服务不可用时，Memmy 会明确反馈错误"）自相矛盾。

## 修复

- `src/config/loader.ts`：新增 `ConfigError` → `ConfigLoadError`（坏 YAML / schema 校验失败），并把既有 `EnvValueError` 归入该体系。文件存在但非法 → 抛错（错误信息含文件路径与具体原因）；**文件不存在 → 行为不变**（返回默认配置，`memmy onboard` 首跑路径不受影响）
- `src/main.ts`：CLI 入口统一 catch `ConfigError`，向 stderr 打印 `memmy: <原因>`，退出码 1；其他异常原样抛出，保留可调试性
- 核查其余入口：frontend-bridge / openai-like-api 的 HTTP 路径已有外层 try/catch 转成干净的 HTTP 错误响应；运行时热重载路径（provider/tools snapshot、`/model` 命令）保持"保留最后可用配置"的现有行为，无需改动

## 验证

- `tests/config/config-migration.test.ts`：把编码旧静默 fallback 契约的 3 个测试改为断言抛错（含路径与原因），新增 1 个"文件缺失仍返回默认配置"的护栏测试；经 `git stash` A/B 确认新测试在旧代码上真红、修复后真绿（19/19）
- 真实运行：非法配置 → `status`/`serve`/`gateway` 均以 `memmy: Failed to load config from ...: apiType must be one of ...` 退出码 1 终止（serve/gateway 在绑定端口前退出）；`${不存在的变量}` → `memmy: Environment variable ... is not set`，退出码 1；配置缺失 → `status` 正常、`onboard` 正常生成配置
- `npm run typecheck` / `npm run build` 全绿；全量 `npm test` 4396/4405（6 个失败为 PTY 时序与构建超时类存量问题，经 `git stash` 在未修改代码上复现确认，与本 diff 无关）

## 未覆盖说明

- CLI 层 try/catch 未加子进程级自动化测试，以真实 `node dist/main.js` 运行验证退出码与 stderr（比 mock `process.exit` 更真实）
- App/shell/desktop（Electron）消费方未实测，超出 App/memmy-agent 范围
