### PR TITLE
fix(release): avoid privileged fork commit checkout

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -84,20 +84,21 @@ jobs:
             exit 1
           fi
 
-      - name: Check out the exact release commit
+      - name: Check out trusted main history
         uses: actions/checkout@v4
         with:
-          ref: ${{ steps.release.outputs.target_sha }}
+          ref: main
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Verify target is on main
         env:
           TARGET_SHA: ${{ steps.release.outputs.target_sha }}
         run: |
           set -euo pipefail
-          git fetch --no-tags origin main
-          git merge-base --is-ancestor "$TARGET_SHA" origin/main
-          test "$(git rev-parse HEAD)" = "$TARGET_SHA"
+          git fetch --no-tags origin refs/heads/main:refs/remotes/origin/main
+          git cat-file -e "$TARGET_SHA^{commit}"
+          git merge-base --is-ancestor "$TARGET_SHA" refs/remotes/origin/main
 
       - name: Download and verify OSS artifacts
         env:
@@ -148,8 +149,9 @@ jobs:
           set -euo pipefail
           notes="release-assets/RELEASE_NOTES.md"
           manual_notes=".github/release-notes/$TAG.md"
-          if [[ -f "$manual_notes" ]]; then
-            cat "$manual_notes" > "$notes"
+          manual_object="${TARGET_SHA}:${manual_notes}"
+          if git cat-file -e "$manual_object" 2>/dev/null; then
+            git show "$manual_object" > "$notes"
             printf '\n\n' >> "$notes"
           else
             : > "$notes"

--- a/tests/release-workflow.test.ts
+++ b/tests/release-workflow.test.ts
@@ -44,13 +44,38 @@ describe("GitHub release workflow", () => {
   it("binds the tag to the merged commit and refuses existing releases", () => {
     const resolveScript = script("Resolve and validate release");
     expect(resolveScript).toContain('target_sha="$PR_MERGE_SHA"');
-    expect(steps.find((step) => step.name === "Check out the exact release commit")?.with).toEqual(
-      expect.objectContaining({ ref: "${{ steps.release.outputs.target_sha }}" }),
+    expect(script("Create draft release and upload every asset")).toContain(
+      '--target "$TARGET_SHA"',
     );
     const duplicateCheck = script("Check for an existing tag or release");
     expect(duplicateCheck).toContain("git ls-remote --exit-code --tags");
     expect(duplicateCheck).toContain('gh release view "$TAG"');
     expect(duplicateCheck).not.toContain("--force");
+  });
+
+  it("keeps merged fork code out of the trusted release checkout", () => {
+    const checkout = steps.find((step) => step.name === "Check out trusted main history");
+    expect(checkout?.uses).toBe("actions/checkout@v4");
+    expect(checkout?.with).toEqual(
+      expect.objectContaining({
+        ref: "main",
+        "fetch-depth": 0,
+        "persist-credentials": false,
+      }),
+    );
+    expect(JSON.stringify(checkout?.with)).not.toContain("target_sha");
+    expect(source).not.toContain("allow-unsafe-pr-checkout");
+
+    const verifyScript = script("Verify target is on main");
+    expect(verifyScript).toContain("refs/heads/main:refs/remotes/origin/main");
+    expect(verifyScript).toContain('git cat-file -e "$TARGET_SHA^{commit}"');
+    expect(verifyScript).toContain(
+      'git merge-base --is-ancestor "$TARGET_SHA" refs/remotes/origin/main',
+    );
+
+    const notesScript = script("Build release notes");
+    expect(notesScript).toContain('manual_object="${TARGET_SHA}:${manual_notes}"');
+    expect(notesScript).toContain('git show "$manual_object" > "$notes"');
   });
 
   it("downloads all four OSS artifacts and verifies Content-MD5", () => {


### PR DESCRIPTION
## Root cause

The v1.0.2 release run failed before any OSS download or Release mutation. GitHub's hardened `actions/checkout` rejected the explicit PR `merge_commit_sha` in a privileged `pull_request_target` job for a fork-originated PR:

- Failed run: https://github.com/MemTensor/memmy-agent/actions/runs/29852449774
- Failed step: **Check out the exact release commit**
- Reviewed PR #24 head: `501a106c1496e8e715eef49c8068f68b5b57af3a`
- PR #24 merge commit: `a41fbea9c93c978783ada98e3e5628e5876b10a8`

This is deterministic workflow behavior, so re-running the unchanged run would not be a safe or effective recovery.

## Fix

- Check out only the literal trusted `main` branch with full history.
- Disable persisted checkout credentials.
- Keep the strict 40-hex target resolution and prove the target commit exists and is an ancestor of the freshly fetched `main` ref.
- Never check out the fork/merge tree into the privileged workspace and do not enable `allow-unsafe-pr-checkout`.
- Read optional manual release notes as inert data from the already-validated commit with `git show "$TARGET_SHA:$path"`.
- Keep tag and Release creation bound to the exact `TARGET_SHA`; duplicate protection, OSS validation, draft/upload/publish ordering, and manual dispatch behavior are unchanged.

## Regression coverage

The release contract now asserts that checkout is pinned to literal `main`, the dynamic target SHA never reaches `actions/checkout`, the unsafe opt-out is absent, ancestry is checked against the fetched remote-main ref, and notes are read from the validated Git object.

- `npm run test:release-workflow`: **9/9 passed**. The new regression was observed failing against the previous workflow before this fix.
- Project Harness Full / T3: **12/12 passed**, `failedEvidence=[]`, `readyForHandoff=true`, decision `needs_review`.
- Commit-bound HEAD: `5860a8fea7c117b57d4f4a40214993c982ff8211`
- Harness fingerprint: `c7a9deb5eb0eed8f677190e2440fef06ec8dd13704a8d213ac543326b0251b28`
- `git diff --check upstream/main..HEAD` passed.
- Independent read-only review found no P0-P3 issues.

## Recovery after merge

Please review and merge this fix first. The old failed run may retain its original workflow snapshot, so it should not be relied on for recovery. After this fix is on `main`, use the existing manual **GitHub Release** dispatch with version `1.0.2`; that run will use the fixed workflow, target the then-current `main`, and retain all duplicate/tag safety checks. This PR does not create or publish a tag or Release.

