### PR TITLE
fix(agent): show connected channel sessions on desktop

### DIFF
--- a/App/frontend/desktop/src/api/tests/memmy-agent-client.test.ts
+++ b/App/frontend/desktop/src/api/tests/memmy-agent-client.test.ts
@@ -329,6 +329,42 @@ describe("memmy-agent client", () => {
     await expect(client.deleteSession("websocket:chat-1")).resolves.toBe(true);
   });
 
+  it("opens channel history whose session key contains address characters", async () => {
+    const sessionKey = "imessage:+15551234567@example.com";
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = new URL(String(input));
+      if (url.pathname === "/webui/bootstrap") {
+        return json(bootstrap);
+      }
+      if (url.pathname === "/api/sessions/imessage%3A%2B15551234567%40example.com/webui-thread") {
+        return json({
+          schemaVersion: 3,
+          sessionKey,
+          last_turn_closed: true,
+          messages: [
+            { role: "user", content: "渠道里的问题" },
+            { role: "assistant", content: "渠道里的回答" }
+          ]
+        });
+      }
+      return json({ error: "not found" }, 404);
+    });
+    const client = createMemmyAgentClient({
+      baseUrl: "http://127.0.0.1:18980",
+      clientId: "frontend-test",
+      fetchFn: fetchMock as typeof fetch
+    });
+
+    await expect(client.readWebuiThread(sessionKey)).resolves.toMatchObject({
+      sessionKey,
+      last_turn_closed: true,
+      messages: [
+        { role: "user", content: "渠道里的问题" },
+        { role: "assistant", content: "渠道里的回答" }
+      ]
+    });
+  });
+
   it("normalizes gateway media URLs in webui-thread snapshots without rewriting unrelated fields", async () => {
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
       const url = new URL(String(input));

--- a/App/memmy-agent/src/entrypoints/frontend-bridge/transcript.ts
+++ b/App/memmy-agent/src/entrypoints/frontend-bridge/transcript.ts
@@ -1158,16 +1158,64 @@ export function lastTranscriptUserTurnClosed(lines: Dict[]): boolean {
   return sawUser && closed;
 }
 
+function sessionMessageText(message: Dict): string {
+  if (typeof message.content === "string") return message.content;
+  if (!Array.isArray(message.content)) return "";
+  return message.content
+    .flatMap((block) => isDict(block) && block.type === "text" && typeof block.text === "string" ? [block.text] : [])
+    .join("\n");
+}
+
+function sessionMessagesToTranscriptLines(messages: Dict[]): Dict[] {
+  const lines: Dict[] = [];
+  for (const message of messages) {
+    if (!isDict(message) || (message.role !== "user" && message.role !== "assistant")) continue;
+    if (
+      message.role === "assistant"
+      && (message.injectedEvent || (Array.isArray(message.tool_calls) && message.tool_calls.length))
+    ) continue;
+    const text = sessionMessageText(message);
+    const media = Array.isArray(message.media)
+      ? message.media.filter((item): item is string => typeof item === "string" && Boolean(item.trim()))
+      : [];
+    if (!text.trim() && !media.length) continue;
+
+    if (message.role === "user") {
+      lines.push({
+        event: "user",
+        text,
+        ...(media.length ? { media_paths: media } : {}),
+        ...createdAtPatch(message),
+      });
+      continue;
+    }
+
+    lines.push({
+      event: "message",
+      text,
+      ...(media.length ? { media } : {}),
+      ...(typeof message.latency_ms === "number" ? { latency_ms: message.latency_ms } : {}),
+      ...createdAtPatch(message),
+    });
+    lines.push({ event: "turn_end" });
+  }
+  return lines;
+}
+
 export function buildWebuiThreadResponse(sessionKey: string, messages: any[]): Dict;
 export function buildWebuiThreadResponse(sessionKey: string, options?: BuildWebuiThreadResponseOptions | null): Dict | null;
 export function buildWebuiThreadResponse(sessionKey: string, messagesOrOptions: any[] | BuildWebuiThreadResponseOptions | null = null): Dict | null {
   if (Array.isArray(messagesOrOptions)) return { id: sessionKey, messages: messagesOrOptions };
-  const lines = readTranscriptLines(sessionKey);
+  const options = messagesOrOptions ?? {};
+  const transcriptLines = readTranscriptLines(sessionKey);
+  const lines = transcriptLines.length
+    ? transcriptLines
+    : sessionMessagesToTranscriptLines(options.sessionMessages ?? []);
   if (!lines.length) return null;
   return {
     schemaVersion: WEBUI_TRANSCRIPT_SCHEMA_VERSION,
     sessionKey,
     last_turn_closed: lastTranscriptUserTurnClosed(lines),
-    messages: replayTranscriptToUiMessages(lines, messagesOrOptions ?? {}),
+    messages: replayTranscriptToUiMessages(lines, options),
   };
 }

--- a/App/memmy-agent/src/integrations/channels/websocket.ts
+++ b/App/memmy-agent/src/integrations/channels/websocket.ts
@@ -81,7 +81,16 @@ type WebSocketChannelOptions = {
 export type WebuiLanguage = "zh-CN" | "en-US";
 
 const CHAT_ID_RE = /^[A-Za-z0-9_:-]{1,64}$/;
-const API_KEY_RE = /^[A-Za-z0-9_:.-]{1,128}$/;
+const API_KEY_RE = /^[A-Za-z0-9_:@+.-]{1,128}$/;
+const DESKTOP_VISIBLE_SESSION_PREFIXES = [
+  "websocket:",
+  "weixin:",
+  "discord:",
+  "telegram:",
+  "imessage:",
+  "feishu:",
+  "dingtalk:",
+] as const;
 const WEBUI_LANGUAGE_VALUES = new Set<WebuiLanguage>(["zh-CN", "en-US"]);
 const LOCALHOSTS = new Set(["127.0.0.1", "::1", "localhost"]);
 const MCP_VALUES_HEADER = "x-memmy-agent-mcp-values";
@@ -874,7 +883,7 @@ export class WebSocketChannel extends BaseChannel {
   }
 
   isDesktopVisibleSessionKey(key: string): boolean {
-    return this.isWebsocketChannelSessionKey(key) || key.startsWith("weixin:");
+    return DESKTOP_VISIBLE_SESSION_PREFIXES.some((prefix) => key.startsWith(prefix));
   }
 
   readSessionFile(key: string): Record<string, any> | null {

--- a/App/memmy-agent/src/integrations/channels/websocket.ts
+++ b/App/memmy-agent/src/integrations/channels/websocket.ts
@@ -712,12 +712,14 @@ export class WebSocketChannel extends BaseChannel {
     const cleaned = Array.isArray(sessions)
       ? sessions.flatMap((session: any) => {
           const key = session?.key;
-          if (typeof key !== "string" || !this.isWebsocketChannelSessionKey(key)) return [];
+          if (typeof key !== "string" || !this.isDesktopVisibleSessionKey(key)) return [];
           const row = { ...session };
           delete row.path;
-          const chatId = key.split(":", 2)[1] ?? "";
-          const startedAt = websocketTurnWallStartedAt(chatId);
-          if (startedAt != null) row.run_started_at = startedAt;
+          if (this.isWebsocketChannelSessionKey(key)) {
+            const chatId = key.split(":", 2)[1] ?? "";
+            const startedAt = websocketTurnWallStartedAt(chatId);
+            if (startedAt != null) row.run_started_at = startedAt;
+          }
           return [row];
         })
       : [];
@@ -871,6 +873,10 @@ export class WebSocketChannel extends BaseChannel {
     return key.startsWith("websocket:");
   }
 
+  isDesktopVisibleSessionKey(key: string): boolean {
+    return this.isWebsocketChannelSessionKey(key) || key.startsWith("weixin:");
+  }
+
   readSessionFile(key: string): Record<string, any> | null {
     const read = this.sessionManager?.readSessionFile;
     if (typeof read === "function") return read.call(this.sessionManager, key);
@@ -889,7 +895,7 @@ export class WebSocketChannel extends BaseChannel {
     if (!this.sessionManager) return httpError(503, "session manager unavailable");
     const decodedKey = decodeApiKey(key);
     if (decodedKey == null) return httpError(400, "invalid session key");
-    if (!this.isWebsocketChannelSessionKey(decodedKey)) return httpError(404, "session not found");
+    if (!this.isDesktopVisibleSessionKey(decodedKey)) return httpError(404, "session not found");
     const data = this.readSessionFile(decodedKey);
     if (!data) return httpError(404, "session not found");
     if (Array.isArray(data.messages)) scrubSubagentMessagesForChannel(data.messages);
@@ -901,7 +907,7 @@ export class WebSocketChannel extends BaseChannel {
     if (!this.checkApiToken(request)) return httpError(401, "Unauthorized");
     const decodedKey = decodeApiKey(key);
     if (decodedKey == null) return httpError(400, "invalid session key");
-    if (!this.isWebsocketChannelSessionKey(decodedKey)) return httpError(404, "session not found");
+    if (!this.isDesktopVisibleSessionKey(decodedKey)) return httpError(404, "session not found");
     const sessionMessages = this.readSessionFile(decodedKey)?.messages;
     const data = buildWebuiThreadResponse(decodedKey, {
       sessionMessages: Array.isArray(sessionMessages) ? sessionMessages : null,
@@ -953,7 +959,7 @@ export class WebSocketChannel extends BaseChannel {
     if (!this.checkApiToken(request)) return httpError(401, "Unauthorized");
     const decodedKey = decodeApiKey(key);
     if (decodedKey == null) return httpError(400, "invalid session key");
-    if (!this.isWebsocketChannelSessionKey(decodedKey)) return httpError(404, "session not found");
+    if (!this.isDesktopVisibleSessionKey(decodedKey)) return httpError(404, "session not found");
     const data = this.readSessionFile(decodedKey);
     if (!data) return httpError(404, "session not found");
     return httpJsonResponse(this.lastCompactionPayload(decodedKey, data.metadata?.lastSummary));
@@ -1083,7 +1089,7 @@ export class WebSocketChannel extends BaseChannel {
     if (!this.sessionManager) return httpError(503, "session manager unavailable");
     const decodedKey = decodeApiKey(key);
     if (decodedKey == null) return httpError(400, "invalid session key");
-    if (!this.isWebsocketChannelSessionKey(decodedKey)) return httpError(404, "session not found");
+    if (!this.isDesktopVisibleSessionKey(decodedKey)) return httpError(404, "session not found");
     const del = this.sessionManager.deleteSession ?? this.sessionManager.delete;
     const deleted = typeof del === "function" ? del.call(this.sessionManager, decodedKey) : false;
     deleteWebuiThread(decodedKey);
@@ -1096,7 +1102,7 @@ export class WebSocketChannel extends BaseChannel {
     if (!this.sessionManager) return httpError(503, "session manager unavailable");
     const decodedKey = decodeApiKey(key);
     if (decodedKey == null) return httpError(400, "invalid session key");
-    if (!this.isWebsocketChannelSessionKey(decodedKey)) return httpError(404, "session not found");
+    if (!this.isDesktopVisibleSessionKey(decodedKey)) return httpError(404, "session not found");
     let decoded: any;
     try {
       decoded = JSON.parse(requestBodyText(request));

--- a/App/memmy-agent/tests/entrypoints/frontend-bridge/channel-session-thread.test.ts
+++ b/App/memmy-agent/tests/entrypoints/frontend-bridge/channel-session-thread.test.ts
@@ -1,0 +1,62 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { buildWebuiThreadResponse } from "../../../src/entrypoints/frontend-bridge/transcript.js";
+
+const roots: string[] = [];
+const oldDataDir = process.env.MEMMY_AGENT_DATA_DIR;
+
+function useEmptyDataDir(): void {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "memmy-channel-thread-"));
+  roots.push(root);
+  process.env.MEMMY_AGENT_DATA_DIR = root;
+}
+
+afterEach(() => {
+  if (oldDataDir == null) delete process.env.MEMMY_AGENT_DATA_DIR;
+  else process.env.MEMMY_AGENT_DATA_DIR = oldDataDir;
+  for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
+});
+
+describe("channel session thread fallback", () => {
+  it("builds a closed WeChat thread from persisted session messages when no WebUI transcript exists", () => {
+    useEmptyDataDir();
+
+    const response = buildWebuiThreadResponse("weixin:wx-user", {
+      sessionMessages: [
+        { role: "user", content: "微信里的问题", timestamp: "2026-07-23T02:00:00.000Z" },
+        { role: "assistant", content: "微信里的回答", timestamp: "2026-07-23T02:00:01.000Z" },
+      ],
+    });
+
+    expect(response).toMatchObject({
+      schemaVersion: 3,
+      sessionKey: "weixin:wx-user",
+      last_turn_closed: true,
+      messages: [
+        { role: "user", content: "微信里的问题" },
+        { role: "assistant", content: "微信里的回答" },
+      ],
+    });
+  });
+
+  it("keeps tool calls and injected subagent messages out of channel history", () => {
+    useEmptyDataDir();
+
+    const response = buildWebuiThreadResponse("weixin:wx-user", {
+      sessionMessages: [
+        { role: "user", content: "帮我查一下" },
+        { role: "assistant", content: "内部工具调用", tool_calls: [{ id: "call-1" }] },
+        { role: "tool", content: "内部工具结果", tool_call_id: "call-1" },
+        { role: "assistant", content: "内部子任务结果", injectedEvent: "subagentResult" },
+        { role: "assistant", content: "这是最终回答" },
+      ],
+    });
+
+    expect(response?.messages).toEqual([
+      expect.objectContaining({ role: "user", content: "帮我查一下" }),
+      expect.objectContaining({ role: "assistant", content: "这是最终回答" }),
+    ]);
+  });
+});

--- a/App/memmy-agent/tests/entrypoints/frontend-bridge/channel-session-thread.test.ts
+++ b/App/memmy-agent/tests/entrypoints/frontend-bridge/channel-session-thread.test.ts
@@ -6,6 +6,15 @@ import { buildWebuiThreadResponse } from "../../../src/entrypoints/frontend-brid
 
 const roots: string[] = [];
 const oldDataDir = process.env.MEMMY_AGENT_DATA_DIR;
+const desktopChannelSessionKeys = [
+  ["WeChat", "weixin:wx-user"],
+  ["Discord", "discord:channel-1"],
+  ["Telegram", "telegram:chat-1"],
+  ["iMessage", "imessage:user@example.com"],
+  ["iMessage phone number", "imessage:+15551234567"],
+  ["Feishu", "feishu:chat-1"],
+  ["DingTalk", "dingtalk:user-1"],
+] as const;
 
 function useEmptyDataDir(): void {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "memmy-channel-thread-"));
@@ -20,23 +29,23 @@ afterEach(() => {
 });
 
 describe("channel session thread fallback", () => {
-  it("builds a closed WeChat thread from persisted session messages when no WebUI transcript exists", () => {
+  it.each(desktopChannelSessionKeys)("builds a closed %s thread from persisted session messages when no WebUI transcript exists", (_channelName, sessionKey) => {
     useEmptyDataDir();
 
-    const response = buildWebuiThreadResponse("weixin:wx-user", {
+    const response = buildWebuiThreadResponse(sessionKey, {
       sessionMessages: [
-        { role: "user", content: "微信里的问题", timestamp: "2026-07-23T02:00:00.000Z" },
-        { role: "assistant", content: "微信里的回答", timestamp: "2026-07-23T02:00:01.000Z" },
+        { role: "user", content: "渠道里的问题", timestamp: "2026-07-23T02:00:00.000Z" },
+        { role: "assistant", content: "渠道里的回答", timestamp: "2026-07-23T02:00:01.000Z" },
       ],
     });
 
     expect(response).toMatchObject({
       schemaVersion: 3,
-      sessionKey: "weixin:wx-user",
+      sessionKey,
       last_turn_closed: true,
       messages: [
-        { role: "user", content: "微信里的问题" },
-        { role: "assistant", content: "微信里的回答" },
+        { role: "user", content: "渠道里的问题" },
+        { role: "assistant", content: "渠道里的回答" },
       ],
     });
   });

--- a/App/memmy-agent/tests/integrations/channels/websocket-http-routes.test.ts
+++ b/App/memmy-agent/tests/integrations/channels/websocket-http-routes.test.ts
@@ -471,14 +471,40 @@ describe("WebSocket HTTP route helpers", () => {
     expect(loadConfig(process.env.MEMMY_CONFIG).tools.imageGeneration.apiKey).toBe("sk-route-secret");
   });
 
-  it("lists only websocket sessions on the WebUI sessions route", async () => {
-    const manager = seedMany(tmpRoot(), ["cli:direct", "slack:C123", "lark:oc_abc", "websocket:alpha", "websocket:beta"]);
+  it("lists desktop and WeChat sessions on the WebUI sessions route", async () => {
+    const manager = seedMany(tmpRoot(), ["cli:direct", "slack:C123", "lark:oc_abc", "weixin:wx-user", "websocket:alpha", "websocket:beta"]);
     const channel = makeChannel({ sessionManager: manager });
     const port = await startChannel(channel);
     const listing = await fetch(`http://127.0.0.1:${port}/api/sessions`, { headers: await authHeaders(port) });
     expect(listing.status).toBe(200);
     const keys = new Set(((await listing.json()) as any).sessions.map((session: any) => session.key));
-    expect(keys).toEqual(new Set(["websocket:alpha", "websocket:beta"]));
+    expect(keys).toEqual(new Set(["weixin:wx-user", "websocket:alpha", "websocket:beta"]));
+  });
+
+  it("opens persisted WeChat messages without a WebUI transcript", async () => {
+    const root = tmpRoot();
+    const manager = new SessionManager(root);
+    const session = new Session({ key: "weixin:wx-user" });
+    session.addMessage("user", "微信里的问题", { timestamp: "2026-07-23T02:00:00.000Z" });
+    session.addMessage("assistant", "微信里的回答", { timestamp: "2026-07-23T02:00:01.000Z" });
+    manager.save(session);
+
+    const channel = makeChannel({ sessionManager: manager });
+    const port = await startChannel(channel);
+    const response = await fetch(
+      `http://127.0.0.1:${port}/api/sessions/${encodeURIComponent("weixin:wx-user")}/webui-thread`,
+      { headers: await authHeaders(port) },
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      sessionKey: "weixin:wx-user",
+      last_turn_closed: true,
+      messages: [
+        { role: "user", content: "微信里的问题" },
+        { role: "assistant", content: "微信里的回答" },
+      ],
+    });
   });
 
   it("uses session message timestamps for WebUI thread messages when transcripts omit time", () => {
@@ -855,7 +881,7 @@ describe("WebSocket HTTP route helpers", () => {
     expect(fs.existsSync(manager.pathFor("websocket:encoded-key"))).toBe(false);
   });
 
-  it("rejects non-websocket session keys for direct session routes", async () => {
+  it("rejects session keys that are not visible in the desktop history", async () => {
     const manager = seedMany(tmpRoot(), ["websocket:kept", "cli:direct", "slack:C123"]);
     const channel = makeChannel({ sessionManager: manager });
     const port = await startChannel(channel);

--- a/App/memmy-agent/tests/integrations/channels/websocket-http-routes.test.ts
+++ b/App/memmy-agent/tests/integrations/channels/websocket-http-routes.test.ts
@@ -34,6 +34,15 @@ const running: WebSocketChannel[] = [];
 const tmpDirs: string[] = [];
 const originalMemmyAgentConfig = process.env.MEMMY_CONFIG;
 const originalMemmyAgentDataDir = process.env.MEMMY_AGENT_DATA_DIR;
+const desktopChannelSessionKeys = [
+  ["WeChat", "weixin:wx-user"],
+  ["Discord", "discord:channel-1"],
+  ["Telegram", "telegram:chat-1"],
+  ["iMessage", "imessage:user@example.com"],
+  ["iMessage phone number", "imessage:+15551234567"],
+  ["Feishu", "feishu:chat-1"],
+  ["DingTalk", "dingtalk:user-1"],
+] as const;
 
 afterEach(async () => {
   await Promise.all(running.splice(0).map((channel) => channel.stop()));
@@ -257,8 +266,10 @@ describe("WebSocket HTTP route helpers", () => {
     const listing = await fetch(`http://127.0.0.1:${port}/api/sessions`, { headers });
     expect(listing.status).toBe(200);
     const sessions = (await listing.json() as any).sessions;
-    expect(sessions.map((row: any) => row.key)).toEqual(["websocket:abc"]);
-    expect(sessions[0]).not.toHaveProperty("path");
+    expect(new Set(sessions.map((row: any) => row.key))).toEqual(
+      new Set(["telegram:abc", "websocket:abc"]),
+    );
+    expect(sessions.every((row: any) => !Object.hasOwn(row, "path"))).toBe(true);
 
     const messages = await fetch(`http://127.0.0.1:${port}/api/sessions/${encodeURIComponent("websocket:abc")}/messages`, { headers });
     expect(messages.status).toBe(200);
@@ -471,38 +482,43 @@ describe("WebSocket HTTP route helpers", () => {
     expect(loadConfig(process.env.MEMMY_CONFIG).tools.imageGeneration.apiKey).toBe("sk-route-secret");
   });
 
-  it("lists desktop and WeChat sessions on the WebUI sessions route", async () => {
-    const manager = seedMany(tmpRoot(), ["cli:direct", "slack:C123", "lark:oc_abc", "weixin:wx-user", "websocket:alpha", "websocket:beta"]);
+  it("lists desktop and supported channel sessions on the WebUI sessions route", () => {
+    const supportedChannelKeys = desktopChannelSessionKeys.map(([, key]) => key);
+    const manager = seedMany(tmpRoot(), [
+      "cli:direct",
+      "slack:C123",
+      ...supportedChannelKeys,
+      "websocket:alpha",
+      "websocket:beta",
+    ]);
     const channel = makeChannel({ sessionManager: manager });
-    const port = await startChannel(channel);
-    const listing = await fetch(`http://127.0.0.1:${port}/api/sessions`, { headers: await authHeaders(port) });
+    const listing = channel.handleSessionsList({ headers: withApiToken(channel) });
     expect(listing.status).toBe(200);
-    const keys = new Set(((await listing.json()) as any).sessions.map((session: any) => session.key));
-    expect(keys).toEqual(new Set(["weixin:wx-user", "websocket:alpha", "websocket:beta"]));
+    const keys = new Set(responseJson(listing).sessions.map((session: any) => session.key));
+    expect(keys).toEqual(new Set([...supportedChannelKeys, "websocket:alpha", "websocket:beta"]));
   });
 
-  it("opens persisted WeChat messages without a WebUI transcript", async () => {
+  it.each(desktopChannelSessionKeys)("opens persisted %s messages without a WebUI transcript", (_channelName, sessionKey) => {
     const root = tmpRoot();
     const manager = new SessionManager(root);
-    const session = new Session({ key: "weixin:wx-user" });
-    session.addMessage("user", "微信里的问题", { timestamp: "2026-07-23T02:00:00.000Z" });
-    session.addMessage("assistant", "微信里的回答", { timestamp: "2026-07-23T02:00:01.000Z" });
+    const session = new Session({ key: sessionKey });
+    session.addMessage("user", "渠道里的问题", { timestamp: "2026-07-23T02:00:00.000Z" });
+    session.addMessage("assistant", "渠道里的回答", { timestamp: "2026-07-23T02:00:01.000Z" });
     manager.save(session);
 
     const channel = makeChannel({ sessionManager: manager });
-    const port = await startChannel(channel);
-    const response = await fetch(
-      `http://127.0.0.1:${port}/api/sessions/${encodeURIComponent("weixin:wx-user")}/webui-thread`,
-      { headers: await authHeaders(port) },
+    const response = channel.handleWebuiThreadGet(
+      { headers: withApiToken(channel) },
+      encodeURIComponent(sessionKey),
     );
 
     expect(response.status).toBe(200);
-    expect(await response.json()).toMatchObject({
-      sessionKey: "weixin:wx-user",
+    expect(responseJson(response)).toMatchObject({
+      sessionKey,
       last_turn_closed: true,
       messages: [
-        { role: "user", content: "微信里的问题" },
-        { role: "assistant", content: "微信里的回答" },
+        { role: "user", content: "渠道里的问题" },
+        { role: "assistant", content: "渠道里的回答" },
       ],
     });
   });


### PR DESCRIPTION
## Summary
- show persisted WeChat, Discord, Telegram, iMessage, Feishu, and DingTalk sessions in desktop history
- allow iMessage address characters in encoded session keys
- restore channel messages from persisted session history when no WebUI transcript exists
- keep unsupported session types hidden

## Tests
- memmy-agent WebSocket HTTP route tests: 44 passed
- channel session thread fallback tests: 8 passed
- desktop client channel-session encoding test passed
- memmy-agent and desktop TypeScript typechecks passed