### PR TITLE
fix(app-state): preserve login state across schema upgrades

### DIFF
--- a/App/backend/src/infrastructure/app-state-store/index.ts
+++ b/App/backend/src/infrastructure/app-state-store/index.ts
@@ -5,6 +5,7 @@ import { createIdempotencyStore, type IdempotencyStore } from "../idempotency-st
 import { getActiveAccountUuid } from "./account-context.js";
 import { openDatabase, resolveDefaultDatabasePath } from "./db.js";
 import { createFilesystemLocalDataStore, type LocalDataStore } from "./local-data-store.js";
+import { captureLegacyAppState } from "./legacy-state-migration.js";
 import { runMigrations } from "./migration-runner.js";
 import { createAccountSessionRepository, type AccountSessionRepository } from "./repositories/account-session-repo.js";
 import { createBootstrapRepository, type BootstrapRepository } from "./repositories/bootstrap-repo.js";
@@ -59,13 +60,14 @@ export interface AppStateStore {
 export function createAppStateStore(options: CreateAppStateStoreOptions = {}): AppStateStore {
   const databasePath = options.databasePath ?? resolveDefaultDatabasePath();
   const db = openDatabase({ databasePath });
+  const legacyState = options.migrateOnOpen !== false ? captureLegacyAppState(db) : null;
 
   if (options.migrateOnOpen !== false) {
     runMigrations(db);
     ensureDefaultAppStateRows(db);
   }
   const secretStore = createSqliteSecretStore(db);
-  finalizeDatabaseDesign(db);
+  finalizeDatabaseDesign(db, legacyState);
   const localDataStore = createFilesystemLocalDataStore({ databasePath, db, secretStore });
   const getActiveUuid = () => getActiveAccountUuid(db);
 

--- a/App/backend/src/infrastructure/app-state-store/legacy-state-migration.ts
+++ b/App/backend/src/infrastructure/app-state-store/legacy-state-migration.ts
@@ -1,0 +1,618 @@
+/** Legacy app-state migration module. */
+import type { DatabaseSync } from "node:sqlite";
+import { LOCAL_BYOK_ACCOUNT_UUID } from "./account-context.js";
+
+const LOCAL_AGENT_SOURCE_UUID = "local-agent-sources";
+const SNAPSHOT_TABLE = "_legacy_app_state_snapshot";
+const SNAPSHOT_ID = "singleton";
+const SNAPSHOT_VERSION = 1;
+
+interface LegacyAccountSessionRow {
+  user_id: string | null;
+  email: string | null;
+  phone: string | null;
+  nickname: string | null;
+  avatar_url: string | null;
+  plan_type: string | null;
+  has_finished_guide: number | null;
+  region: string | null;
+  registered_at: string | null;
+  raw_profile_json: string | null;
+  cloud_uuid_ref: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+interface LegacyOnboardingRow {
+  completed: number;
+  current_step: string;
+  has_accepted_terms: number;
+  accepted_terms_version: string | null;
+  scan_permission: string;
+  improvement_program: string;
+  completed_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+interface LegacyPrivacyRow {
+  allow_memory_improvement_upload: number;
+  local_only_mode: number;
+  created_at: string;
+  updated_at: string;
+}
+
+interface LegacyTokenUsageRow {
+  plan_name: string;
+  total_tokens: number;
+  used_tokens: number;
+  remaining_tokens: number;
+  expires_at: string | null;
+  last_synced_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+interface LegacyModelConfigRow {
+  provider: string;
+  base_url: string;
+  model_id: string;
+  api_key_ref: string | null;
+  embedding_mode: string;
+  embedding_base_url: string | null;
+  embedding_model_id: string | null;
+  embedding_api_key_ref: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+interface LegacyAgentSourceRow {
+  source_id: string;
+  display_name: string;
+  data_path: string;
+  builtin: number;
+  status: string;
+  last_scanned_at: string | null;
+  created_at: string;
+}
+
+interface LegacyIngestionSeenRow {
+  dedup_key: string;
+  source_id: string;
+  created_at: string;
+}
+
+interface LegacyIdempotencyRow {
+  adapter_id: string;
+  request_id: string;
+  body_hash: string;
+  response_json: string;
+  status_code: number;
+  created_at: string;
+}
+
+export interface LegacyAppStateSnapshot {
+  userMode: string | null;
+  account: LegacyAccountSessionRow | null;
+  onboarding: LegacyOnboardingRow | null;
+  privacy: LegacyPrivacyRow | null;
+  tokenUsage: LegacyTokenUsageRow | null;
+  modelConfig: LegacyModelConfigRow | null;
+  agentSources: LegacyAgentSourceRow[];
+  ingestionSeen: LegacyIngestionSeenRow[];
+  idempotency: LegacyIdempotencyRow[];
+}
+
+/**
+ * Captures the singleton schema before later SQL migrations replace or remove it.
+ *
+ * @param db The open app-state database before runMigrations.
+ * @returns A snapshot for final-schema restoration, or null when the database is already current or empty.
+ */
+export function captureLegacyAppState(db: DatabaseSync): LegacyAppStateSnapshot | null {
+  const persistedSnapshot = readPersistedSnapshot(db);
+  if (persistedSnapshot) {
+    return persistedSnapshot;
+  }
+  if (!tableExists(db, "account_session")) {
+    return null;
+  }
+
+  const registeredAtColumn = tableHasColumn(db, "account_session", "registered_at")
+    ? "registered_at"
+    : "NULL AS registered_at";
+  const cloudUuidColumn = legacyCloudUuidSelect(db);
+
+  const snapshot: LegacyAppStateSnapshot = {
+    userMode: readOptionalRow<{ user_mode: string }>(
+      db,
+      "app_settings",
+      "SELECT user_mode FROM app_settings WHERE id = 'default'"
+    )?.user_mode ?? null,
+    account: readOptionalRow<LegacyAccountSessionRow>(
+      db,
+      "account_session",
+      `SELECT
+        user_id,
+        email,
+        phone,
+        nickname,
+        avatar_url,
+        plan_type,
+        has_finished_guide,
+        region,
+        ${registeredAtColumn},
+        raw_profile_json,
+        ${cloudUuidColumn},
+        created_at,
+        updated_at
+      FROM account_session
+      WHERE id = 'default'`
+    ),
+    onboarding: readOptionalRow<LegacyOnboardingRow>(
+      db,
+      "onboarding_state",
+      `SELECT
+        completed,
+        current_step,
+        has_accepted_terms,
+        accepted_terms_version,
+        scan_permission,
+        improvement_program,
+        completed_at,
+        created_at,
+        updated_at
+      FROM onboarding_state
+      WHERE id = 'default'`
+    ),
+    privacy: readOptionalRow<LegacyPrivacyRow>(
+      db,
+      "privacy_settings",
+      `SELECT
+        allow_memory_improvement_upload,
+        local_only_mode,
+        created_at,
+        updated_at
+      FROM privacy_settings
+      WHERE id = 'default'`
+    ),
+    tokenUsage: readOptionalRow<LegacyTokenUsageRow>(
+      db,
+      "token_usage_cache",
+      `SELECT
+        plan_name,
+        total_tokens,
+        used_tokens,
+        remaining_tokens,
+        expires_at,
+        last_synced_at,
+        created_at,
+        updated_at
+      FROM token_usage_cache
+      WHERE id = 'default'`
+    ),
+    modelConfig: readOptionalRow<LegacyModelConfigRow>(
+      db,
+      "model_config",
+      `SELECT
+        provider,
+        base_url,
+        model_id,
+        api_key_ref,
+        embedding_mode,
+        embedding_base_url,
+        embedding_model_id,
+        embedding_api_key_ref,
+        created_at,
+        updated_at
+      FROM model_config
+      WHERE id = 'default'`
+    ),
+    agentSources: readRows<LegacyAgentSourceRow>(
+      db,
+      "agent_sources",
+      `SELECT
+        source_id,
+        display_name,
+        data_path,
+        builtin,
+        status,
+        last_scanned_at,
+        created_at
+      FROM agent_sources`
+    ),
+    ingestionSeen: readRows<LegacyIngestionSeenRow>(
+      db,
+      "ingestion_seen",
+      "SELECT dedup_key, source_id, created_at FROM ingestion_seen"
+    ),
+    idempotency: tableHasColumn(db, "idempotency_keys", "uuid")
+      ? []
+      : readRows<LegacyIdempotencyRow>(
+          db,
+          "idempotency_keys",
+          `SELECT
+            adapter_id,
+            request_id,
+            body_hash,
+            response_json,
+            status_code,
+            created_at
+          FROM idempotency_keys`
+        )
+  };
+  persistSnapshot(db, snapshot);
+  return snapshot;
+}
+
+/**
+ * Restores a pre-account-isolation snapshot into the fully migrated schema.
+ *
+ * @param db The migrated app-state database.
+ * @param snapshot The state captured before SQL migrations ran.
+ */
+export function restoreLegacyAppState(db: DatabaseSync, snapshot: LegacyAppStateSnapshot): void {
+  const accountUuid = legacyAccountUuid(snapshot.account);
+  const stateUuid = snapshot.userMode === "account" && accountUuid
+    ? accountUuid
+    : LOCAL_BYOK_ACCOUNT_UUID;
+
+  if (accountUuid && snapshot.account) {
+    restoreCloudAccount(db, accountUuid, snapshot.account);
+  }
+  if (stateUuid && stateUuid !== accountUuid) {
+    ensureScopeAccount(db, stateUuid);
+  }
+
+  if (stateUuid) {
+    restoreOnboarding(db, stateUuid, snapshot);
+    restorePrivacy(db, stateUuid, snapshot.privacy);
+    restoreModelConfig(db, stateUuid, snapshot.modelConfig);
+  }
+
+  if (accountUuid) {
+    restoreTokenUsage(db, accountUuid, snapshot.tokenUsage);
+    restoreIdempotency(db, accountUuid, snapshot.idempotency);
+    if (snapshot.userMode === "account") {
+      db.prepare(
+        `UPDATE app_settings
+         SET active_uuid = ?, updated_at = ?
+         WHERE id = 'default' AND active_uuid IS NULL`
+      ).run(accountUuid, new Date().toISOString());
+    }
+  }
+
+  restoreAgentSources(db, snapshot.agentSources, snapshot.ingestionSeen);
+}
+
+/** Removes the durable snapshot after restoration and schema finalization succeed. */
+export function discardLegacyAppStateSnapshot(db: DatabaseSync): void {
+  db.exec(`DROP TABLE IF EXISTS ${SNAPSHOT_TABLE}`);
+}
+
+function restoreCloudAccount(db: DatabaseSync, uuid: string, account: LegacyAccountSessionRow): void {
+  db.prepare(
+    `INSERT OR IGNORE INTO cloud_accounts (
+      uuid,
+      user_id,
+      email,
+      phone,
+      nickname,
+      avatar,
+      plan_type,
+      has_finished_guide,
+      region,
+      registered_at,
+      cloud_uuid_ref,
+      raw_profile_json,
+      last_login_at,
+      created_at,
+      updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+  ).run(
+    uuid,
+    account.user_id,
+    account.email,
+    account.phone,
+    account.nickname,
+    account.avatar_url,
+    account.plan_type,
+    account.has_finished_guide,
+    account.region,
+    account.registered_at,
+    account.cloud_uuid_ref,
+    account.raw_profile_json,
+    account.updated_at,
+    account.created_at,
+    account.updated_at
+  );
+}
+
+function restoreOnboarding(db: DatabaseSync, uuid: string, snapshot: LegacyAppStateSnapshot): void {
+  const onboarding = snapshot.onboarding;
+  const now = new Date().toISOString();
+  db.prepare(
+    `INSERT OR IGNORE INTO account_onboarding_state (
+      uuid,
+      has_finished_guide,
+      current_step,
+      has_accepted_terms,
+      accepted_terms_version,
+      scan_permission,
+      improvement_program,
+      completed_at,
+      created_at,
+      updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+  ).run(
+    uuid,
+    onboarding?.completed ?? snapshot.account?.has_finished_guide ?? 0,
+    onboarding?.current_step ?? "scan_permission_required",
+    onboarding?.has_accepted_terms ?? 0,
+    onboarding?.accepted_terms_version ?? null,
+    onboarding?.scan_permission ?? "unset",
+    onboarding?.improvement_program ?? "unset",
+    onboarding?.completed_at ?? null,
+    onboarding?.created_at ?? now,
+    onboarding?.updated_at ?? now
+  );
+}
+
+function restorePrivacy(db: DatabaseSync, uuid: string, privacy: LegacyPrivacyRow | null): void {
+  const now = new Date().toISOString();
+  db.prepare(
+    `INSERT OR IGNORE INTO account_privacy_settings (
+      uuid,
+      allow_memory_improvement_upload,
+      local_only_mode,
+      created_at,
+      updated_at
+    ) VALUES (?, ?, ?, ?, ?)`
+  ).run(
+    uuid,
+    privacy?.allow_memory_improvement_upload ?? 0,
+    privacy?.local_only_mode ?? 0,
+    privacy?.created_at ?? now,
+    privacy?.updated_at ?? now
+  );
+}
+
+function restoreTokenUsage(db: DatabaseSync, uuid: string, usage: LegacyTokenUsageRow | null): void {
+  if (!usage) {
+    return;
+  }
+
+  db.prepare(
+    `INSERT OR IGNORE INTO account_token_usage_cache (
+      uuid,
+      plan_name,
+      total_tokens,
+      used_tokens,
+      remaining_tokens,
+      expires_at,
+      last_synced_at,
+      created_at,
+      updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+  ).run(
+    uuid,
+    usage.plan_name,
+    usage.total_tokens,
+    usage.used_tokens,
+    usage.remaining_tokens,
+    usage.expires_at,
+    usage.last_synced_at,
+    usage.created_at,
+    usage.updated_at
+  );
+}
+
+function restoreModelConfig(db: DatabaseSync, uuid: string, config: LegacyModelConfigRow | null): void {
+  if (!config) {
+    return;
+  }
+
+  const customEmbedding = config.embedding_mode === "separate";
+  db.prepare(
+    `INSERT OR IGNORE INTO account_model_config (
+      uuid,
+      provider,
+      base_url,
+      model_id,
+      api_key_ref,
+      embedding_mode,
+      embedding_base_url,
+      embedding_model_id,
+      embedding_api_key_ref,
+      created_at,
+      updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+  ).run(
+    uuid,
+    config.provider,
+    config.base_url,
+    config.model_id,
+    config.api_key_ref,
+    customEmbedding ? "custom" : "local",
+    customEmbedding ? config.embedding_base_url : null,
+    customEmbedding ? config.embedding_model_id : null,
+    customEmbedding ? config.embedding_api_key_ref : null,
+    config.created_at,
+    config.updated_at
+  );
+}
+
+function restoreAgentSources(
+  db: DatabaseSync,
+  sources: LegacyAgentSourceRow[],
+  ingestionSeen: LegacyIngestionSeenRow[]
+): void {
+  if (sources.length === 0 && ingestionSeen.length === 0) {
+    return;
+  }
+
+  ensureScopeAccount(db, LOCAL_AGENT_SOURCE_UUID);
+  const sourceIds = new Set(sources.map((source) => source.source_id));
+  const insertSource = db.prepare(
+    `INSERT OR IGNORE INTO account_agent_sources (
+      uuid,
+      source_id,
+      display_name,
+      data_path,
+      builtin,
+      status,
+      last_scanned_at,
+      created_at,
+      updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+  );
+  for (const source of sources) {
+    insertSource.run(
+      LOCAL_AGENT_SOURCE_UUID,
+      source.source_id,
+      source.display_name,
+      source.data_path,
+      source.builtin,
+      source.status,
+      source.last_scanned_at,
+      source.created_at,
+      source.created_at
+    );
+  }
+
+  const insertSeen = db.prepare(
+    `INSERT OR IGNORE INTO account_ingestion_seen (
+      uuid,
+      dedup_key,
+      source_id,
+      created_at
+    ) VALUES (?, ?, ?, ?)`
+  );
+  for (const seen of ingestionSeen) {
+    if (sourceIds.has(seen.source_id)) {
+      insertSeen.run(LOCAL_AGENT_SOURCE_UUID, seen.dedup_key, seen.source_id, seen.created_at);
+    }
+  }
+}
+
+function restoreIdempotency(db: DatabaseSync, uuid: string, rows: LegacyIdempotencyRow[]): void {
+  const insert = db.prepare(
+    `INSERT OR IGNORE INTO idempotency_keys (
+      uuid,
+      adapter_id,
+      request_id,
+      body_hash,
+      response_json,
+      status_code,
+      created_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?)`
+  );
+  for (const row of rows) {
+    insert.run(
+      uuid,
+      row.adapter_id,
+      row.request_id,
+      row.body_hash,
+      row.response_json,
+      row.status_code,
+      row.created_at
+    );
+  }
+}
+
+function ensureScopeAccount(db: DatabaseSync, uuid: string): void {
+  const now = new Date().toISOString();
+  db.prepare(
+    `INSERT OR IGNORE INTO cloud_accounts (uuid, created_at, updated_at)
+     VALUES (?, ?, ?)`
+  ).run(uuid, now, now);
+}
+
+function legacyAccountUuid(account: LegacyAccountSessionRow | null): string | null {
+  const userId = account?.user_id?.trim();
+  return userId && userId !== "unknown" ? userId : null;
+}
+
+function readOptionalRow<T>(db: DatabaseSync, tableName: string, sql: string): T | null {
+  if (!tableExists(db, tableName)) {
+    return null;
+  }
+  return (db.prepare(sql).get() as T | undefined) ?? null;
+}
+
+function readRows<T>(db: DatabaseSync, tableName: string, sql: string): T[] {
+  if (!tableExists(db, tableName)) {
+    return [];
+  }
+  return db.prepare(sql).all() as unknown as T[];
+}
+
+function tableExists(db: DatabaseSync, tableName: string): boolean {
+  return Boolean(
+    db.prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?").get(tableName)
+  );
+}
+
+function readPersistedSnapshot(db: DatabaseSync): LegacyAppStateSnapshot | null {
+  if (!tableExists(db, SNAPSHOT_TABLE)) {
+    return null;
+  }
+  const row = db
+    .prepare(`SELECT schema_version, snapshot_json FROM ${SNAPSHOT_TABLE} WHERE id = ?`)
+    .get(SNAPSHOT_ID) as { schema_version: number; snapshot_json: string } | undefined;
+  if (!row) {
+    return null;
+  }
+  if (row.schema_version !== SNAPSHOT_VERSION) {
+    throw new Error(`Unsupported legacy app-state snapshot version: ${row.schema_version}`);
+  }
+  return JSON.parse(row.snapshot_json) as LegacyAppStateSnapshot;
+}
+
+function persistSnapshot(db: DatabaseSync, snapshot: LegacyAppStateSnapshot): void {
+  db.exec("BEGIN IMMEDIATE");
+  try {
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS ${SNAPSHOT_TABLE} (
+        id TEXT PRIMARY KEY CHECK (id = '${SNAPSHOT_ID}'),
+        schema_version INTEGER NOT NULL,
+        snapshot_json TEXT NOT NULL,
+        created_at TEXT NOT NULL
+      )
+    `);
+    db.prepare(
+      `INSERT OR REPLACE INTO ${SNAPSHOT_TABLE} (
+        id,
+        schema_version,
+        snapshot_json,
+        created_at
+      ) VALUES (?, ?, ?, ?)`
+    ).run(SNAPSHOT_ID, SNAPSHOT_VERSION, JSON.stringify(snapshot), new Date().toISOString());
+    db.exec("COMMIT");
+  } catch (error) {
+    db.exec("ROLLBACK");
+    throw error;
+  }
+}
+
+function tableHasColumn(db: DatabaseSync, tableName: string, columnName: string): boolean {
+  if (!tableExists(db, tableName)) {
+    return false;
+  }
+  return (db.prepare(`PRAGMA table_info(${tableName})`).all() as Array<{ name: string }>).some(
+    (column) => column.name === columnName
+  );
+}
+
+function legacyCloudUuidSelect(db: DatabaseSync): string {
+  if (tableHasColumn(db, "account_session", "cloud_uuid_ref")) {
+    return "cloud_uuid_ref";
+  }
+  if (tableHasColumn(db, "account_session", "cloud_token_ref")) {
+    return `CASE cloud_token_ref
+      WHEN 'account-session:default:cloud-token' THEN 'account-session:default:cloud-uuid'
+      ELSE cloud_token_ref
+    END AS cloud_uuid_ref`;
+  }
+  return "NULL AS cloud_uuid_ref";
+}

--- a/App/backend/src/infrastructure/app-state-store/schema-finalizer.ts
+++ b/App/backend/src/infrastructure/app-state-store/schema-finalizer.ts
@@ -1,5 +1,10 @@
 /** Schema finalizer module. */
 import type { DatabaseSync } from "node:sqlite";
+import {
+  discardLegacyAppStateSnapshot,
+  restoreLegacyAppState,
+  type LegacyAppStateSnapshot
+} from "./legacy-state-migration.js";
 
 const LEGACY_ACCOUNT_TABLES = [
   "account_session",
@@ -51,10 +56,26 @@ interface ModelConfigRefRow {
 }
 
 /** Handles finalize database design. */
-export function finalizeDatabaseDesign(db: DatabaseSync): void {
-  normalizeCloudAccountPrimaryKeys(db);
-  normalizeAccountSecretRefs(db);
-  dropLegacyAccountTables(db);
+export function finalizeDatabaseDesign(
+  db: DatabaseSync,
+  legacyState: LegacyAppStateSnapshot | null = null
+): void {
+  db.exec("BEGIN IMMEDIATE");
+  try {
+    if (legacyState) {
+      restoreLegacyAppState(db, legacyState);
+    }
+    normalizeCloudAccountPrimaryKeys(db);
+    normalizeAccountSecretRefs(db);
+    dropLegacyAccountTables(db);
+    if (legacyState) {
+      discardLegacyAppStateSnapshot(db);
+    }
+    db.exec("COMMIT");
+  } catch (error) {
+    db.exec("ROLLBACK");
+    throw error;
+  }
 }
 
 /** Normalizes normalize cloud account primary keys. */

--- a/App/backend/src/infrastructure/app-state-store/tests/index.test.ts
+++ b/App/backend/src/infrastructure/app-state-store/tests/index.test.ts
@@ -1,10 +1,12 @@
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
 import { afterEach, describe, expect, it } from "vitest";
-import { createAppStateStore } from "../index.js";
-import { createSqliteSecretStore } from "../secret-store.js";
 import { LOCAL_BYOK_ACCOUNT_UUID } from "../account-context.js";
+import { createAppStateStore, runMigrations } from "../index.js";
+import { captureLegacyAppState } from "../legacy-state-migration.js";
+import { createSqliteSecretStore } from "../secret-store.js";
 
 let tempDir: string | undefined;
 
@@ -41,6 +43,452 @@ describe("app state store migrations", () => {
     expect(agentSources).toEqual([]);
     expect(firstMigrationCount).toBe(25);
     expect(secondMigrationCount).toBe(25);
+  });
+
+  it("preserves the authenticated account when upgrading the legacy 0007 database", () => {
+    tempDir = mkdtempSync(join(tmpdir(), "memmy-app-state-"));
+    const databasePath = join(tempDir, "app.sqlite");
+    const secretSeedPath = join(tempDir, "secret-seed.sqlite");
+    const legacyCloudUuidRef = "account-session:default:cloud-uuid";
+
+    const [encryptedCloudUuid] = createEncryptedSecretFixtures(secretSeedPath, [
+      { ref: legacyCloudUuidRef, value: "legacy-cloud-login-uuid" }
+    ]);
+
+    const legacyDb = createLegacy0007Database(databasePath);
+    legacyDb.prepare("UPDATE app_settings SET user_mode = 'account' WHERE id = 'default'").run();
+    legacyDb.prepare(
+      `UPDATE account_session SET
+        user_id = ?,
+        email = ?,
+        nickname = ?,
+        plan_type = ?,
+        has_finished_guide = ?,
+        region = ?,
+        registered_at = ?,
+        raw_profile_json = ?,
+        cloud_uuid_ref = ?,
+        updated_at = ?
+      WHERE id = 'default'`
+    ).run(
+      "legacy-user-1",
+      "legacy@example.com",
+      "Legacy User",
+      "free",
+      1,
+      "CN",
+      "2026-06-01T10:00:00.000Z",
+      JSON.stringify({ userId: "legacy-user-1", userName: "Legacy User" }),
+      legacyCloudUuidRef,
+      "2026-07-21T10:00:00.000Z"
+    );
+    insertLegacySecretFixtures(legacyDb, [encryptedCloudUuid]);
+    legacyDb.prepare(
+      `UPDATE onboarding_state SET
+        completed = 1,
+        current_step = 'completed',
+        has_accepted_terms = 1,
+        scan_permission = 'scan_only',
+        improvement_program = 'accepted',
+        completed_at = '2026-06-01T10:30:00.000Z'
+      WHERE id = 'default'`
+    ).run();
+    legacyDb.prepare(
+      `UPDATE privacy_settings SET
+        allow_memory_improvement_upload = 1,
+        local_only_mode = 1
+      WHERE id = 'default'`
+    ).run();
+    legacyDb.prepare(
+      `UPDATE token_usage_cache SET
+        plan_name = 'free',
+        total_tokens = 40000000,
+        used_tokens = 36191554,
+        remaining_tokens = 3808446,
+        last_synced_at = '2026-07-22T02:22:51.000Z'
+      WHERE id = 'default'`
+    ).run();
+    legacyDb.prepare(
+      `UPDATE model_config SET
+        provider = 'deepseek',
+        base_url = 'https://legacy-model.example/v1',
+        model_id = 'deepseek-chat',
+        embedding_mode = 'separate',
+        embedding_base_url = 'https://legacy-embedding.example/v1',
+        embedding_model_id = 'legacy-embedding'
+      WHERE id = 'default'`
+    ).run();
+    legacyDb.prepare(
+      `INSERT INTO agent_sources (
+        source_id,
+        display_name,
+        data_path,
+        builtin,
+        status,
+        last_scanned_at
+      ) VALUES (?, ?, ?, ?, ?, ?)`
+    ).run("legacy-source", "Legacy Source", "/legacy/source", 1, "skill_installed", "2026-07-21T11:00:00.000Z");
+    legacyDb.prepare(
+      "INSERT INTO ingestion_seen (dedup_key, source_id, created_at) VALUES (?, ?, ?)"
+    ).run("legacy-message", "legacy-source", "2026-07-21T11:01:00.000Z");
+    legacyDb.prepare(
+      `INSERT INTO idempotency_keys (
+        adapter_id,
+        request_id,
+        body_hash,
+        response_json,
+        status_code,
+        created_at
+      ) VALUES (?, ?, ?, ?, ?, ?)`
+    ).run("legacy-adapter", "legacy-request", "legacy-hash", "{\"ok\":true}", 200, "2026-07-21T11:02:00.000Z");
+    legacyDb.close();
+
+    const upgradedStore = createAppStateStore({ databasePath });
+    const upgradedSession = upgradedStore.repositories.accountSession.get();
+    const upgradedCloudUuid = upgradedStore.repositories.accountSession.getCloudUuid();
+    const upgradedTokenUsage = upgradedStore.repositories.bootstrap.getTokenUsage();
+    const upgradedOnboarding = upgradedStore.repositories.bootstrap.getOnboardingState();
+    const upgradedPrivacy = upgradedStore.repositories.bootstrap.getPrivacySettings();
+    const upgradedModelConfig = upgradedStore.db
+      .prepare("SELECT provider, base_url, model_id, embedding_mode, embedding_model_id FROM account_model_config WHERE uuid = ?")
+      .get("legacy-user-1");
+    const upgradedAgentSource = upgradedStore.db
+      .prepare("SELECT display_name, status, last_scanned_at FROM account_agent_sources WHERE uuid = ? AND source_id = ?")
+      .get("local-agent-sources", "legacy-source");
+    const upgradedIngestionSeen = upgradedStore.db
+      .prepare("SELECT source_id FROM account_ingestion_seen WHERE uuid = ? AND dedup_key = ?")
+      .get("local-agent-sources", "legacy-message");
+    const upgradedIdempotency = upgradedStore.repositories.idempotency.lookup("legacy-adapter", "legacy-request");
+    const upgradedActiveUuid = upgradedStore.db
+      .prepare("SELECT active_uuid FROM app_settings WHERE id = 'default'")
+      .get() as { active_uuid: string | null };
+    upgradedStore.close();
+
+    expect(upgradedSession).toMatchObject({
+      authenticated: true,
+      profile: {
+        userId: "legacy-user-1",
+        email: "legacy@example.com",
+        nickname: "Legacy User"
+      }
+    });
+    expect(upgradedCloudUuid).toBe("legacy-cloud-login-uuid");
+    expect(upgradedActiveUuid.active_uuid).toBe("legacy-user-1");
+    expect(upgradedTokenUsage).toMatchObject({
+      planName: "free",
+      totalTokens: 40000000,
+      usedTokens: 36191554,
+      remainingTokens: 3808446
+    });
+    expect(upgradedOnboarding).toMatchObject({
+      completed: true,
+      currentStep: "completed",
+      scanPermission: "scan_only",
+      improvementProgram: "accepted"
+    });
+    expect(upgradedPrivacy).toMatchObject({
+      allowMemoryImprovementUpload: true,
+      localOnlyMode: true
+    });
+    expect(upgradedModelConfig).toEqual({
+      provider: "deepseek",
+      base_url: "https://legacy-model.example/v1",
+      model_id: "deepseek-chat",
+      embedding_mode: "custom",
+      embedding_model_id: "legacy-embedding"
+    });
+    expect(upgradedAgentSource).toEqual({
+      display_name: "Legacy Source",
+      status: "skill_installed",
+      last_scanned_at: "2026-07-21T11:00:00.000Z"
+    });
+    expect(upgradedIngestionSeen).toEqual({ source_id: "legacy-source" });
+    expect(upgradedIdempotency).toEqual({
+      bodyHash: "legacy-hash",
+      responseJson: "{\"ok\":true}",
+      statusCode: 200,
+      createdAt: "2026-07-21T11:02:00.000Z"
+    });
+
+    const reopenedStore = createAppStateStore({ databasePath });
+    expect(reopenedStore.repositories.accountSession.get()).toMatchObject({
+      authenticated: true,
+      profile: { userId: "legacy-user-1" }
+    });
+    expect(reopenedStore.repositories.accountSession.getCloudUuid()).toBe("legacy-cloud-login-uuid");
+    expect(reopenedStore.repositories.bootstrap.getTokenUsage()).toMatchObject({
+      planName: "free",
+      totalTokens: 40000000,
+      usedTokens: 36191554,
+      remainingTokens: 3808446,
+      lastSyncedAt: "2026-07-22T02:22:51.000Z"
+    });
+    expect(reopenedStore.repositories.agentSources.listSources()).toEqual([
+      {
+        sourceId: "legacy-source",
+        displayName: "Legacy Source",
+        dataPath: "/legacy/source",
+        builtin: true,
+        status: "skill_installed",
+        messageCount: 1,
+        lastScannedAt: "2026-07-21T11:00:00.000Z"
+      }
+    ]);
+    expect(reopenedStore.repositories.agentSources.hasSeen("legacy-message")).toBe(true);
+    expect(reopenedStore.repositories.idempotency.lookup("legacy-adapter", "legacy-request")).toEqual({
+      bodyHash: "legacy-hash",
+      responseJson: "{\"ok\":true}",
+      statusCode: 200,
+      createdAt: "2026-07-21T11:02:00.000Z"
+    });
+    reopenedStore.close();
+  });
+
+  it("preserves legacy BYOK config and secrets in the local scope", () => {
+    tempDir = mkdtempSync(join(tmpdir(), "memmy-app-state-"));
+    const databasePath = join(tempDir, "app.sqlite");
+    const secretSeedPath = join(tempDir, "secret-seed.sqlite");
+    const legacyModelRef = "model:default:api-key";
+    const legacyEmbeddingRef = "model:default:embedding-api-key";
+    const secretFixtures = createEncryptedSecretFixtures(secretSeedPath, [
+      { ref: legacyModelRef, value: "primary-fixture-value" },
+      { ref: legacyEmbeddingRef, value: "embedding-fixture-value" }
+    ]);
+
+    const legacyDb = createLegacy0007Database(databasePath);
+    legacyDb.prepare("UPDATE app_settings SET user_mode = 'byok' WHERE id = 'default'").run();
+    legacyDb.prepare(
+      `UPDATE account_session SET
+        user_id = 'stale-cloud-user',
+        nickname = 'Stale Cloud User'
+      WHERE id = 'default'`
+    ).run();
+    legacyDb.prepare(
+      `UPDATE onboarding_state SET
+        completed = 1,
+        current_step = 'completed',
+        completed_at = '2026-07-20T10:00:00.000Z'
+      WHERE id = 'default'`
+    ).run();
+    legacyDb.prepare(
+      `UPDATE privacy_settings SET
+        allow_memory_improvement_upload = 1,
+        local_only_mode = 1
+      WHERE id = 'default'`
+    ).run();
+    legacyDb.prepare(
+      `UPDATE model_config SET
+        provider = 'deepseek',
+        base_url = 'https://legacy-byok.example/v1',
+        model_id = 'deepseek-chat',
+        api_key_ref = ?,
+        embedding_mode = 'separate',
+        embedding_base_url = 'https://legacy-embedding.example/v1',
+        embedding_model_id = 'legacy-embedding',
+        embedding_api_key_ref = ?
+      WHERE id = 'default'`
+    ).run(legacyModelRef, legacyEmbeddingRef);
+    insertLegacySecretFixtures(legacyDb, secretFixtures);
+    legacyDb.close();
+
+    const upgradedStore = createAppStateStore({ databasePath });
+    const upgradedSettings = upgradedStore.repositories.bootstrap.getAppSettings();
+    const upgradedOnboarding = upgradedStore.repositories.bootstrap.getOnboardingState();
+    const upgradedPrivacy = upgradedStore.repositories.bootstrap.getPrivacySettings();
+    const upgradedModel = upgradedStore.repositories.modelConfig.get();
+    const upgradedActiveUuid = upgradedStore.db
+      .prepare("SELECT active_uuid FROM app_settings WHERE id = 'default'")
+      .get() as { active_uuid: string | null };
+    const upgradedModelRow = upgradedStore.db
+      .prepare(
+        `SELECT uuid, api_key_ref, embedding_api_key_ref
+         FROM account_model_config
+         WHERE uuid = ?`
+      )
+      .get(LOCAL_BYOK_ACCOUNT_UUID);
+    const upgradedSecretRows = upgradedStore.db
+      .prepare(
+        `SELECT ref, uuid, purpose
+         FROM secret_store
+         WHERE ref IN (?, ?)
+         ORDER BY purpose ASC`
+      )
+      .all(
+        `account:${LOCAL_BYOK_ACCOUNT_UUID}:model-api-key`,
+        `account:${LOCAL_BYOK_ACCOUNT_UUID}:embedding-api-key`
+      );
+
+    expect(upgradedSettings.userMode).toBe("byok");
+    expect(upgradedActiveUuid.active_uuid).toBeNull();
+    expect(upgradedOnboarding).toMatchObject({ completed: true, currentStep: "completed" });
+    expect(upgradedPrivacy).toMatchObject({
+      allowMemoryImprovementUpload: true,
+      localOnlyMode: true
+    });
+    expect(upgradedModel).toMatchObject({
+      provider: "deepseek",
+      baseUrl: "https://legacy-byok.example/v1",
+      modelId: "deepseek-chat",
+      hasApiKey: true,
+      embedding: {
+        mode: "custom",
+        baseUrl: "https://legacy-embedding.example/v1",
+        modelId: "legacy-embedding",
+        hasApiKey: true
+      }
+    });
+    expect(upgradedStore.repositories.modelConfig.getTestApiKey?.("primary")).toBe(
+      "primary-fixture-value"
+    );
+    expect(upgradedStore.repositories.modelConfig.getTestApiKey?.("embedding")).toBe(
+      "embedding-fixture-value"
+    );
+    expect(upgradedModelRow).toEqual({
+      uuid: LOCAL_BYOK_ACCOUNT_UUID,
+      api_key_ref: `account:${LOCAL_BYOK_ACCOUNT_UUID}:model-api-key`,
+      embedding_api_key_ref: `account:${LOCAL_BYOK_ACCOUNT_UUID}:embedding-api-key`
+    });
+    expect(upgradedSecretRows).toEqual([
+      {
+        ref: `account:${LOCAL_BYOK_ACCOUNT_UUID}:embedding-api-key`,
+        uuid: LOCAL_BYOK_ACCOUNT_UUID,
+        purpose: "embedding_api_key"
+      },
+      {
+        ref: `account:${LOCAL_BYOK_ACCOUNT_UUID}:model-api-key`,
+        uuid: LOCAL_BYOK_ACCOUNT_UUID,
+        purpose: "model_api_key"
+      }
+    ]);
+    upgradedStore.close();
+
+    const reopenedStore = createAppStateStore({ databasePath });
+    expect(reopenedStore.repositories.bootstrap.getAppSettings().userMode).toBe("byok");
+    expect(reopenedStore.repositories.bootstrap.getOnboardingState()).toMatchObject({
+      completed: true,
+      currentStep: "completed"
+    });
+    expect(reopenedStore.repositories.bootstrap.getPrivacySettings()).toMatchObject({
+      allowMemoryImprovementUpload: true,
+      localOnlyMode: true
+    });
+    expect(reopenedStore.repositories.modelConfig.get()).toMatchObject({
+      provider: "deepseek",
+      modelId: "deepseek-chat",
+      hasApiKey: true,
+      embedding: { mode: "custom", modelId: "legacy-embedding", hasApiKey: true }
+    });
+    expect(reopenedStore.repositories.modelConfig.getTestApiKey?.("primary")).toBe(
+      "primary-fixture-value"
+    );
+    expect(reopenedStore.repositories.modelConfig.getTestApiKey?.("embedding")).toBe(
+      "embedding-fixture-value"
+    );
+    reopenedStore.close();
+  });
+
+  it("preserves logged-out legacy singleton state in the local fallback scope", () => {
+    tempDir = mkdtempSync(join(tmpdir(), "memmy-app-state-"));
+    const databasePath = join(tempDir, "app.sqlite");
+    const legacyDb = createLegacy0007Database(databasePath);
+    legacyDb.prepare("UPDATE app_settings SET user_mode = 'account' WHERE id = 'default'").run();
+    legacyDb.prepare(
+      `UPDATE onboarding_state SET
+        completed = 1,
+        current_step = 'completed',
+        completed_at = '2026-07-20T11:00:00.000Z'
+      WHERE id = 'default'`
+    ).run();
+    legacyDb.prepare(
+      `UPDATE privacy_settings SET
+        allow_memory_improvement_upload = 1,
+        local_only_mode = 1
+      WHERE id = 'default'`
+    ).run();
+    legacyDb.prepare(
+      `UPDATE model_config SET
+        provider = 'deepseek',
+        base_url = 'https://legacy-logged-out.example/v1',
+        model_id = 'deepseek-chat'
+      WHERE id = 'default'`
+    ).run();
+    legacyDb.close();
+
+    const upgradedStore = createAppStateStore({ databasePath });
+    const activeUuid = upgradedStore.db
+      .prepare("SELECT active_uuid FROM app_settings WHERE id = 'default'")
+      .get() as { active_uuid: string | null };
+    const modelRow = upgradedStore.db
+      .prepare("SELECT uuid FROM account_model_config WHERE uuid = ?")
+      .get(LOCAL_BYOK_ACCOUNT_UUID);
+
+    expect(upgradedStore.repositories.accountSession.get()).toEqual({ authenticated: false });
+    expect(activeUuid.active_uuid).toBeNull();
+    expect(upgradedStore.repositories.bootstrap.getOnboardingState()).toMatchObject({
+      completed: true,
+      currentStep: "completed"
+    });
+    expect(upgradedStore.repositories.bootstrap.getPrivacySettings()).toMatchObject({
+      allowMemoryImprovementUpload: true,
+      localOnlyMode: true
+    });
+    expect(upgradedStore.repositories.modelConfig.get()).toMatchObject({
+      provider: "deepseek",
+      baseUrl: "https://legacy-logged-out.example/v1",
+      modelId: "deepseek-chat"
+    });
+    expect(modelRow).toEqual({ uuid: LOCAL_BYOK_ACCOUNT_UUID });
+    upgradedStore.close();
+  });
+
+  it("resumes legacy restoration from the durable snapshot after SQL migrations", () => {
+    tempDir = mkdtempSync(join(tmpdir(), "memmy-app-state-"));
+    const databasePath = join(tempDir, "app.sqlite");
+    const legacyDb = createLegacy0007Database(databasePath);
+    legacyDb.prepare("UPDATE app_settings SET user_mode = 'account' WHERE id = 'default'").run();
+    legacyDb.prepare(
+      `UPDATE account_session SET
+        user_id = 'interrupted-user',
+        nickname = 'Interrupted User'
+      WHERE id = 'default'`
+    ).run();
+    legacyDb.prepare(
+      `INSERT INTO idempotency_keys (
+        adapter_id,
+        request_id,
+        body_hash,
+        response_json,
+        status_code,
+        created_at
+      ) VALUES ('interrupted-adapter', 'interrupted-request', 'hash', '{}', 201, ?)`
+    ).run("2026-07-21T12:00:00.000Z");
+
+    expect(captureLegacyAppState(legacyDb)).not.toBeNull();
+    runMigrations(legacyDb);
+    expect(
+      legacyDb.prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?")
+        .get("_legacy_app_state_snapshot")
+    ).toBeDefined();
+    legacyDb.close();
+
+    const resumedStore = createAppStateStore({ databasePath });
+    expect(resumedStore.repositories.accountSession.get()).toMatchObject({
+      authenticated: true,
+      profile: { userId: "interrupted-user", nickname: "Interrupted User" }
+    });
+    expect(
+      resumedStore.repositories.idempotency.lookup("interrupted-adapter", "interrupted-request")
+    ).toEqual({
+      bodyHash: "hash",
+      responseJson: "{}",
+      statusCode: 201,
+      createdAt: "2026-07-21T12:00:00.000Z"
+    });
+    expect(
+      resumedStore.db.prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?")
+        .get("_legacy_app_state_snapshot")
+    ).toBeUndefined();
+    resumedStore.close();
   });
 
   it("recovers when the ASR migration columns already exist but its migration record is missing", () => {
@@ -618,6 +1066,90 @@ describe("bootstrap repository writes", () => {
 function getMigrationCount(db: { prepare(sql: string): { get(): unknown } }): number {
   const row = db.prepare("SELECT COUNT(*) AS count FROM _migrations").get() as { count: number };
   return row.count;
+}
+
+/**
+ * Creates the last legacy app-state schema before account isolation was introduced.
+ *
+ * @param databasePath SQLite path for the legacy fixture.
+ * @returns The open legacy database.
+ */
+function createLegacy0007Database(databasePath: string): DatabaseSync {
+  const db = new DatabaseSync(databasePath);
+  db.exec(`
+    PRAGMA foreign_keys = ON;
+    CREATE TABLE _migrations (
+      name TEXT PRIMARY KEY,
+      applied_at TEXT NOT NULL
+    );
+  `);
+
+  for (const [migrationName, migrationUrl] of [
+    ["0001-init-app-state.sql", new URL("../migrations/0001-init-app-state.sql", import.meta.url)],
+    ["0002-agent-sources.sql", new URL("../../agent-source-store/migrations/0002-agent-sources.sql", import.meta.url)],
+    ["0003-idempotency.sql", new URL("../../idempotency-store/migrations/0003-idempotency.sql", import.meta.url)],
+    ["0004-account-and-config.sql", new URL("../migrations/0004-account-and-config.sql", import.meta.url)],
+    ["0005-account-registered-at.sql", new URL("../migrations/0005-account-registered-at.sql", import.meta.url)],
+    ["0006-token-usage-real-plan.sql", new URL("../migrations/0006-token-usage-real-plan.sql", import.meta.url)],
+    ["0007-cloud-login-uuid.sql", new URL("../migrations/0007-cloud-login-uuid.sql", import.meta.url)]
+  ]) {
+    db.exec(readFileSync(migrationUrl, "utf8"));
+    db.prepare("INSERT INTO _migrations (name, applied_at) VALUES (?, ?)").run(
+      migrationName,
+      "2026-07-21T10:00:00.000Z"
+    );
+  }
+
+  return db;
+}
+
+interface EncryptedSecretFixture {
+  ref: string;
+  ciphertext: string;
+  iv: string;
+  auth_tag: string;
+  created_at: string;
+  updated_at: string;
+}
+
+function createEncryptedSecretFixtures(
+  databasePath: string,
+  inputs: ReadonlyArray<{ ref: string; value: string }>
+): EncryptedSecretFixture[] {
+  const store = createAppStateStore({ databasePath });
+  const fixtures = inputs.map(({ ref, value }) => {
+    store.secretStore.set(ref, value);
+    const row = store.db
+      .prepare(
+        `SELECT ref, ciphertext, iv, auth_tag, created_at, updated_at
+         FROM secret_store
+         WHERE ref = ?`
+      )
+      .get(ref) as EncryptedSecretFixture | undefined;
+    if (!row) {
+      throw new Error(`Missing encrypted test fixture for ${ref}`);
+    }
+    return row;
+  });
+  store.close();
+  return fixtures;
+}
+
+function insertLegacySecretFixtures(db: DatabaseSync, fixtures: EncryptedSecretFixture[]): void {
+  const insert = db.prepare(
+    `INSERT INTO secret_store (ref, ciphertext, iv, auth_tag, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?)`
+  );
+  for (const fixture of fixtures) {
+    insert.run(
+      fixture.ref,
+      fixture.ciphertext,
+      fixture.iv,
+      fixture.auth_tag,
+      fixture.created_at,
+      fixture.updated_at
+    );
+  }
 }
 
 function listColumnNames(db: { prepare(sql: string): { all(): unknown[] } }, tableName: string): string[] {


### PR DESCRIPTION
## Root cause

The account-isolation migration created scoped tables without copying legacy singleton state, then finalization dropped the legacy tables. On restart, the account session became unauthenticated and token usage fell back to defaults.

## Changes

- Snapshot and restore legacy account/BYOK state, quota, sources, idempotency records, and encrypted secret references.
- Make restoration crash-safe with a durable snapshot and atomic finalization.
- Preserve logged-out fallback state without activating stale cloud accounts.
- Add regressions for authenticated, BYOK, logged-out, reopen, and interrupted-migration flows.

## Validation

- App-state migration tests: 22/22 passed.
- Backend suite: 88 files, 640 tests passed.
- Typecheck and lint passed.
- Project Harness Full: no failed evidence; T3 change is awaiting independent review.