### PR TITLE
fix: docs home use locale-matched architecture images

### DIFF
--- a/docs/cn/index.mdx
+++ b/docs/cn/index.mdx
@@ -39,7 +39,7 @@ Memmy 不是只有一个聊天窗口的应用，而是一套完整的本地 Agen
 
 ## 工作原理
 
-![Memmy 架构图](https://cdn.memtensor.com.cn/img/1783665524205_5h1ohc_compressed.png)
+![Memmy 系统架构](../assets/memmy-architecture-zh.png)
 
 ## 核心能力
 

--- a/docs/en/index.mdx
+++ b/docs/en/index.mdx
@@ -38,7 +38,7 @@ Memmy is not just an app with a chat window — it is a complete local Agent Run
 
 ## How It Works
 
-![Memmy architecture](https://cdn.memtensor.com.cn/img/1783665524205_5h1ohc_compressed.png)
+![Memmy System Architecture](../assets/memmy-architecture-en.png)
 
 ## Core Capabilities
 


### PR DESCRIPTION
## Summary
- English docs home (`docs/en/index.mdx`) was using a Chinese CDN architecture diagram under How It Works
- Switch EN/CN docs home images to the same local assets already used by the architecture pages (`memmy-architecture-en.png` / `memmy-architecture-zh.png`)

## Test plan
- [ ] Open English docs home `/docs/` and confirm How It Works shows the English architecture diagram
- [ ] Open Chinese docs home and confirm the Chinese architecture diagram
- [ ] Compare with `/docs/concepts/architecture/` — images should match per locale


Made with [Cursor](https://cursor.com)