### PR TITLE
fix(openai-api): report real token usage in chat completions

### DIFF
--- a/App/memmy-agent/src/core/agent-runtime/loop.ts
+++ b/App/memmy-agent/src/core/agent-runtime/loop.ts
@@ -62,6 +62,7 @@ type AgentLoopResult = [
   hadInjections: boolean,
   finalContentStreamed: boolean,
   errorCategory: ProviderErrorCategory | null,
+  usage: Record<string, any>,
 ];
 
 export enum TurnState {
@@ -108,6 +109,7 @@ export class TurnContext {
   hadInjections = false;
   userPersistedEarly = false;
   saveSkip = 0;
+  usage: Record<string, any> = {};
   outbound: OutboundMessage | null = null;
   onProgress: any = null;
   onStream: any = null;
@@ -1647,7 +1649,8 @@ export class AgentLoop {
         injectionCallback: ({ limit = 3 } = {}) => this.drainPendingQueue(pendingQueue, limit, session?.key ?? sessionKey),
       }),
     );
-    this.lastUsage = normalizeUsageRecord(result.usage ?? result.response?.usage);
+    const turnUsage = normalizeUsageRecord(result.usage ?? result.response?.usage);
+    this.lastUsage = turnUsage;
     const toolsUsed = (result.toolCalls ?? []).map((call: any) => call?.function?.name ?? call?.name).filter(Boolean);
     return [
       result.finalContent ?? result.content ?? EMPTY_FINAL_RESPONSE_MESSAGE,
@@ -1657,6 +1660,7 @@ export class AgentLoop {
       Boolean(result.hadInjections),
       Boolean(result.finalContentStreamed),
       result.response?.errorCategory ?? null,
+      turnUsage,
     ];
   }
 
@@ -1666,11 +1670,12 @@ export class AgentLoop {
     allMessages: Record<string, any>[],
     stopReason: string,
     hadInjections: boolean,
-    { turnLatencyMs = null, tools = null, finalContentStreamed = false, errorCategory = null }: {
+    { turnLatencyMs = null, tools = null, finalContentStreamed = false, errorCategory = null, usage = null }: {
       turnLatencyMs?: number | null;
       tools?: ToolRegistryInstance | null;
       finalContentStreamed?: boolean;
       errorCategory?: ProviderErrorCategory | null;
+      usage?: Record<string, any> | null;
     } = {},
   ): OutboundMessage | null {
     void allMessages;
@@ -1687,6 +1692,7 @@ export class AgentLoop {
         ...(finalContentStreamed && !["error", "toolError"].includes(stopReason) ? { streamed: true } : {}),
         ...(turnLatencyMs != null ? { latencyMs: Math.trunc(turnLatencyMs) } : {}),
         ...(errorCategory === "quota_exhausted" ? { modelErrorCategory: errorCategory } : {}),
+        ...(usage ? { usage } : {}),
       },
     });
   }
