### PR TITLE
fix: unblock mac packaging for migrations runtime

### DIFF
--- a/App/frontend/desktop/src/pages/memory/tests/memory-runtime-fixtures.ts
+++ b/App/frontend/desktop/src/pages/memory/tests/memory-runtime-fixtures.ts
@@ -329,7 +329,6 @@ export function createMockMemoryRuntimeClient(): MemoryRuntimeClient {
         turnId: input.turnId ?? "mock-turn",
         contextPacketId: "context-1",
         sessionId: input.sessionId,
-        episodeId: "mock-episode",
         injectedContext: { markdown: "- 用户偏好中文注释", sections: [] },
 	        searchEventId: "search-1",
 	        sourceMemoryIds: hits.map((hit) => hit.id),

--- a/App/shell/desktop/electron-builder.unsigned.yml
+++ b/App/shell/desktop/electron-builder.unsigned.yml
@@ -17,6 +17,7 @@ asarUnpack:
   - "**/@img/sharp-libvips-darwin-*/lib/libvips*.dylib"
   - "**/@lydell/node-pty-darwin-*/prebuilds/darwin-*/spawn-helper"
   - "**/node_modules/sqlite-vec-*/vec0.*"
+  - "dist/runtime/memmy-agent/node_modules/@memmy/migrations/**"
   - "dist/renderer/**"
 
 extraResources:

--- a/App/shell/desktop/electron-builder.yml
+++ b/App/shell/desktop/electron-builder.yml
@@ -17,6 +17,7 @@ asarUnpack:
   - "**/@img/sharp-libvips-darwin-*/lib/libvips*.dylib"
   - "**/@lydell/node-pty-darwin-*/prebuilds/darwin-*/spawn-helper"
   - "**/node_modules/sqlite-vec-*/vec0.*"
+  - "dist/runtime/memmy-agent/node_modules/@memmy/migrations/**"
   - "dist/renderer/**"
 
 extraResources:

--- a/docs/cn/concepts/meta.json
+++ b/docs/cn/concepts/meta.json
@@ -1,5 +1,5 @@
 {
   "title": "概念",
   "icon": "Boxes",
-  "pages": ["architecture", "features"]
+  "pages": ["architecture", "end-to-end-flow", "features"]
 }


### PR DESCRIPTION
fix: unblock mac packaging for migrations runtime