### PR TITLE
release: finalize Memmy v1.0.3

### DIFF
--- a/.github/release-notes/v1.0.3.md
+++ b/.github/release-notes/v1.0.3.md
@@ -1,0 +1,47 @@
+# Memmy v1.0.3
+
+## Highlights
+
+- Added a cross-AI continuation flow after the first conversation. Based on the granted scan permission and locally detected tools, Memmy can prepare a handoff to Cursor, Claude Code, Codex, OpenCode, OpenClaw, Hermes, or WorkBuddy.
+- Improved desktop and Agent Gateway recovery after disconnects by reconciling message history, task state, and runtime state during reconnection.
+- Strengthened Memory processing reliability and diagnostics across import, embedding, retrieval, summarization, and memory evolution.
+
+## Desktop improvements
+
+- Token-quota requests now show their actual eligibility and review state, including pending review, cooldowns, request limits, decisions, and the next eligible request time.
+- Upgrades now preserve existing login state and local BYOK model configuration.
+- Fixed pet mode incorrectly dismissing or marking the current task as read when it opens. The latest task remains available in the task list.
+- Improved Markdown rendering for Memory and task details, including tables, code blocks, lists, and quoted content.
+- Reduced disruption from transient connection and sidebar-operation errors.
+
+## Agent improvements
+
+- Added a `fileMemory.enabled` runtime switch for independently controlling local file memory, Recent History, and Dream capabilities.
+- Added targeted format and syntax validation after the Agent writes or modifies supported files.
+- Increased the default maximum output budget to 65,536 tokens for complex tasks and longer responses.
+- Improved Agent Gateway process recovery and restart backoff behavior.
+- Agent history import now skips malformed JSONL records instead of stopping the entire synchronization.
+- Shortened Session DAG retry backoff for faster recovery from transient failures.
+
+## Memory improvements
+
+- Separated session ingestion, retrieval, import, embedding, worker, evolution, feedback, and read-model responsibilities into more maintainable modules while preserving existing storage and API compatibility.
+- Added clearer retry and fallback behavior for truncated or malformed model output, summaries, retrieval, and embeddings.
+- Fixed inconsistent account-mode model routing and summary generation.
+- Improved preservation of relative time expressions such as “today” and “yesterday” in generated summaries.
+- Hardened reward-scoring fallback validation, recalled-evidence filtering, and unknown-intent handling.
+- Added more structured diagnostics for model calls, embedding work, and background processing.
+
+## Upgrade notes
+
+- Existing login state and local model configuration are preserved during upgrade.
+- File memory is disabled by default. To use file memory and `/dream`, `/dream-log`, or `/dream-restore`, enable it in the Agent configuration:
+
+  ```yaml
+  fileMemory:
+    enabled: true
+  ```
+
+- The legacy built-in `my` tool has been removed. Existing `tools.my`, `tools.myEnabled`, and `tools.mySet` settings are ignored.
+- Token-quota status and request operations require a signed-in Memmy account.
+- The cross-AI continuation entry is shown only when scan permission is granted and a supported local Agent is detected.

--- a/.github/release-notes/v1.0.3.md
+++ b/.github/release-notes/v1.0.3.md
@@ -2,7 +2,6 @@
 
 ## Highlights
 
-- Added a cross-AI continuation flow after the first conversation. Based on the granted scan permission and locally detected tools, Memmy can prepare a handoff to Cursor, Claude Code, Codex, OpenCode, OpenClaw, Hermes, or WorkBuddy.
 - Improved desktop and Agent Gateway recovery after disconnects by reconciling message history, task state, and runtime state during reconnection.
 - Strengthened Memory processing reliability and diagnostics across import, embedding, retrieval, summarization, and memory evolution.
 

--- a/.github/release-notes/v1.0.3.md
+++ b/.github/release-notes/v1.0.3.md
@@ -45,3 +45,7 @@
 - The legacy built-in `my` tool has been removed. Existing `tools.my`, `tools.myEnabled`, and `tools.mySet` settings are ignored.
 - Token-quota status and request operations require a signed-in Memmy account.
 - The cross-AI continuation entry is shown only when scan permission is granted and a supported local Agent is detected.
+
+## Source and installer scope
+
+- The v1.0.3 source tag includes PR #52 (the Windows data-storage path display fix), but the frozen v1.0.3 desktop installers were built before that change and do not include it. The fix is scheduled to first ship in official installers with v1.0.4.

--- a/App/memmy-agent/package-lock.json
+++ b/App/memmy-agent/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "memmy-agent",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "memmy-agent",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.100.1",
         "@aws-sdk/client-bedrock-runtime": "^3.1061.0",

--- a/App/memmy-agent/package.json
+++ b/App/memmy-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memmy-agent",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "TypeScript refactor of memmy's agent runtime.",
   "type": "module",
   "main": "./dist/index.js",

--- a/App/shell/desktop/package.json
+++ b/App/shell/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memmy/desktop",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "private": true,
   "type": "module",
   "description": "Memmy desktop client.",