@@ -1824,7 +1830,7 @@ export class AgentLoop {
   }
 
   async stateRun(ctx: TurnContext): Promise<string> {
-    const [finalContent, toolsUsed, allMessages, stopReason, hadInjections, finalContentStreamed, errorCategory] = await this.runAgentLoop(ctx.initialMessages, {
+    const [finalContent, toolsUsed, allMessages, stopReason, hadInjections, finalContentStreamed, errorCategory, usage] = await this.runAgentLoop(ctx.initialMessages, {
       onProgress: ctx.onProgress,
       onStream: ctx.onStream,
       onStreamEnd: ctx.onStreamEnd,
@@ -1859,6 +1865,7 @@ export class AgentLoop {
     ctx.hadInjections = hadInjections;
     ctx.finalContentStreamed = finalContentStreamed;
     ctx.errorCategory = errorCategory;
+    ctx.usage = usage;
     return "ok";
   }
 
@@ -1891,6 +1898,7 @@ export class AgentLoop {
       tools: ctx.tools,
       finalContentStreamed: ctx.finalContentStreamed,
       errorCategory: ctx.errorCategory,
+      usage: ctx.usage,
     });
     return "ok";
   }

--- a/App/memmy-agent/src/entrypoints/openai-like-api/server.ts
+++ b/App/memmy-agent/src/entrypoints/openai-like-api/server.ts
@@ -30,7 +30,19 @@ export function errorJson(status: number, message: string, errType = "invalid_re
   return Response.json({ error: { message, type: errType, code: status } }, { status });
 }
 
-export function chatCompletionResponse(content: string, model: string): Record<string, any> {
+function normalizeChatUsage(usage: Record<string, any> | null | undefined): {
+  prompt_tokens: number;
+  completion_tokens: number;
+  total_tokens: number;
+} {
+  const promptTokens = Math.max(0, Math.trunc(Number(usage?.prompt_tokens ?? 0)) || 0);
+  const completionTokens = Math.max(0, Math.trunc(Number(usage?.completion_tokens ?? 0)) || 0);
+  const rawTotal = Number(usage?.total_tokens);
+  const totalTokens = Number.isFinite(rawTotal) && rawTotal > 0 ? Math.trunc(rawTotal) : promptTokens + completionTokens;
+  return { prompt_tokens: promptTokens, completion_tokens: completionTokens, total_tokens: totalTokens };
+}
+
+export function chatCompletionResponse(content: string, model: string, usage?: Record<string, any> | null): Record<string, any> {
   return {
     id: `chatcmpl-${crypto.randomUUID().slice(0, 12)}`,
     object: "chat.completion",
@@ -43,7 +55,7 @@ export function chatCompletionResponse(content: string, model: string): Record<s
         finish_reason: "stop",
       },
     ],
-    usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
+    usage: normalizeChatUsage(usage),
   };
 }
 
@@ -51,6 +63,22 @@ function responseText(value: any): string {
   if (value == null) return "";
   if (typeof value?.content === "string") return value.content;
   return String(value);
+}
+
+function responseUsage(value: any): Record<string, any> {
+  const usage = value?.metadata?.usage;
+  return usage && typeof usage === "object" ? usage : {};
+}
+
+function mergeUsageRecords(...records: Array<Record<string, any> | null | undefined>): Record<string, number> {
+  const merged: Record<string, number> = {};
+  for (const record of records) {
+    for (const [key, value] of Object.entries(record ?? {})) {
+      const num = Number(value);
+      if (Number.isFinite(num)) merged[key] = (merged[key] ?? 0) + num;
+    }
+  }
+  return merged;
 }
 
 export function sseChunk(delta: string, model: string, chunkId: string, finishReason: string | null = null): string {
@@ -66,6 +94,18 @@ export function sseChunk(delta: string, model: string, chunkId: string, finishRe
         finish_reason: finishReason,
       },
     ],
+  };
+  return `data: ${JSON.stringify(payload)}\n\n`;
+}
+
+export function sseUsageChunk(usage: Record<string, any> | null | undefined, model: string, chunkId: string): string {
+  const payload = {
+    id: chunkId,
+    object: "chat.completion.chunk",
+    created: Math.floor(Date.now() / 1000),
+    model,
+    choices: [] as unknown[],
+    usage: normalizeChatUsage(usage),
   };
   return `data: ${JSON.stringify(payload)}\n\n`;
 }
@@ -215,6 +255,7 @@ export async function handleChatCompletions(request: Request, ctx?: ApiContext):
   let sessionId: string | null | undefined;
   let requestedModel: string | null | undefined;
   let stream = false;
