### PR TITLE
fix(settings): ignore IME Enter when editing nickname

### DIFF
--- a/App/frontend/desktop/src/pages/settings-page.tsx
+++ b/App/frontend/desktop/src/pages/settings-page.tsx
@@ -1,5 +1,5 @@
 /** Settings page module. */
-import { useEffect, useRef, useState, type CSSProperties, type Dispatch, type ReactNode } from "react";
+import { useEffect, useRef, useState, type CSSProperties, type Dispatch, type KeyboardEvent as ReactKeyboardEvent, type ReactNode } from "react";
 import { Brain, Palette, Rocket, Settings2, Shield, User, Zap, ArrowRight, ArrowLeft, Bell, ExternalLink, FolderOpen, Info, LogOut, Wrench, Search, Eye, EyeOff, ChevronDown, ChevronUp, ChevronRight, Database, Loader2, CheckCircle2, XCircle, Check, AlertTriangle, ArrowDownToLine, ArrowUpFromLine, MessageSquare, FileText, Sparkles, Mic, Image as ImageIcon } from "lucide-react";
 import type { AppSettingsDto, ByokTokenUsageByKind, ByokTokenUsageKind, ByokTokenUsageSummary, Language, PrivacySettingsDto, TokenUsageDto } from "@memmy/local-api-contracts";
 import { useApiClients } from "../app/providers.js";
@@ -19,6 +19,7 @@ import {
 import { consumeTokenExhaustedApplyMoreRequest, TOKEN_EXHAUSTED_APPLY_MORE_EVENT } from "../app/token-exhausted-apply-more.js";
 import { getLegalLinkUrl } from "../legal/legal-links.js";
 import { maskAccountIdentifier } from "../utils/mask-account-identifier.js";
+import { isComposingKeyboardEvent } from "../utils/keyboard.js";
 import { openExternalUrl } from "../utils/open-url.js";
 import { useTranslation } from "../i18n/use-translation.js";
 import { appActions, type AppAction } from "../state/app-actions.js";
@@ -208,6 +209,11 @@ export interface SettingsPageViewProps {
   update: UpdateCoordinatorValue;
   track?: TrackAnalyticsEvent;
   onUsageDetailVisibleChange?: (visible: boolean) => void;
+}
+
+/** Returns whether a nickname input key event should save the current draft. */
+export function shouldSaveAccountNicknameOnKeyDown(event: ReactKeyboardEvent<HTMLInputElement>): boolean {
+  return event.key === "Enter" && !isComposingKeyboardEvent(event);
 }
 
 /**
@@ -1113,7 +1119,7 @@ export function SettingsPageView(props: SettingsPageViewProps) {
                       value={nicknameDraft}
                       onChange={(event) => setNicknameDraft(event.target.value)}
                       onKeyDown={(event) => {
-                        if (event.key === "Enter") {
+                        if (shouldSaveAccountNicknameOnKeyDown(event)) {
                           void saveNickname();
                         }
                         if (event.key === "Escape") {

--- a/App/frontend/desktop/src/pages/settings-page.tsx
+++ b/App/frontend/desktop/src/pages/settings-page.tsx
@@ -1,5 +1,5 @@
 /** Settings page module. */
-import { useEffect, useRef, useState, type CSSProperties, type Dispatch, type KeyboardEvent as ReactKeyboardEvent, type ReactNode } from "react";
+import { useEffect, useRef, useState, type CSSProperties, type Dispatch, type ReactNode } from "react";
 import { Brain, Palette, Rocket, Settings2, Shield, User, Zap, ArrowRight, ArrowLeft, Bell, ExternalLink, FolderOpen, Info, LogOut, Wrench, Search, Eye, EyeOff, ChevronDown, ChevronUp, ChevronRight, Database, Loader2, CheckCircle2, XCircle, Check, AlertTriangle, ArrowDownToLine, ArrowUpFromLine, MessageSquare, FileText, Sparkles, Mic, Image as ImageIcon } from "lucide-react";
 import type { AppSettingsDto, ByokTokenUsageByKind, ByokTokenUsageKind, ByokTokenUsageSummary, Language, PrivacySettingsDto, TokenUsageDto } from "@memmy/local-api-contracts";
 import { useApiClients } from "../app/providers.js";
@@ -212,7 +212,7 @@ export interface SettingsPageViewProps {
 }
 
 /** Returns whether a nickname input key event should save the current draft. */
-export function shouldSaveAccountNicknameOnKeyDown(event: ReactKeyboardEvent<HTMLInputElement>): boolean {
+export function shouldSaveAccountNicknameOnKeyDown(event: import("react").KeyboardEvent<HTMLInputElement>): boolean {
   return event.key === "Enter" && !isComposingKeyboardEvent(event);
 }
 

--- a/App/frontend/desktop/src/pages/tests/settings-page.test.tsx
+++ b/App/frontend/desktop/src/pages/tests/settings-page.test.tsx
@@ -14,6 +14,7 @@ import {
   formatUsageUpdatedAt,
   isPendingQuotaRequestError,
   readLogLevel,
+  shouldSaveAccountNicknameOnKeyDown,
   writeLogLevel
 } from "../settings-page.js";
 
@@ -720,6 +721,16 @@ describe("SettingsPageView", () => {
     expect(source).toContain("appActions.accountCleared()");
   });
 
+  it("中文输入法组合输入中的 Enter 只确认候选，不保存账户昵称", () => {
+    expect(shouldSaveAccountNicknameOnKeyDown(nicknameKeyEvent({ nativeEvent: { isComposing: true } }))).toBe(false);
+    expect(shouldSaveAccountNicknameOnKeyDown(nicknameKeyEvent({ nativeEvent: { keyCode: 229 } }))).toBe(false);
+    expect(shouldSaveAccountNicknameOnKeyDown(nicknameKeyEvent({ nativeEvent: { isComposing: false, keyCode: 13 } }))).toBe(true);
+    expect(shouldSaveAccountNicknameOnKeyDown(nicknameKeyEvent({ key: "Escape" }))).toBe(false);
+
+    const source = readFileSync(settingsPageSourcePath, "utf8");
+    expect(source).toContain("if (shouldSaveAccountNicknameOnKeyDown(event))");
+  });
+
   it("设置页账户区长昵称和账号按真实溢出再显示提示", () => {
     const longAccountState = appReducer(
       createAccountModeState(),
@@ -857,6 +868,15 @@ function createUpdateViewModel(
  */
 function normalizeSsrHtml(html: string): string {
   return html.replaceAll("<!-- -->", "");
+}
+
+function nicknameKeyEvent(
+  overrides: { key?: string; nativeEvent?: { isComposing?: boolean; keyCode?: number } } = {}
+) {
+  return {
+    key: overrides.key ?? "Enter",
+    nativeEvent: overrides.nativeEvent ?? { isComposing: false, keyCode: 13 }
+  } as any;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Ignore Enter while the account nickname editor is handling an active IME composition, including legacy `keyCode 229`.
- Preserve normal Enter-to-save and Escape-to-cancel behavior.
- Add regression coverage for composing Enter, legacy IME Enter, ordinary Enter, and Escape.

## Validation

- Project Harness Full (0.3.2): 12/12 required evidence checks passed.
- Gate: `needs_review`; independent human review is still required.
- The PR contains 1 commit and changes only the settings page plus its matching test file.