### PR TITLE
feat(desktop): add jump-to-latest conversation control

### DIFF
--- a/App/frontend/desktop/src/pages/home-page.tsx
+++ b/App/frontend/desktop/src/pages/home-page.tsx
@@ -59,7 +59,7 @@ import { mergeVoiceTranscript, useAsrRecorder } from "./asr-recorder.js";
 import { consumePendingFirstEncounterTaskLaunch } from "./first-encounter-task-launch.js";
 import { HistoryDagPanel, type HistoryDagPanelState } from "./history-dag-panel.js";
 import { Mic, Pause, Plus, Send } from "./memory/memory-prototype-icons.js";
-import { RotateCw, X, ChevronDown } from "lucide-react";
+import { ArrowDown, RotateCw, X } from "lucide-react";
 
 export { agentChatScopeKey, updateComposerDraftForScope };
 export { hydrateAgentThreadInBackground };
@@ -1526,15 +1526,15 @@ export function HomePage() {
       setShowScrollToBottomFab(false);
       return;
     }
-    // Only a scroll event that follows a real wheel/touch gesture is allowed
-    // to turn auto-scroll off. This is what "the user took over the mouse and scrolled up"
-    // means literally — a scroll event with no recent user gesture behind it
-    // (e.g. one racing with streaming content growth) must not disable it.
+    // The control reflects the actual scroll position even when the user moved
+    // with the scrollbar or keyboard. Only a scroll event that follows a real
+    // wheel/touch gesture is allowed to turn auto-scroll off, so a scroll event
+    // racing with streaming content growth cannot disable it.
+    setShowScrollToBottomFab(true);
     if (Date.now() > userScrollIntentUntilRef.current) {
       return;
     }
     shouldAutoScrollAgentConversationRef.current = false;
