### PR TITLE
revert: remove PR #37 from main

### DIFF
--- a/App/frontend/desktop/src/pages/pet-page.tsx
+++ b/App/frontend/desktop/src/pages/pet-page.tsx
@@ -1285,7 +1285,7 @@ export function PetPageView({ bus, mainRoute = "/main", onNavigate, onPetWindowC
 
   useEffect(() => {
     if (focusedTask && (focusedTask.status === "done" || focusedTask.status === "error") && !focusedTask.dismissed) {
-      bus.focusTask(null);
+      bus.dismissTask(focusedTask.id);
     }
   }, []);
 

--- a/App/frontend/desktop/src/pages/tests/pet-page.test.tsx
+++ b/App/frontend/desktop/src/pages/tests/pet-page.test.tsx
@@ -767,17 +767,14 @@ describe("PetPageView SSR", () => {
     expect(source).not.toContain("const transcript = textInput.trim();");
   });
 
-  it("挂载时只清除已完成 focusedTask 的焦点，避免残留气泡同时保留任务列表记录", () => {
+  it("挂载时自动 dismiss 已处于终态的 focusedTask，避免完整模式残留气泡", () => {
     const source = readFileSync(petPageSourcePath, "utf8");
 
-    const mountGuard = source.indexOf('if (focusedTask && (focusedTask.status === "done" || focusedTask.status === "error")');
-    const mountEffectEnd = source.indexOf("}, []);", mountGuard);
-    const mountEffect = source.slice(mountGuard, mountEffectEnd);
-
+    expect(source).toContain('bus.dismissTask(focusedTask.id)');
+    const dismissBlock = source.indexOf('bus.dismissTask(focusedTask.id)');
+    const mountGuard = source.indexOf('focusedTask.status === "done" || focusedTask.status === "error"');
     expect(mountGuard).toBeGreaterThan(-1);
-    expect(mountEffectEnd).toBeGreaterThan(mountGuard);
-    expect(mountEffect).toContain("bus.focusTask(null);");
-    expect(mountEffect).not.toContain("bus.dismissTask(");
+    expect(dismissBlock).toBeGreaterThan(mountGuard);
     expect(source).not.toContain("react-hooks/exhaustive-deps");
   });
 


### PR DESCRIPTION
## Summary

- Revert the accidental merge of PR #37 into `main` without rewriting history.
- Restore `main` to the exact tree state before merge commit `e6449fc`.
- Reapply the fix separately to `v1.0.3` through a dedicated follow-up PR.

## Validation

- `npx vitest run App/frontend/desktop/src/pages/tests/pet-page.test.tsx` — 50 tests passed.
- Project Harness Standard gate — passed.
- Full-tree comparison against `e6449fc^1` — no differences.

Related: #37