### PR TITLE
fix(packaging): restore runtime env in desktop installers

### DIFF
--- a/App/shell/desktop/electron-builder.unsigned.yml
+++ b/App/shell/desktop/electron-builder.unsigned.yml
@@ -25,6 +25,9 @@ extraResources:
     to: MenuBarIconTemplate.png
   - from: build/MenuBarIconTemplate@2x.png
     to: MenuBarIconTemplate@2x.png
+  - from: ../../../.env
+    to: .env
+
 mac:
   icon: build/icon.icns
   category: public.app-category.productivity

--- a/App/shell/desktop/electron-builder.win.unsigned.yml
+++ b/App/shell/desktop/electron-builder.win.unsigned.yml
@@ -21,6 +21,8 @@ extraResources:
     to: cli
     filter:
       - "**/*"
+  - from: ../../../.env
+    to: .env
   - from: build/icon.ico
     to: icon.ico
 

--- a/App/shell/desktop/electron-builder.win.yml
+++ b/App/shell/desktop/electron-builder.win.yml
@@ -21,6 +21,8 @@ extraResources:
     to: cli
     filter:
       - "**/*"
+  - from: ../../../.env
+    to: .env
   - from: build/icon.ico
     to: icon.ico
 

--- a/App/shell/desktop/electron-builder.yml
+++ b/App/shell/desktop/electron-builder.yml
@@ -25,6 +25,9 @@ extraResources:
     to: MenuBarIconTemplate.png
   - from: build/MenuBarIconTemplate@2x.png
     to: MenuBarIconTemplate@2x.png
+  - from: ../../../.env
+    to: .env
+
 mac:
   icon: build/icon.icns
   category: public.app-category.productivity

--- a/App/shell/desktop/tests/packaged-runtime-boundary.test.ts
+++ b/App/shell/desktop/tests/packaged-runtime-boundary.test.ts
@@ -890,7 +890,7 @@ describe("desktop packaged runtime boundaries", () => {
     expect(source).not.toContain("mv -f");
   });
 
-  it("does not bundle the repo-root .env into packaged apps", () => {
+  it("bundles the repo-root .env so packaged apps can resolve MEMMY_CLOUD_SERVICE", () => {
     const configs = [
       readFileSync(electronBuilderPath, "utf8"),
       readFileSync(unsignedElectronBuilderPath, "utf8"),
@@ -899,8 +899,8 @@ describe("desktop packaged runtime boundaries", () => {
     ];
 
     for (const config of configs) {
-      expect(config).not.toContain("from: ../../../.env");
-      expect(config).not.toContain("to: .env");
+      expect(config).toContain("from: ../../../.env");
+      expect(config).toContain("to: .env");
     }
   });
 });

--- a/tests/release-workflow.test.ts
+++ b/tests/release-workflow.test.ts
@@ -127,14 +127,14 @@ describe("GitHub release workflow", () => {
     expect(workflow.concurrency.group).toContain("pull_request.head.ref");
   });
 
-  it("does not embed a repository .env file in desktop installers", () => {
+  it("embeds the repository .env required by packaged desktop runtimes", () => {
     for (const config of packagingConfigs) {
       const packagingSource = readFileSync(
         resolve(import.meta.dirname, `../App/shell/desktop/${config}`),
         "utf8",
       );
-      expect(packagingSource).not.toMatch(/from:\s+.*\.env(?:\s|$)/);
-      expect(packagingSource).not.toMatch(/to:\s+\.env(?:\s|$)/);
+      expect(packagingSource).toMatch(/from:\s+\.\.\/\.\.\/\.\.\/\.env(?:\s|$)/);
+      expect(packagingSource).toMatch(/to:\s+\.env(?:\s|$)/);
     }
   });
 });


### PR DESCRIPTION
## Summary

- restore the repository-root `.env` mapping in all signed and unsigned macOS/Windows electron-builder configs
- restore the packaged-runtime regression contract for `MEMMY_CLOUD_SERVICE`
- keep the change limited to packaging configuration and matching tests

## Why

The packaged desktop main process and bundled agent currently resolve `MEMMY_CLOUD_SERVICE` from a `.env` file in the application resources hierarchy. Removing the `extraResources` mapping left installed builds without that required runtime configuration.

This is a temporary compatibility restoration so packaging and installed runtime validation can proceed. A follow-up should replace it with an allowlisted runtime configuration file.

## Verification

- regression phase before the config fix: 2 expected failures, 42 passing tests
- after the fix: 44/44 targeted release and packaged-runtime tests pass
- lint, affected typechecks/tests, smoke checks, and the full workspace build pass
- `git diff --check` passes

## Known risk

`extraResources` copies the complete build-machine `.env` into the installer resources directory. Until the allowlisted runtime configuration follow-up lands, packaging must use a sanitized `.env` that contains no credentials or private values.
