### PR TITLE
fix(release): support merged fork release PRs

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -1,7 +1,9 @@
 name: GitHub Release
 
 on:
-  pull_request:
+  # Use the base repository's trusted workflow so merged PRs from public forks
+  # can publish without executing workflow code from the PR branch.
+  pull_request_target:
     types: [closed]
     branches: [main]
   workflow_dispatch:
@@ -39,7 +41,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+          if [[ "$EVENT_NAME" == "pull_request_target" ]]; then
             if [[ ! "$PR_HEAD_REF" =~ ^release/v((0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*))$ ]]; then
               echo "Release branch must match release/vX.Y.Z" >&2
               exit 1

--- a/tests/release-workflow.test.ts
+++ b/tests/release-workflow.test.ts
@@ -19,11 +19,14 @@ const packagingConfigs = [
 ];
 
 describe("GitHub release workflow", () => {
-  it("only automatically handles merged release/vX.Y.Z PRs targeting main", () => {
-    expect(workflow.on.pull_request).toEqual({ types: ["closed"], branches: ["main"] });
+  it("uses the trusted base workflow for merged release/vX.Y.Z PRs targeting main", () => {
+    expect(workflow.on.pull_request_target).toEqual({ types: ["closed"], branches: ["main"] });
+    expect(workflow.on.pull_request).toBeUndefined();
     expect(releaseJob.if).toContain("github.event.pull_request.merged == true");
     expect(releaseJob.if).toContain("startsWith(github.event.pull_request.head.ref, 'release/v')");
-    expect(script("Resolve and validate release")).toContain(
+    const resolveScript = script("Resolve and validate release");
+    expect(resolveScript).toContain('if [[ "$EVENT_NAME" == "pull_request_target" ]]');
+    expect(resolveScript).toContain(
       "^release/v((0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*))$",
     );
   });


### PR DESCRIPTION
## Why

`MemTensor/memmy-agent` is public, and GitHub downgrades `GITHUB_TOKEN` to read-only for workflows triggered by `pull_request` events from forks. The v1.0.2 release PR will come from a fork, so the existing closed-PR workflow could pass all release validation but fail when creating or publishing the GitHub Release.

GitHub documents this restriction in [Events that trigger workflows](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#workflows-in-forked-repositories).

## Change

- use `pull_request_target` for closed PRs targeting `main`, so the trusted base workflow receives the requested `contents: write` permission
- route automatic version resolution through the matching `pull_request_target` event name
- add a regression contract that requires the trusted-base trigger and rejects a fallback to `pull_request`

The workflow does not execute code from the PR head. It still requires `merged == true`, strictly validates `release/vX.Y.Z`, resolves `merge_commit_sha`, checks out that exact merged commit, and verifies it is an ancestor of `main` before creating a release.

Manual dispatch, the `release` environment, minimal permissions, per-version concurrency, duplicate tag/release refusal, OSS Content-MD5 verification, checksums, and draft-upload-publish ordering are unchanged.

## Validation

- regression test failed before the workflow change and passed afterward
- `npm run test:release-workflow` — 8/8 passed
- Project Harness Full/T3 — `needs_review`, `readyForHandoff: true`, no failed evidence
- commit-bound Harness fingerprint: `64b598c2885ad67e92110488de5da0c2cede224027272b7598c6dba9bdccad85`
- `git diff --check upstream/main` — passed
- independent security review — no findings

## Required merge order

This PR must be reviewed and merged into `main` before the `release/v1.0.2` PR is merged. Do not merge the v1.0.2 release PR first, or its automatic publish event may still run with the old fork-incompatible trigger.