-    setShowScrollToBottomFab(true);
   }
 
   /**
@@ -1777,7 +1777,7 @@ export function HomePage() {
               />
             </div>
           </div>
-          {showScrollToBottomFab && isCurrentAgentRunning ? (
+          {showScrollToBottomFab ? (
             <button
               type="button"
               className="agent-scroll-to-bottom-fab"
@@ -1785,7 +1785,7 @@ export function HomePage() {
               title={t("home.scrollToLatest")}
               onClick={resumeAgentConversationAutoScroll}
             >
-              <ChevronDown size={16} aria-hidden="true" />
+              <ArrowDown size={16} aria-hidden="true" />
             </button>
           ) : null}
           <div className="agent-conversation-composer">

--- a/App/frontend/desktop/src/pages/tests/home-page-scroll.interaction.test.tsx
+++ b/App/frontend/desktop/src/pages/tests/home-page-scroll.interaction.test.tsx
@@ -1,0 +1,124 @@
+// @vitest-environment happy-dom
+
+import { act, useEffect } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AgentRuntimeBridge } from "../../app/agent-runtime-bridge.js";
+import { AppProviders } from "../../app/providers.js";
+import { agentActions } from "../../state/app-actions.js";
+import { useAppState } from "../../state/app-state.js";
+import { HomePage } from "../home-page.js";
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe("HomePage conversation scrolling", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    Object.defineProperty(window, "localStorage", { configurable: true, value: createMemoryStorage() });
+    Object.defineProperty(window, "sessionStorage", { configurable: true, value: createMemoryStorage() });
+    container = document.createElement("div");
+    document.body.append(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    vi.clearAllTimers();
+    vi.useRealTimers();
+    document.body.replaceChildren();
+  });
+
+  it("jumps to the latest message in a completed long conversation", () => {
+    act(() => {
+      root.render(
+        <AppProviders>
+          <AgentRuntimeBridge>
+            <CompletedConversationSeeder />
+            <HomePage />
+          </AgentRuntimeBridge>
+        </AppProviders>
+      );
+    });
+
+    const scrollContainer = document.querySelector<HTMLDivElement>(".agent-conversation-scroll");
+    expect(scrollContainer).not.toBeNull();
+    if (!scrollContainer) {
+      throw new Error("Missing agent conversation scroll container");
+    }
+    Object.defineProperties(scrollContainer, {
+      clientHeight: { configurable: true, value: 400 },
+      scrollHeight: { configurable: true, value: 1200 },
+      scrollTop: { configurable: true, value: 800, writable: true }
+    });
+
+    act(() => vi.advanceTimersByTime(121));
+    expect(findScrollToLatestButton()).toBeNull();
+
+    act(() => {
+      scrollContainer.scrollTop = 200;
+      scrollContainer.dispatchEvent(new Event("scroll", { bubbles: true }));
+    });
+
+    const button = findScrollToLatestButton();
+    expect(button).not.toBeNull();
+    act(() => button?.click());
+
+    expect(scrollContainer.scrollTop).toBe(scrollContainer.scrollHeight);
+    expect(findScrollToLatestButton()).toBeNull();
+
+    act(() => {
+      vi.advanceTimersByTime(121);
+      scrollContainer.dispatchEvent(new Event("wheel", { bubbles: true }));
+      scrollContainer.scrollTop = 200;
+      scrollContainer.dispatchEvent(new Event("scroll", { bubbles: true }));
+    });
+    expect(findScrollToLatestButton()).not.toBeNull();
+
+    act(() => {
+      scrollContainer.scrollTop = 800;
+      scrollContainer.dispatchEvent(new Event("scroll", { bubbles: true }));
+    });
+    expect(findScrollToLatestButton()).toBeNull();
+  });
+});
+
+function CompletedConversationSeeder() {
+  const { dispatch } = useAppState();
+
+  useEffect(() => {
+    const requestId = "scroll-test-request";
+    dispatch(agentActions.historyLoading("websocket:scroll-test", "scroll-test", requestId));
+    dispatch(agentActions.historyLoaded({
+      schemaVersion: 1,
+      sessionKey: "websocket:scroll-test",
+      last_turn_closed: true,
+      messages: [
+        { role: "user", content: "较早的消息" },
+        { role: "assistant", content: "最近的消息" }
+      ]
+    }, requestId));
+  }, [dispatch]);
+
+  return null;
+}
+
+function findScrollToLatestButton(): HTMLButtonElement | null {
+  return document.querySelector<HTMLButtonElement>('button[aria-label="回到最新"]');
+}
+
+function createMemoryStorage(): Storage {
+  const values = new Map<string, string>();
+  return {
+    get length() {
+      return values.size;
+    },
+    clear: () => values.clear(),
+    getItem: (key) => values.get(key) ?? null,
+    key: (index) => Array.from(values.keys())[index] ?? null,
+    removeItem: (key) => values.delete(key),
+    setItem: (key, value) => values.set(key, value)
+  };
+}


### PR DESCRIPTION
## Summary

- Show the jump-to-latest control whenever a long conversation is scrolled away from the bottom, including completed conversations.
- Update the control for scrollbar and keyboard scrolling while preserving gesture-gated auto-scroll behavior during streaming.
- Use the downward-arrow icon with the existing localized accessible label and tooltip.

## Tests

- Added HomePage interaction coverage for a completed long conversation.
- Verified the control is hidden at the latest message and appears after scrolling upward.
- Verified clicking the control jumps to the latest message and hides the control.
- Verified wheel-driven auto-scroll pause and resume behavior.
- Project Harness Standard Gate passed (T1) against `upstream/main`.

## Harness evidence

- HEAD: `93749010918fbdf5454d57db624fb49b57524b8b`
- Merge base: `e1b5717f857cea9f2481f983d059893dc5ccd6a7`
- Worktree fingerprint: `535b01e8c6c29ba5f29ec1a1eb96c6027c39a42d5def12d96981dc0aedd88e8c`
- Test policy: passed (`covered`)
- Changed during run: no