+  let streamIncludeUsage = false;
 
   try {
     if (contentType.startsWith("multipart/")) {
@@ -227,6 +268,7 @@ export async function handleChatCompletions(request: Request, ctx?: ApiContext):
         return errorJson(400, "Invalid JSON body");
       }
       stream = Boolean(body.stream);
+      streamIncludeUsage = Boolean(body.stream_options?.include_usage);
       requestedModel = body.model;
       [text, mediaPaths] = parseJsonContent(body);
       sessionId = body.session_id;
@@ -277,6 +319,7 @@ export async function handleChatCompletions(request: Request, ctx?: ApiContext):
         };
         void (async () => {
           let failed = false;
+          let turnUsage: Record<string, any> = {};
           const onStream = async (token: string) => {
             if (token) emitted = true;
             write(sseChunk(token, context.modelName, chunkId));
@@ -294,6 +337,7 @@ export async function handleChatCompletions(request: Request, ctx?: ApiContext):
                 ),
                 context.requestTimeout,
               );
+              turnUsage = responseUsage(response);
               if (!emitted) {
                 const finalText = responseText(response);
                 if (finalText.trim()) write(sseChunk(finalText, context.modelName, chunkId));
@@ -304,6 +348,7 @@ export async function handleChatCompletions(request: Request, ctx?: ApiContext):
           } finally {
             if (!failed) {
               write(sseChunk("", context.modelName, chunkId, "stop"));
+              if (streamIncludeUsage) write(sseUsageChunk(turnUsage, context.modelName, chunkId));
               write(SSE_DONE);
             }
             close();
@@ -328,14 +373,16 @@ export async function handleChatCompletions(request: Request, ctx?: ApiContext):
     const reply = await withSessionLock(context, sessionKey, async () => {
       const first = await withTimeout(Promise.resolve(callAgent(context, baseArgs)), context.requestTimeout);
       let textResponse = responseText(first);
+      let usage = responseUsage(first);
       if (!textResponse.trim()) {
         const retry = await withTimeout(Promise.resolve(callAgent(context, baseArgs)), context.requestTimeout);
         textResponse = responseText(retry);
+        usage = mergeUsageRecords(usage, responseUsage(retry));
         if (!textResponse.trim()) textResponse = EMPTY_FINAL_RESPONSE_MESSAGE;
       }
-      return textResponse;
+      return { text: textResponse, usage };
     });
-    return Response.json(chatCompletionResponse(reply, context.modelName));
+    return Response.json(chatCompletionResponse(reply.text, context.modelName, reply.usage));
   } catch (err) {
     const message = (err as Error).message ?? "";
     if (message.startsWith("Request timed out")) return errorJson(504, message);

--- a/App/memmy-agent/tests/core/agent-runtime/loop-usage-metadata.test.ts
+++ b/App/memmy-agent/tests/core/agent-runtime/loop-usage-metadata.test.ts
@@ -1,0 +1,91 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AgentLoop } from "../../../src/core/agent-runtime/loop.js";
+import { AgentRunResult } from "../../../src/core/agent-runtime/runner.js";
+import { Config } from "../../../src/config/schema.js";
+
+const roots: string[] = [];
+
+function workspace(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "memmy-loop-usage-"));
+  roots.push(dir);
+  return dir;
+}
+
+function loop(): AgentLoop {
+  const root = workspace();
+  return new AgentLoop({
+    provider: { generation: { maxTokens: 100 }, chat: vi.fn(), getDefaultModel: () => "test-model" },
+    workspace: root,
+    model: "test-model",
+    contextWindowTokens: 4096,
+    sessionDir: path.join(root, "sessions"),
+    config: new Config({ memmyMemory: { enabled: false } }),
+  });
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  for (const dir of roots.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
+});
+
+describe("AgentLoop turn usage propagation", () => {
+  it("attaches the turn's accumulated token usage to the OutboundMessage metadata", async () => {
+    const agent = loop();
+    agent.runner.run = vi.fn(async () =>
+      new AgentRunResult({
+        finalContent: "done",
+        messages: [{ role: "assistant", content: "done" }],
+        stopReason: "completed",
+        // Simulates a turn that ran two tool-call iterations before finishing:
+        // AgentRunner.run() sums per-iteration usage before returning here.
+        usage: { prompt_tokens: 120, completion_tokens: 45, total_tokens: 165 },
+      }),
+    );
+
+    const outbound = await agent.processDirect("hello", { sessionKey: "cli:usage" });
+
+    expect(outbound?.metadata.usage).toEqual({ prompt_tokens: 120, completion_tokens: 45, total_tokens: 165 });
+    expect(agent.lastUsage).toEqual({ prompt_tokens: 120, completion_tokens: 45, total_tokens: 165 });
+  });
+
+  it("falls back to zeroed usage fields when the run reports none", async () => {
+    const agent = loop();
+    agent.runner.run = vi.fn(async () =>
+      new AgentRunResult({
+        finalContent: "done",
+        messages: [{ role: "assistant", content: "done" }],
+        stopReason: "completed",
+      }),
+    );
+
+    const outbound = await agent.processDirect("hello", { sessionKey: "cli:usage2" });
+
+    expect(outbound?.metadata.usage).toEqual({ prompt_tokens: 0, completion_tokens: 0 });
+  });
+
+  it("keeps distinct sessions' usage isolated across sequential turns", async () => {
+    const agent = loop();
+    const usages = [
+      { prompt_tokens: 10, completion_tokens: 2, total_tokens: 12 },
+      { prompt_tokens: 30, completion_tokens: 8, total_tokens: 38 },
+    ];
+    let call = 0;
+    agent.runner.run = vi.fn(async () =>
+      new AgentRunResult({
+        finalContent: "done",
+        messages: [{ role: "assistant", content: "done" }],
+        stopReason: "completed",
+        usage: usages[call++],
+      }),
+    );
+
+    const first = await agent.processDirect("first", { sessionKey: "cli:a" });
+    const second = await agent.processDirect("second", { sessionKey: "cli:b" });
+
+    expect(first?.metadata.usage).toEqual(usages[0]);
+    expect(second?.metadata.usage).toEqual(usages[1]);
+  });
+});

