### PR TITLE
fix(desktop): keep latest task in pet switcher

### DIFF
--- a/App/frontend/desktop/src/pages/pet-page.tsx
+++ b/App/frontend/desktop/src/pages/pet-page.tsx
@@ -1321,7 +1321,7 @@ export function PetPageView({ bus, mainRoute = "/main", onNavigate, onPetWindowC
 
   useEffect(() => {
     if (focusedTask && (focusedTask.status === "done" || focusedTask.status === "error") && !focusedTask.dismissed) {
-      bus.dismissTask(focusedTask.id);
+      bus.focusTask(null);
     }
   }, []);
 

--- a/App/frontend/desktop/src/pages/tests/pet-page.test.tsx
+++ b/App/frontend/desktop/src/pages/tests/pet-page.test.tsx
@@ -767,14 +767,17 @@ describe("PetPageView SSR", () => {
     expect(source).not.toContain("const transcript = textInput.trim();");
   });
 
-  it("挂载时自动 dismiss 已处于终态的 focusedTask，避免完整模式残留气泡", () => {
+  it("挂载时只清除已完成 focusedTask 的焦点，避免残留气泡同时保留任务列表记录", () => {
     const source = readFileSync(petPageSourcePath, "utf8");
 
-    expect(source).toContain('bus.dismissTask(focusedTask.id)');
-    const dismissBlock = source.indexOf('bus.dismissTask(focusedTask.id)');
-    const mountGuard = source.indexOf('focusedTask.status === "done" || focusedTask.status === "error"');
+    const mountGuard = source.indexOf('if (focusedTask && (focusedTask.status === "done" || focusedTask.status === "error")');
+    const mountEffectEnd = source.indexOf("}, []);", mountGuard);
+    const mountEffect = source.slice(mountGuard, mountEffectEnd);
+
     expect(mountGuard).toBeGreaterThan(-1);
-    expect(dismissBlock).toBeGreaterThan(mountGuard);
+    expect(mountEffectEnd).toBeGreaterThan(mountGuard);
+    expect(mountEffect).toContain("bus.focusTask(null);");
+    expect(mountEffect).not.toContain("bus.dismissTask(");
     expect(source).not.toContain("react-hooks/exhaustive-deps");
   });
 


### PR DESCRIPTION
## Summary

- Reapply the actual code and regression test from PR #37 to the intended v1.0.3 branch.
- Keep the latest task in the pet switcher while clearing only the focused task when pet mode mounts.
- Do not carry the original merge commit into v1.0.3.

## Validation

- Baseline reproduction failed as expected: mounting pet mode dismissed the completed task instead of only clearing focus.
- Post-fix behavior assertion passed.
- Targeted Vitest: 1 file passed, 50 tests passed.
- Scoped Project Harness Standard gate passed for the two changed files.

## Release note

A separate full v1.0.3 branch audit found pre-existing release blockers outside this PR diff. Those should be resolved before publishing v1.0.3; they do not belong in this isolated correction PR.

Related: #37