--- a/Memory/package.json
+++ b/Memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memmy/memory",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "private": true,
   "type": "module",
   "main": "./dist/src/index.js",

--- a/Memory/src/cli/npm/package.json
+++ b/Memory/src/cli/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memtensor/memmy-memory-cli",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Memmy Memory CLI for local agent memory.",
   "type": "module",
   "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "memmy-agent",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "memmy-agent",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "workspaces": [
         "Memory",
         "App/backend/local-api-contracts",
@@ -85,7 +85,7 @@
     },
     "App/shell/desktop": {
       "name": "@memmy/desktop",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "dependencies": {
         "@memmy/backend": "0.0.0",
         "@memmy/desktop-interface": "0.0.0",
@@ -221,7 +221,7 @@
     },
     "Memory": {
       "name": "@memmy/memory",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "dependencies": {
         "@huggingface/transformers": "^3.8.0",
         "better-sqlite3": "^12.6.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memmy-agent",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "private": true,
   "type": "module",
   "description": "Local-first agent memory substrate with desktop and CLI surfaces.",

--- a/tests/release-workflow.test.ts
+++ b/tests/release-workflow.test.ts
@@ -17,8 +17,39 @@ const packagingConfigs = [
   "electron-builder.win.yml",
   "electron-builder.win.unsigned.yml",
 ];
+const versionedManifests = [
+  "Memory/package.json",
+  "Memory/src/cli/npm/package.json",
+  "App/memmy-agent/package.json",
+  "App/shell/desktop/package.json",
+];
+
+function readJson(relativePath: string): {
+  version?: string;
+  packages?: Record<string, { version?: string }>;
+} {
+  return JSON.parse(readFileSync(resolve(repoRoot, relativePath), "utf8"));
+}
 
 describe("GitHub release workflow", () => {
+  it("keeps every release manifest and lockfile aligned to the root version", () => {
+    const version = readJson("package.json").version;
+
+    for (const manifest of versionedManifests) {
+      expect(readJson(manifest).version, manifest).toBe(version);
+    }
+
+    const rootLock = readJson("package-lock.json");
+    expect(rootLock.version).toBe(version);
+    expect(rootLock.packages?.[""].version).toBe(version);
+    expect(rootLock.packages?.Memory.version).toBe(version);
+    expect(rootLock.packages?.["App/shell/desktop"].version).toBe(version);
+
+    const agentLock = readJson("App/memmy-agent/package-lock.json");
+    expect(agentLock.version).toBe(version);
+    expect(agentLock.packages?.[""].version).toBe(version);
+  });
+
   it("uses the trusted base workflow for merged release/vX.Y.Z PRs targeting main", () => {
     expect(workflow.on.pull_request_target).toEqual({ types: ["closed"], branches: ["main"] });
     expect(workflow.on.pull_request).toBeUndefined();


### PR DESCRIPTION
## Summary

- Rebuild `release/v1.0.3` from the current `main` after PR #56.
- Synchronize the root, Memory, Agent, desktop, and lockfile version metadata to `1.0.3`.
- Add the v1.0.3 release notes and a regression test that keeps every release manifest and lockfile aligned.
- Keep PR #52 in the source tree while documenting that the frozen v1.0.3 installers were built before that fix.

## Release behavior

Merging this exact `release/v1.0.3` branch into `main` satisfies the GitHub Release workflow trigger. The workflow will:

1. Create `v1.0.3` at the merged commit.
2. Download the four already-frozen installers from OSS without rebuilding them.
3. Verify each OSS object against its `Content-MD5`.
4. Attach the installers plus `MD5SUMS.txt` and `SHA256SUMS.txt`.
5. Publish `Memmy v1.0.3` as the latest GitHub Release.

## Validation

- `npm run version:check`
- `npm run test:release-workflow` — 10/10 passed
- `npm --prefix App/memmy-agent test -- tests/package-version.test.ts` — 2/2 passed
- Full lint, changed-file lint, affected typecheck/tests, contract checks, desktop assertions, critical smoke, full build, and diff sanity passed
- `git diff --check upstream/main...HEAD`

## Required human review / known release risks

- The v1.0.3 source tag includes PR #52, but these frozen installers do not. The fix is scheduled to first ship in official installers with v1.0.4.
- The installer wrapper reports `1.0.3`, while the frozen installers contain embedded Memory and Agent manifests that still report `1.0.2`.
- The four Electron builder configurations currently embed a raw `.env` file because the packaged runtimes depend on it. This fails the distribution-boundary gate. **Do not merge until a human confirms the packaged `.env` contains only intended public runtime configuration and no credentials or secrets.**
- The macOS artifacts are notarized and stapled, but strict local `codesign` verification failed; clean-machine verification remains recommended.
- Windows Authenticode was not independently verified from the macOS audit host.
- Dependency installation reports existing audit findings (root: 18; Agent: 32). This PR only changes version metadata and adds no dependencies.

This PR is intentionally a draft until the release owner accepts the disclosed artifact and distribution risks.