--- a/App/memmy-agent/tests/entrypoints/openai-like-api/api-stream.test.ts
+++ b/App/memmy-agent/tests/entrypoints/openai-like-api/api-stream.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { SSE_DONE, sseChunk, createApp } from "../../../src/entrypoints/openai-like-api/server.js";
+import { SSE_DONE, sseChunk, sseUsageChunk, createApp } from "../../../src/entrypoints/openai-like-api/server.js";
 
 function request(body: unknown): Request {
   return new Request("http://localhost/v1/chat/completions", {
@@ -46,6 +46,17 @@ describe("SSE response helpers", () => {
 
   it("uses the OpenAI [DONE] SSE terminator", () => {
     expect(SSE_DONE).toBe("data: [DONE]\n\n");
+  });
+
+  it("formats a usage-only chunk with empty choices, per stream_options.include_usage", () => {
+    const payload = JSON.parse(
+      sseUsageChunk({ prompt_tokens: 12, completion_tokens: 8, total_tokens: 20 }, "test-model", "chatcmpl-abc123").split("data: ", 2)[1],
+    );
+
+    expect(payload.id).toBe("chatcmpl-abc123");
+    expect(payload.object).toBe("chat.completion.chunk");
+    expect(payload.choices).toEqual([]);
+    expect(payload.usage).toEqual({ prompt_tokens: 12, completion_tokens: 8, total_tokens: 20 });
   });
 });
 
@@ -240,6 +251,51 @@ describe("SSE chat completions", () => {
 
     expect(response.status).toBe(200);
     expect(capturedKey).toBe("api:my-session");
+  });
+
+  it("emits a trailing usage chunk when stream_options.include_usage is set", async () => {
+    const app = createApp(
+      {
+        processDirect: async (args: any) => {
+          await args.onStream("hi");
+          await args.onStreamEnd();
+          return { content: "hi", metadata: { usage: { prompt_tokens: 11, completion_tokens: 4, total_tokens: 15 } } };
+        },
+      },
+      "m",
+    );
+
+    const response = await app.fetch(
+      request({ messages: [{ role: "user", content: "hi" }], stream: true, stream_options: { include_usage: true } }),
+    );
+    const payloads = ssePayloads(await response.text());
+    const chunks = payloads.slice(0, -1).map((line) => JSON.parse(line));
+    const usageChunk = chunks.at(-1);
+
+    expect(payloads.at(-1)).toBe("[DONE]");
+    expect(usageChunk.choices).toEqual([]);
+    expect(usageChunk.usage).toEqual({ prompt_tokens: 11, completion_tokens: 4, total_tokens: 15 });
+    expect(chunks.at(-2).choices[0].finish_reason).toBe("stop");
+  });
+
+  it("omits the usage chunk when stream_options.include_usage is not set", async () => {
+    const app = createApp(
+      {
+        processDirect: async (args: any) => {
+          await args.onStream("hi");
+          await args.onStreamEnd();
+          return { content: "hi", metadata: { usage: { prompt_tokens: 11, completion_tokens: 4, total_tokens: 15 } } };
+        },
+      },
+      "m",
+    );
+
+    const response = await app.fetch(request({ messages: [{ role: "user", content: "hi" }], stream: true }));
+    const payloads = ssePayloads(await response.text());
+    const chunks = payloads.slice(0, -1).map((line) => JSON.parse(line));
+
+    expect(payloads.at(-1)).toBe("[DONE]");
+    expect(chunks.every((chunk) => chunk.usage === undefined)).toBe(true);
   });
 
   it("does not emit a successful terminator after backend failures", async () => {

--- a/App/memmy-agent/tests/entrypoints/openai-like-api/openai-api.test.ts
+++ b/App/memmy-agent/tests/entrypoints/openai-like-api/openai-api.test.ts
@@ -56,6 +56,26 @@ describe("OpenAI-compatible API response helpers", () => {
     expect(result.choices[0].message.content).toBe("hello world");
     expect(result.choices[0].finish_reason).toBe("stop");
     expect(result.id).toMatch(/^chatcmpl-/);
+    expect(result.usage).toEqual({ prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 });
+  });
+
+  it("reports real token usage when the agent run supplied it", () => {
+    const result = chatCompletionResponse("hello world", "test-model", {
+      prompt_tokens: 128,
+      completion_tokens: 32,
+      total_tokens: 160,
+    });
+
+    expect(result.usage).toEqual({ prompt_tokens: 128, completion_tokens: 32, total_tokens: 160 });
+  });
+
+  it("derives total_tokens from prompt+completion when upstream omits it", () => {
+    const result = chatCompletionResponse("hello world", "test-model", {
+      prompt_tokens: 10,
+      completion_tokens: 5,
+    });
+
+    expect(result.usage).toEqual({ prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 });
   });
 });
 
@@ -323,6 +343,57 @@ describe("OpenAI-compatible API routing", () => {
     expect(captured).not.toBeNull();
     expect(captured.media).toEqual(["/tmp/image.png", "/tmp/report.pdf"]);
     expect(captured.content).toBe("analyze this");
+  });
+
+  it("propagates the turn's real token usage from the agent loop into the API response", async () => {
+    const app = createApp(
+      {
+        processDirect: async () => ({
+          content: "mock response",
+          metadata: { usage: { prompt_tokens: 42, completion_tokens: 17, total_tokens: 59 } },
+        }),
+      },
+      "test-model",
+    );
+
+    const response = await app.fetch(request({ messages: [{ role: "user", content: "hello" }] }));
+    const body = (await response.json()) as any;
+
+    expect(response.status).toBe(200);
+    expect(body.choices[0].message.content).toBe("mock response");
+    expect(body.usage).toEqual({ prompt_tokens: 42, completion_tokens: 17, total_tokens: 59 });
+  });
+
+  it("sums usage across the empty-response retry into a single reported total", async () => {
+    let calls = 0;
+    const app = createApp(
+      {
+        processDirect: async () => {
+          calls += 1;
+          if (calls === 1) {
+            return { content: "", metadata: { usage: { prompt_tokens: 20, completion_tokens: 0, total_tokens: 20 } } };
+          }
+          return { content: "recovered", metadata: { usage: { prompt_tokens: 25, completion_tokens: 9, total_tokens: 34 } } };
+        },
+      },
+      "m",
+    );
+
+    const response = await app.fetch(request({ messages: [{ role: "user", content: "hello" }] }));
+    const body = (await response.json()) as any;
+
+    expect(calls).toBe(2);
+    expect(body.choices[0].message.content).toBe("recovered");
+    expect(body.usage).toEqual({ prompt_tokens: 45, completion_tokens: 9, total_tokens: 54 });
+  });
+
+  it("defaults to zeroed usage when the agent loop reports none", async () => {
+    const app = createApp({ processDirect: async () => "plain string reply" }, "m");
+
+    const response = await app.fetch(request({ messages: [{ role: "user", content: "hello" }] }));
+    const body = (await response.json()) as any;
+
+    expect(body.usage).toEqual({ prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 });
   });
 
   it("adapts real AgentLoop-style processDirect calls from API object arguments", async () => {


### PR DESCRIPTION
## 问题

`memmy serve` 的 OpenAI 兼容 API `/v1/chat/completions` 返回的 `usage` 恒为 `{"prompt_tokens":0,"completion_tokens":0,"total_tokens":0}`。把 memmy 当 OpenAI 端点接入其他工具时计量完全失真。

## 根因

`src/entrypoints/openai-like-api/server.ts` 的 `chatCompletionResponse()` 硬编码了三个 0。真实 usage 一直存在：`AgentRunner.run()` 跨工具调用迭代累计 usage，`AgentLoop.runAgentLoop()` 也做了归一化（`lastUsage`），但从未随 turn 结果传到 API 入口。

## 修复

沿既有的 per-turn 对象传递 usage，不依赖共享的 `lastUsage` 字段，避免并发 turn 竞争：

- `runAgentLoop()` 在 `v1.0.5` 已有的 `errorCategory` 之后追加本 turn 的归一化 usage
- `TurnContext.usage` 由 `stateRun()` 填充，`assembleOutbound()` 再挂到 `OutboundMessage.metadata.usage`
- 非流式 API 从 metadata 读取真实 usage；空响应重试路径将两次真实 LLM 调用的 usage 求和
- 流式 API 支持 `stream_options.include_usage`，设置时在 `[DONE]` 前追加 `choices: []` 的 usage 尾块；未设置时行为不变

## 冲突处理

本分支已 rebase 到当前 `v1.0.5`。唯一冲突来自 `runAgentLoop()` 返回元组：base 新增了 `errorCategory`，本 PR 新增了 `usage`。最终同时保留两者，顺序为 `errorCategory` 第 7 项、`usage` 第 8 项，避免改变 base 现有调用方语义。

## 验证

- focused tests：3 个文件，42 passed / 0 failed
- `npm run typecheck`：通过
- `npm run build`：通过
- memmy-agent 全量测试：4633 passed / 3 skipped / 1 failed
  - 唯一失败为 `schema-validation.test.ts` 的旧 fallback 预期；在未包含本 PR 改动的纯 `v1.0.5@80b07d7` 上可独立复现。`v1.0.5` 已通过 #7 改为 invalid config fail-loud，但该旧测试仍期待 fallback；本 PR 不顺带修改这项无关基线问题。
- 真实服务 + curl（OpenAI-compatible BYOK gateway）：
  - 非流式：`usage={"prompt_tokens":6304,"completion_tokens":5,"total_tokens":6309}`，总数校验通过
  - 流式带 `include_usage: true`：finish chunk 之后、`[DONE]` 之前收到 `choices: []` 的 usage chunk；`6341+5=6346`
  - 流式未设置 `include_usage`：0 个 usage chunk，保留兼容行为

## 未覆盖说明

- 空响应重试的 usage 求和仅以测试验证，无法稳定诱导真实 LLM 返回空内容
- `processSystemMessage()`（cron/系统通道，不经 OpenAI API）未接 usage，属于有意边界
- usage 使用 per-call 对象传递，未增加专门的并发竞态测试
- GitHub 当前未为该 PR 返回 CI checks；以上为本地和真实运行验证结果
