### PR TITLE
fix(release): detach only validated main commits

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -84,10 +84,9 @@ jobs:
             exit 1
           fi
 
-      - name: Check out trusted main history
+      - name: Check out trusted base history
         uses: actions/checkout@v4
         with:
-          ref: main
           fetch-depth: 0
           persist-credentials: false
 
@@ -96,9 +95,11 @@ jobs:
           TARGET_SHA: ${{ steps.release.outputs.target_sha }}
         run: |
           set -euo pipefail
-          git fetch --no-tags origin refs/heads/main:refs/remotes/origin/main
+          git fetch --no-tags origin main
           git cat-file -e "$TARGET_SHA^{commit}"
-          git merge-base --is-ancestor "$TARGET_SHA" refs/remotes/origin/main
+          git merge-base --is-ancestor "$TARGET_SHA" origin/main
+          git checkout --detach "$TARGET_SHA"
+          test "$(git rev-parse HEAD)" = "$TARGET_SHA"
 
       - name: Download and verify OSS artifacts
         env:

--- a/tests/release-workflow.test.ts
+++ b/tests/release-workflow.test.ts
@@ -54,24 +54,28 @@ describe("GitHub release workflow", () => {
   });
 
   it("keeps merged fork code out of the trusted release checkout", () => {
-    const checkout = steps.find((step) => step.name === "Check out trusted main history");
+    const checkout = steps.find((step) => step.name === "Check out trusted base history");
     expect(checkout?.uses).toBe("actions/checkout@v4");
-    expect(checkout?.with).toEqual(
-      expect.objectContaining({
-        ref: "main",
-        "fetch-depth": 0,
-        "persist-credentials": false,
-      }),
-    );
-    expect(JSON.stringify(checkout?.with)).not.toContain("target_sha");
+    expect(checkout?.with).toEqual({
+      "fetch-depth": 0,
+      "persist-credentials": false,
+    });
+    expect(checkout?.with).not.toHaveProperty("ref");
+    expect(JSON.stringify(checkout)).not.toContain("github.event.pull_request");
+    expect(source).not.toContain("refs/pull/");
     expect(source).not.toContain("allow-unsafe-pr-checkout");
 
     const verifyScript = script("Verify target is on main");
-    expect(verifyScript).toContain("refs/heads/main:refs/remotes/origin/main");
+    expect(verifyScript).toContain("git fetch --no-tags origin main");
     expect(verifyScript).toContain('git cat-file -e "$TARGET_SHA^{commit}"');
-    expect(verifyScript).toContain(
-      'git merge-base --is-ancestor "$TARGET_SHA" refs/remotes/origin/main',
-    );
+    const ancestorCheck = 'git merge-base --is-ancestor "$TARGET_SHA" origin/main';
+    const detachTarget = 'git checkout --detach "$TARGET_SHA"';
+    const verifyHead = 'test "$(git rev-parse HEAD)" = "$TARGET_SHA"';
+    expect(verifyScript).toContain(ancestorCheck);
+    expect(verifyScript).toContain(detachTarget);
+    expect(verifyScript).toContain(verifyHead);
+    expect(verifyScript.indexOf(detachTarget)).toBeGreaterThan(verifyScript.indexOf(ancestorCheck));
+    expect(verifyScript.indexOf(verifyHead)).toBeGreaterThan(verifyScript.indexOf(detachTarget));
 
     const notesScript = script("Build release notes");
     expect(notesScript).toContain('manual_object="${TARGET_SHA}:${manual_notes}"');


### PR DESCRIPTION
## Context

This is a focused security follow-up to #25 and the failed v1.0.2 release run:

- https://github.com/MemTensor/memmy-agent/actions/runs/29852449774
- https://github.com/MemTensor/memmy-agent/pull/25

`actions/checkout@v4.4.0` backported a breaking fork guard that treats a `pull_request_target` payload's `merge_commit_sha` as fork PR code even when that commit is already reachable from `main`. The workflow must not opt out with `allow-unsafe-pr-checkout`.

Official references:

- https://github.com/actions/checkout/releases/tag/v4.4.0
- https://github.com/actions/checkout/blob/11d5960a326750d5838078e36cf38b85af677262/src/unsafe-pr-checkout-helper.ts
- https://docs.github.com/en/actions/reference/security/securely-using-pull_request_target

## Change

- Let `actions/checkout@v4` use the trusted base/default branch for `pull_request_target` by omitting `ref` entirely.
- Keep `fetch-depth: 0` and `persist-credentials: false`.
- Explicitly fetch `origin main`.
- Require the strict target SHA to exist and be an ancestor of `origin/main` before any target checkout.
- Only then detach to the exact target SHA and verify `HEAD` equals it.
- Keep `allow-unsafe-pr-checkout`, `refs/pull/*`, and every dynamic PR ref out of the checkout action.

Manual dispatch, strict semver validation, duplicate tag/Release protection, OSS checksum validation, exact Release Notes lookup, draft-before-publish ordering, and `gh release --target "$TARGET_SHA"` semantics are unchanged.

## Regression coverage

The contract test now asserts the checkout input contains only full-history and credential settings, has no `ref`, unsafe flag, PR expression, or `refs/pull`, and verifies that main ancestry occurs before detached checkout while exact HEAD verification occurs afterward.

- The refined regression was observed failing against the #25 implementation before this change.
- `npm run test:release-workflow`: **9/9 passed**.
- Project Harness Full / T3: **12/12 passed**, `failedEvidence=[]`, `readyForHandoff=true`, decision `needs_review`.
- Commit: `b5443eb216aaeeb2f75d1647c1f348de206c5eab`
- Harness fingerprint: `a854dc818bda616e20eb67b71a47fec201d6b297020d1e6e2e794e79c5f883ac`
- `git diff --check upstream/main..HEAD` passed.
- Independent read-only review found no P0-P3 issues.

## Release recovery

Do not re-run the old failed run because it retains the old workflow. After this PR is reviewed and merged, start a new **GitHub Release** `workflow_dispatch` with version `1.0.2`, then monitor that new run through publication and asset verification. This PR does not create a tag or Release.

