### PR TITLE
fix(desktop): unpack migrations in Windows packages

### DIFF
--- a/App/shell/desktop/electron-builder.win.unsigned.yml
+++ b/App/shell/desktop/electron-builder.win.unsigned.yml
@@ -17,6 +17,7 @@ asarUnpack:
   - "**/@img/sharp-win32-x64/lib/libvips*.dll"
   - "**/@lydell/node-pty-win32-x64/prebuilds/win32-x64/conpty/**"
   - "**/node_modules/sqlite-vec-*/vec0.*"
+  - "dist/runtime/memmy-agent/node_modules/@memmy/migrations/**"
   - "dist/renderer/**"
 
 extraResources:

--- a/App/shell/desktop/electron-builder.win.yml
+++ b/App/shell/desktop/electron-builder.win.yml
@@ -17,6 +17,7 @@ asarUnpack:
   - "**/@img/sharp-win32-x64/lib/libvips*.dll"
   - "**/@lydell/node-pty-win32-x64/prebuilds/win32-x64/conpty/**"
   - "**/node_modules/sqlite-vec-*/vec0.*"
+  - "dist/runtime/memmy-agent/node_modules/@memmy/migrations/**"
   - "dist/renderer/**"
 
 extraResources:

--- a/App/shell/desktop/tests/packaged-runtime-boundary.test.ts
+++ b/App/shell/desktop/tests/packaged-runtime-boundary.test.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
+import { parse as parseYaml } from "yaml";
 
 const mainSourcePath = fileURLToPath(new URL("../src/main/main.ts", import.meta.url));
 const preloadSourcePath = fileURLToPath(new URL("../src/preload/preload.cts", import.meta.url));
@@ -215,6 +216,22 @@ describe("desktop packaged runtime boundaries", () => {
     expect(winSource.indexOf('run build --prefix "$MIGRATIONS_DIR"')).toBeLessThan(
       winSource.indexOf('ci --prefix "$AGENT_DIR"'),
     );
+  });
+
+  it("unpacks the migrations runtime in every desktop package variant", () => {
+    for (const configPath of [
+      electronBuilderPath,
+      unsignedElectronBuilderPath,
+      winElectronBuilderPath,
+      winUnsignedBuilderPath
+    ]) {
+      const config = parseYaml(readFileSync(configPath, "utf8")) as {
+        asarUnpack?: string[];
+      };
+      expect(config.asarUnpack).toContain(
+        "dist/runtime/memmy-agent/node_modules/@memmy/migrations/**"
+      );
+    }
   });
 
   it("unpacks the sqlite-vec native extension in every desktop package variant", () => {


### PR DESCRIPTION
## Summary

- unpack the bundled `@memmy/migrations` runtime in signed and unsigned Windows packages
- parse electron-builder YAML in the regression test and verify all desktop package variants keep the migrations runtime unpacked

## Why

Windows package verification expects the migrations runtime under `app.asar.unpacked`, but the Windows-specific electron-builder configurations did not include the migrations package in `asarUnpack`. This caused a valid build to fail packaged-runtime verification with a missing `dist/index.js` error.

## Testing

- `npm test -w @memmy/desktop -- tests/packaged-runtime-boundary.test.ts` (14 files, 135 tests passed)
- `npm run typecheck -w @memmy/desktop`
- `git diff --check`