### PR TITLE
[AI-assist] fix: start trace summaries when turns complete

### DIFF
--- a/Memory/src/algorithm/plugin-algorithms.ts
+++ b/Memory/src/algorithm/plugin-algorithms.ts
@@ -1367,28 +1367,6 @@ Return JSON:
 }`
 } as const;
 
-export const REFLECTED_TRACE_SUMMARY_PROMPT = {
-  id: "reflected_trace_summary",
-  version: 1,
-  description:
-    "Summarize reflected L1 traces in batches for durable retrieval.",
-  system: `You summarize each reflected AI-agent trace for future retrieval.
-
-Return JSON only: {"summaries":[{"index":0,"summary":"..."}]}.
-Rules:
-- Return exactly one item for every input trace index.
-- Write a highly condensed retrieval summary: retain only the primary intent,
-  key decision or outcome, and the reflection's most useful conclusion.
-- Do not enumerate every detail. Include names, dates, paths, commands,
-  identifiers, errors, tool parameters, or observed results only when they are
-  essential to understanding or retrieving the trace.
-- When tool use is present, summarize the overall attempt and outcome instead
-  of listing intermediate calls or results.
-- Keep each summary normally within 200 characters.
-- Follow the separate language instruction provided for the current batch.
-- Do not invent facts, merge traces, or omit an input index.`
-} as const;
-
 export const SKILL_CRYSTALLIZE_PROMPT = {
   id: "skill.crystallize",
   version: 6,

--- a/Memory/src/service/embedding/embedding-job-processor.ts
+++ b/Memory/src/service/embedding/embedding-job-processor.ts
@@ -258,7 +258,7 @@ export class EmbeddingJobProcessor {
     if (!trace) throw new Error(`trace payload is missing: ${memory.id}`);
 
     const summary = this.deps.llm.isConfigured()
-      ? await this.deps.summarizeTraceForCapture({ trace, userText: trace.userText, agentText: trace.agentText, toolCalls: trace.toolCalls, reflectionText: trace.reflection ?? "" }, { strict: true })
+      ? await this.deps.summarizeTraceForCapture({ trace, userText: trace.userText, agentText: trace.agentText, toolCalls: trace.toolCalls, reflectionText: "" }, { strict: true })
       : trace.summary || fallbackTraceSummary(trace);
     const at = this.deps.nowIso();
     const current = this.deps.repos.memories.get(memory.id);

--- a/Memory/src/service/evolution/span-pipeline.ts
+++ b/Memory/src/service/evolution/span-pipeline.ts
@@ -1,6 +1,5 @@
 import {
   BATCH_REFLECTION_PROMPT,
-  REFLECTED_TRACE_SUMMARY_PROMPT,
   REFLECTION_SCORE_PROMPT,
   detectDominantLanguage,
   languageSteeringLine,
@@ -33,7 +32,6 @@ import type { EnqueueJobInput } from "../worker/job-handlers.js";
 type TraceMeta = NonNullable<ReturnType<typeof traceMetaFromMemory>>;
 
 const pipelineLogger = createMemoryLogger("pipeline");
-const REFLECTED_TRACE_SUMMARY_BATCH_SIZE = 10;
 
 export interface SpanPipelineDeps {
   repos: Repositories;
@@ -120,13 +118,7 @@ private async reflectSingleTrace(
       agentThinking,
       reflectionText
     ]);
-    const summarized = await this.summarizeTraceForCapture({
-      trace,
-      userText,
-      agentText,
-      toolCalls,
-      reflectionText
-    });
+    const summarized = trace.summary || fallbackTraceSummary(trace);
 
     if (!this.deps.config.algorithm.capture.alphaScoring) {
       const reflection = reflectionText || "RELATED_DEFAULT";
@@ -401,13 +393,6 @@ private async applyBatchReflectionScores(
     scores: BatchReflectionScore[]
   ): Promise<void> {
     const at = nowIso();
-    const pending: Array<{
-      memory: MemoryRow;
-      trace: TraceMeta;
-      score: BatchReflectionScore;
-      reflection: string;
-      source: "adapter" | "extracted" | "synth" | "none";
-    }> = [];
     for (const [index, score] of scores.entries()) {
       const memory = memories[index];
       if (!memory || traceReflectionWasScored(memory)) {
@@ -419,26 +404,7 @@ private async applyBatchReflectionScores(
       }
       const incoming = trace.reflection?.trim() ?? "";
       const reflection = incoming || score.reflectionText;
-      pending.push({
-        memory,
-        trace,
-        score,
-        reflection,
-        source: incoming
-          ? traceReflectionSource(memory)
-          : score.reflectionText === "RELATED_DEFAULT"
-            ? "none"
-            : "synth"
-      });
-    }
-
-    const summaries = await this.summarizeReflectedTraces(pending);
-    for (const [index, item] of pending.entries()) {
-      const summary = summaries[index];
-      if (!summary) {
-        throw new Error(`reflected trace summary missing index: ${index}`);
-      }
-      const { memory, score, reflection, source } = item;
+      const summary = trace.summary || fallbackTraceSummary(trace);
       const previous = memory;
       const saved = this.deps.repos.memories.update(updateImportPipelineStatus(updateTraceReflection(memory, {
         summary,
@@ -446,7 +412,11 @@ private async applyBatchReflectionScores(
         alpha: clampNumber(score.alpha, 0, 1),
         usable: score.usable,
         reason: score.reason,
-        source,
+        source: incoming
+          ? traceReflectionSource(memory)
+          : score.reflectionText === "RELATED_DEFAULT"
+            ? "none"
+            : "synth",
         tags: memoryHasImportPipeline(memory) ? importStatusTags(memory.tags, "indexing") : memory.tags,
         updatedAt: at
       }), "indexing", at));
@@ -465,79 +435,6 @@ private async applyBatchReflectionScores(
       });
       this.enqueuePostReflectionEmbedding(saved, job, at);
     }
-  }
-
-private async summarizeReflectedTraces(input: Array<{
-    memory: MemoryRow;
-    trace: TraceMeta;
-    reflection: string;
-  }>): Promise<string[]> {
-    const output: string[] = [];
-    for (let start = 0; start < input.length; start += REFLECTED_TRACE_SUMMARY_BATCH_SIZE) {
-      const batch = input.slice(start, start + REFLECTED_TRACE_SUMMARY_BATCH_SIZE);
-      const language = detectDominantLanguage(batch.flatMap(({ trace, reflection }) => [
-        trace.userText,
-        trace.agentText,
-        reflection
-      ]));
-      const messages = [
-        {
-          role: "system" as const,
-          content: REFLECTED_TRACE_SUMMARY_PROMPT.system
-        },
-        {
-          role: "system" as const,
-          content: languageSteeringLine(language)
-        },
-        {
-          role: "user" as const,
-          content: stableStringify({
-            traces: batch.map(({ memory, trace, reflection }, index) => ({
-              index,
-              id: memory.id,
-              userText: clip(trace.userText, 1200),
-              agentText: clip(trace.agentText, 1200),
-              toolCalls: trace.toolCalls.map((call) => ({
-                name: call.name,
-                input: clip(stringifyForMemory(call.input), 240),
-                output: clip(stringifyForMemory(call.output), 360),
-                error: call.error ? clip(call.error, 240) : null
-              })),
-              reflection: clip(reflection, 500)
-            }))
-          })
-        }
-      ];
-      const clients = [this.deps.llm, this.deps.skillLlm].filter((client, index, all) =>
-        client.isConfigured() && all.indexOf(client) === index
-      );
-      let lastError: unknown;
-      let summaries: string[] | undefined;
-      for (const client of clients) {
-        for (let attempt = 0; attempt < 3; attempt += 1) {
-          try {
-            const result = await client.completeJson<{ summaries?: unknown }>(messages, {
-              operation: REFLECTED_TRACE_SUMMARY_OPERATION,
-              thinkingMode: "disabled",
-              temperature: 0,
-              maxTokens: Math.max(500, batch.length * 160)
-            });
-            summaries = normalizeReflectedTraceSummaries(result.summaries, batch.length);
-            break;
-          } catch (error) {
-            lastError = error;
-          }
-        }
-        if (summaries) break;
-      }
-      if (!summaries) {
-        throw lastError instanceof Error
-          ? lastError
-          : new Error("reflected trace summary has no configured model");
-      }
-      output.push(...summaries);
-    }
-    return output;
   }
 
 private applyUnconfiguredEpisodeDefault(job: EvolutionJobRecord): boolean {
@@ -814,8 +711,6 @@ private enqueuePostReflectionEmbedding(memory: MemoryRow, job: EvolutionJobRecor
 }
 
 const BATCH_REFLECTION_OPERATION = `capture.${BATCH_REFLECTION_PROMPT.id}.v${BATCH_REFLECTION_PROMPT.version}`;
-const REFLECTED_TRACE_SUMMARY_OPERATION =
-  `capture.${REFLECTED_TRACE_SUMMARY_PROMPT.id}.v${REFLECTED_TRACE_SUMMARY_PROMPT.version}`;
 
 function renderTraceMemoryValue(step: {
   summary: string;
@@ -1198,28 +1093,6 @@ function sanitizeSummaryText(value: string): string {
     .replace(/```$/i, "")
     .replace(/\s+/g, " ")
     .trim();
-}
-
-function normalizeReflectedTraceSummaries(value: unknown, traceCount: number): string[] {
-  if (!Array.isArray(value) || value.length !== traceCount) {
-    throw new Error("reflected trace summary returned wrong summary count");
-  }
-  const summaries = new Array<string>(traceCount);
-  for (const item of value) {
-    if (!isRecord(item)) {
-      throw new Error("reflected trace summary returned invalid item");
-    }
-    const index = Math.floor(numberOr(item.index, -1));
-    const summary = clip(sanitizeSummaryText(stringOr(item.summary, "")), 200);
-    if (index < 0 || index >= traceCount || !summary || summaries[index]) {
-      throw new Error("reflected trace summary returned invalid summary item");
-    }
-    summaries[index] = summary;
-  }
-  if (summaries.some((summary) => !summary)) {
-    throw new Error("reflected trace summary did not cover all traces");
-  }
-  return summaries;
 }
 
 function reflectionContextIncludesDownstream(mode: string): boolean {

--- a/Memory/src/service/session/session-turn-service.ts
+++ b/Memory/src/service/session/session-turn-service.ts
@@ -1004,7 +1004,6 @@ export class SessionTurnService {
               usable: step.reflection.usable,
               reflection_source: step.reflection.source,
               summary: "",
-              summary_deferred_until_reflection: true,
               tags: step.tags,
               value: step.value,
               priority: step.priority,
@@ -1047,6 +1046,19 @@ export class SessionTurnService {
             failedAt: null,
             updatedAt: at
           });
+          jobs.push(this.deps.enqueueJob({
+            jobType: "trace_summary",
+            userId: session.userId,
+            sessionId: session.id,
+            episodeId: episode.id,
+            targetMemoryId: upsert.memory.id,
+            payload: {
+              source: "turn.complete.capture",
+              contentHash: upsert.memory.contentHash
+            },
+            maxAttempts: 3,
+            createdAt: at
+          }));
         }
       }
       for (const artifact of requestArtifacts) {

--- a/Memory/src/service/worker/worker-runner.ts
+++ b/Memory/src/service/worker/worker-runner.ts
@@ -15,7 +15,6 @@ import {
   type Repositories
 } from "../../storage/repositories.js";
 import type { JobRef,MemoryRow,RequestEnvelope } from "../../types.js";
-import { isRecord } from "../../utils/json.js";
 import type {
   EmbeddingJobProcessor,
   PreparedEmbeddingJob
@@ -194,10 +193,6 @@ export class WorkerRunner {
       }
 
       if (processing.state === "summary_pending" || processing.state === "summarizing") {
-        const trace = memory.properties.internal_info.trace;
-        if (isRecord(trace) && trace.summary_deferred_until_reflection === true) {
-          continue;
-        }
         const jobType = memoryHasImportPipeline(memory) ? "import_summary" : "trace_summary";
         let job = this.deps.repos.runtime.getPendingJob(memory.id, jobType, memory.contentHash ?? undefined);
         if (!job) {

--- a/Memory/src/storage/repositories.ts
+++ b/Memory/src/storage/repositories.ts
@@ -2211,13 +2211,7 @@ export class RuntimeRepository {
                    )
                    AND (
                      memory_processing_state.state IN ('embedding_pending', 'embedding')
-                     OR (
-                       memory_processing_state.state IN ('summary_pending', 'summarizing')
-                       AND json_extract(
-                         memories.properties_json,
-                         '$.internal_info.trace.summary_deferred_until_reflection'
-                       ) = 1
-                     )
+                   OR memory_processing_state.state IN ('summary_pending', 'summarizing')
                    )
                )
              )

--- a/Memory/tests/fixtures/memory-service-fixture.ts
+++ b/Memory/tests/fixtures/memory-service-fixture.ts
@@ -297,17 +297,6 @@ export function createBatchReflectionLlm(calls: Array<{
           }))
         } as unknown as T;
       }
-      if (options.operation === "capture.reflected_trace_summary.v1") {
-        const payload = JSON.parse(messages.find((message) => message.role === "user")?.content ?? "{}") as {
-          traces?: Array<{ index: number }>;
-        };
-        return {
-          summaries: (payload.traces ?? []).map((trace) => ({
-            index: trace.index,
-            summary: captureSummary
-          }))
-        } as unknown as T;
-      }
       if (options.operation === "capture.summarize") {
         return {
           summary: captureSummary

--- a/Memory/tests/service/embedding/embedding-processing.test.ts
+++ b/Memory/tests/service/embedding/embedding-processing.test.ts
@@ -172,7 +172,7 @@ describe("MemoryService / embedding / processing", () => {
     db.close();
   });
 
-  it("defers captured L1 summary and embedding until episode reflection", async () => {
+  it("summarizes and embeds captured L1 traces before episode reflection", async () => {
     const llmCalls: Array<{
       messages: Array<{ role: string; content: string }>;
       options: { operation: string };
@@ -203,7 +203,7 @@ describe("MemoryService / embedding / processing", () => {
       answer: "Use focused checks first, then broaden only after the migration path is verified."
     });
 
-    expect(complete.jobs.map((job) => job.jobType)).toEqual(["episode_idle_close"]);
+    expect(complete.jobs.map((job) => job.jobType)).toEqual(["trace_summary", "episode_idle_close"]);
     expect(new Repositories(db.db).processing.get(complete.l1MemoryId)).toMatchObject({
       state: "summary_pending",
       stage: "summary",
@@ -216,14 +216,15 @@ describe("MemoryService / embedding / processing", () => {
     });
     expect(recall.hits.some((hit) => hit.id === complete.l1MemoryId)).toBe(true);
     const openEpisodeRun = await service.runWorkerOnce(10);
-    expect(openEpisodeRun.jobs.map((job) => job.jobType)).toEqual(["episode_idle_close"]);
-    expect(llmCalls.some((call) => call.options.operation.includes("summar"))).toBe(false);
-    expect(embeddingTexts).toHaveLength(0);
-    service.reconcileWorkerStartup();
+    expect(openEpisodeRun.jobs.map((job) => job.jobType)).toEqual(["episode_idle_close", "trace_summary"]);
+    expect(llmCalls.filter((call) => call.options.operation === "capture.summarize")).toHaveLength(1);
+    const embeddingRun = await service.runWorkerOnce(10);
+    expect(embeddingRun.jobs.map((job) => job.jobType)).toEqual(["embedding"]);
+    expect(embeddingTexts).toHaveLength(1);
     expect(db.db.prepare(
       `SELECT COUNT(*) AS count FROM evolution_jobs
        WHERE target_memory_id = ? AND job_type IN ('trace_summary', 'embedding')`
-    ).get(complete.l1MemoryId)).toEqual({ count: 0 });
+    ).get(complete.l1MemoryId)).toEqual({ count: 2 });
     const row = db.db.prepare(
       `SELECT info_json, properties_json
        FROM memories
@@ -235,20 +236,18 @@ describe("MemoryService / embedding / processing", () => {
         summary?: string;
         trace: {
           summary?: string;
-          summary_deferred_until_reflection?: boolean;
           vec_summary?: number[];
         };
       };
     };
-    expect(info.summary).toBe("");
-    expect(properties.internal_info.summary).toBe("");
-    expect(properties.internal_info.trace.summary).toBe("");
-    expect(properties.internal_info.trace.summary_deferred_until_reflection).toBe(true);
+    expect(info.summary).toBe("SQLite migrations should run focused checks before broad checks.");
+    expect(properties.internal_info.summary).toBe("SQLite migrations should run focused checks before broad checks.");
+    expect(properties.internal_info.trace.summary).toBe("SQLite migrations should run focused checks before broad checks.");
     expect(properties.internal_info.trace.vec_summary).toBeUndefined();
     expect(db.db.prepare(
       `SELECT embedding_dim FROM memory_vector_entries
        WHERE memory_id = ? AND vector_field = 'vec_summary'`
-    ).get(complete.l1MemoryId)).toBeUndefined();
+    ).get(complete.l1MemoryId)).toEqual({ embedding_dim: 3 });
     db.close();
   });
 });

--- a/Memory/tests/service/evolution/evolution-llm-stubs.ts
+++ b/Memory/tests/service/evolution/evolution-llm-stubs.ts
@@ -39,15 +39,9 @@ export function createCapturingL2Llm(calls: Array<{
           }))
         } as unknown as T;
       }
-      if (options.operation === "capture.reflected_trace_summary.v1") {
-        const payload = JSON.parse(messages.find((message) => message.role === "user")?.content ?? "{}") as {
-          traces?: Array<{ index: number; userText?: string }>;
-        };
+      if (options.operation === "capture.summarize") {
         return {
-          summaries: (payload.traces ?? []).map((trace) => ({
-            index: trace.index,
-            summary: trace.userText || "reflected trace summary"
-          }))
+          summary: "reflected trace summary"
         } as unknown as T;
       }
       if (options.operation === "l2.induction.v3") {

--- a/Memory/tests/service/evolution/reflection.test.ts
+++ b/Memory/tests/service/evolution/reflection.test.ts
@@ -62,17 +62,6 @@ function createUnusableReflectionLlm(): LlmClient {
           }))
         } as unknown as T;
       }
-      if (options.operation === "capture.reflected_trace_summary.v1") {
-        const payload = JSON.parse(messages.find((message) => message.role === "user")?.content ?? "{}") as {
-          traces?: Array<{ index: number }>;
-        };
-        return {
-          summaries: (payload.traces ?? []).map((trace) => ({
-            index: trace.index,
-            summary: "unusable reflection summary"
-          }))
-        } as unknown as T;
-      }
       return {
         summary: "unusable reflection summary",
         reflection: "tautological reflection",
@@ -434,14 +423,15 @@ describe("MemoryService / evolution / reflection", () => {
       call.options.operation === "capture.reflection.batch.v13"
     );
     expect(reflectionCalls).toHaveLength(1);
-    const summaryCalls = calls.filter((call) =>
-      call.options.operation === "capture.reflected_trace_summary.v1"
-    );
-    expect(summaryCalls).toHaveLength(1);
-    const summaryPayload = JSON.parse(
-      summaryCalls[0]!.messages.find((message) => message.role === "user")?.content ?? "{}"
-    ) as { traces: Array<{ index: number }> };
-    expect(summaryPayload.traces.map((trace) => trace.index)).toEqual([0, 1]);
+    const summaryCalls = calls.filter((call) => call.options.operation === "capture.summarize");
+    expect(summaryCalls).toHaveLength(2);
+    expect(summaryCalls.map((call) => call.messages.find((message) => message.role === "user")?.content))
+      .toEqual(expect.arrayContaining([
+        expect.stringContaining("USER: Hi, thanks"),
+        expect.stringContaining("USER: 为什么黑美人西瓜不常见？")
+      ]));
+    expect(summaryCalls.every((call) => !call.messages.find((message) => message.role === "user")?.content.includes("REFLECTION:"))).toBe(true);
+    expect(calls.some((call) => call.options.operation === "capture.reflected_trace_summary.v1")).toBe(false);
     const payload = JSON.parse(
       reflectionCalls[0]!.messages.find((message) => message.role === "user")?.content ?? "{}"
     ) as { steps: Array<{ idx: number; state: string }> };
@@ -549,12 +539,11 @@ describe("MemoryService / evolution / reflection", () => {
     );
     expect(reflectionCall?.options.thinkingMode).toBe("disabled");
     expect(summaryCalls.some((call) => call.options.operation === "capture.reflection.batch.v13")).toBe(false);
-    const summaryCall = summaryCalls.find((call) =>
-      call.options.operation === "capture.reflected_trace_summary.v1"
-    );
+    const summaryCall = summaryCalls.find((call) => call.options.operation === "capture.summarize");
     expect(summaryCall).toBeTruthy();
-    expect(summaryCall!.messages[0]?.content).not.toContain("Write in English");
-    expect(summaryCall!.messages[1]?.content).toContain("Simplified Chinese");
+    expect(summaryCall!.messages[0]?.content).toContain("single user/agent exchange");
+    expect(summaryCall!.messages[1]?.content).not.toContain("REFLECTION:");
+    expect(summaryCalls.some((call) => call.options.operation === "capture.reflected_trace_summary.v1")).toBe(false);
     const payload = JSON.parse(
       reflectionCall?.messages.find((message) => message.role === "user")?.content ?? "{}"
     ) as { host_context?: { reflectionModel?: string } };
@@ -843,20 +832,13 @@ describe("MemoryService / evolution / reflection", () => {
     expect(payload.steps[0]?.tool_calls).toHaveLength(2);
     expect(payload.steps.every((step) => step.synth_allowed)).toBe(true);
     expect(payload.task_context).toContain("sqlite migration");
-    const summaryCall = calls.find((call) =>
-      call.options.operation === "capture.reflected_trace_summary.v1"
-    );
+    const summaryCall = calls.find((call) => call.options.operation === "capture.summarize");
     expect(summaryCall).toBeTruthy();
-    expect(summaryCall!.messages[0]?.content).toContain("each reflected AI-agent trace");
-    const summaryPayload = JSON.parse(
-      summaryCall!.messages.find((message) => message.role === "user")?.content ?? "{}"
-    ) as { traces: Array<{ index: number; reflection: string; toolCalls: unknown[] }> };
-    expect(summaryPayload.traces).toHaveLength(1);
-    expect(summaryPayload.traces[0]).toMatchObject({
-      index: 0,
-      reflection: "PIVOTAL"
-    });
-    expect(summaryPayload.traces[0]?.toolCalls).toHaveLength(2);
+    expect(summaryCall!.messages[0]?.content).toContain("single user/agent exchange");
+    const summaryPayload = summaryCall!.messages.find((message) => message.role === "user")?.content ?? "";
+    expect(summaryPayload).not.toContain("REFLECTION:");
+    expect(summaryPayload).toContain("TOOLS:");
+    expect(calls.some((call) => call.options.operation === "capture.reflected_trace_summary.v1")).toBe(false);
 
     const rows = complete.l1MemoryIds.map((id) => db.db.prepare(
       `SELECT properties_json
@@ -894,7 +876,7 @@ describe("MemoryService / evolution / reflection", () => {
        WHERE job_type = 'embedding'
          AND payload_json LIKE '%reflection.updated%'`
     ).get() as { count: number };
-    expect(queuedEmbedding.count).toBeGreaterThan(0);
+    expect(queuedEmbedding.count).toBe(complete.l1MemoryIds.length);
     db.close();
   });
 });

--- a/Memory/tests/service/evolution/reward.test.ts
+++ b/Memory/tests/service/evolution/reward.test.ts
@@ -122,7 +122,7 @@ describe("MemoryService / evolution / reward", () => {
       query: "finish the migration scaffold with durable sqlite state and a worker queue",
       answer: "implemented the service scaffold, sqlite schema, raw turn capture, and asynchronous worker queue"
     });
-    expect(complete.jobs.map((job) => job.jobType)).toEqual(["episode_idle_close"]);
+    expect(complete.jobs.map((job) => job.jobType)).toEqual(["trace_summary", "episode_idle_close"]);
 
     const rewardBeforeClose = db.db.prepare(
       `SELECT COUNT(*) AS count
@@ -171,7 +171,7 @@ describe("MemoryService / evolution / reward", () => {
       userId: "user-implicit-reward",
       status: "queued"
     }).items.map((job) => job.jobType);
-    expect(queuedOrder.slice(0, 2)).toEqual(["episode_idle_close", "reflection"]);
+    expect(queuedOrder.slice(0, 2)).toEqual(["episode_idle_close", "trace_summary"]);
 
     const run = await service.runWorkerOnce(20);
     expect(run.changeSeq).toBeGreaterThan(0);
@@ -280,12 +280,9 @@ describe("MemoryService / evolution / reward", () => {
       turnSummaries: string[];
       finalExchange: { user: string; assistant: string };
     };
-    expect(immediateRewardInput.turnSummaries[0]).toContain("我喜欢吃的水果是西瓜");
-    expect(immediateRewardInput.turnSummaries[0]).toContain("→ 记住了，你喜欢吃的水果是西瓜。");
+    expect(immediateRewardInput.turnSummaries[0]).toBe("LLM batch summary");
     expect(immediateRewardInput.turnSummaries[0]!.length).toBeLessThanOrEqual(200);
-    expect(immediateRewardInput.turnSummaries[1]).toBe(
-      "水果中和西瓜比较相似有哪些，推荐一个 → 我推荐哈密瓜。"
-    );
+    expect(immediateRewardInput.turnSummaries[1]).toBe("LLM batch summary");
     expect(immediateRewardInput.finalExchange).toEqual({
       user: "水果中和西瓜比较相似有哪些，推荐一个",
       assistant: "我推荐哈密瓜。"
@@ -293,9 +290,7 @@ describe("MemoryService / evolution / reward", () => {
     expect(calls.filter((call) =>
       call.options.operation === "reward.reward.r_human.v7"
     )).toHaveLength(1);
-    expect(calls.some((call) =>
-      call.options.operation === "capture.reflected_trace_summary.v1"
-    )).toBe(false);
+    expect(calls.filter((call) => call.options.operation === "capture.summarize")).toHaveLength(2);
 
     const third = service.completeTurn("turn-reward-before-reflection-3", {
       sessionId: session.sessionId,
@@ -621,7 +616,10 @@ describe("MemoryService / evolution / reward", () => {
     };
     expect(rewardInput).toEqual({
       mission: "verify reward scoring prompt",
-      turnSummaries: ["reflected reward summary", "reflected reward summary"],
+      turnSummaries: [
+        "verify reward scoring prompt",
+        "now summarize the final reward result"
+      ],
       finalExchange: {
         user: "now summarize the final reward result",
         assistant: "summarized the final reward result"
@@ -644,7 +642,6 @@ describe("MemoryService / evolution / reward", () => {
         agent: "codex"
       }
     });
-    expect(rewardCall!.messages[1]!.content).not.toContain("prepared the requested scoring workflow");
     expect(rewardCall!.messages[1]!.content).not.toContain("\"q\":\"reward prompt\"");
     expect(rewardCall!.messages[1]!.content).not.toContain("\"output\":\"ok\"");
     expect(rewardCall!.messages[1]!.content).not.toContain("reward-summary-capturing");

--- a/Memory/tests/service/evolution/span-big-turn.test.ts
+++ b/Memory/tests/service/evolution/span-big-turn.test.ts
@@ -76,12 +76,9 @@ function createSpanBigTurnLlm(
           }))
         } as unknown as T;
       }
-      if (options.operation === "capture.reflected_trace_summary.v1") {
+      if (options.operation === "capture.summarize") {
         return {
-          summaries: [{
-            index: 0,
-            summary: "定位构建失败、修改依赖配置并验证修复结果"
-          }]
+          summary: "定位构建失败、修改依赖配置并验证修复结果"
         } as unknown as T;
       }
       if (options.operation === "reward.reward.r_human.v7") {

--- a/Memory/tests/service/feedback/decision-repair.test.ts
+++ b/Memory/tests/service/feedback/decision-repair.test.ts
@@ -56,15 +56,9 @@ function createDecisionRepairLlm(
           }))
         } as unknown as T;
       }
-      if (options.operation === "capture.reflected_trace_summary.v1") {
-        const payload = JSON.parse(messages.find((message) => message.role === "user")?.content ?? "{}") as {
-          traces?: Array<{ index: number; userText?: string }>;
-        };
+      if (options.operation === "capture.summarize") {
         return {
-          summaries: (payload.traces ?? []).map((trace) => ({
-            index: trace.index,
-            summary: trace.userText || "sqlite migration workflow"
-          }))
+          summary: "sqlite migration workflow"
         } as unknown as T;
       }
       if (options.operation === "decision.repair.v1") {


### PR DESCRIPTION
Captured L1 traces now enqueue their individual summary and summary embedding at turn completion. Episode reflection reuses that durable summary, avoiding a second model summary while retaining reflection-driven vector refreshes.

Constraint: Reflection remains episode-scoped, but summaries must be available before the episode closes.
Rejected: Keep summaries deferred until reflection | leaves active episodes without retrievable summaries and can stall on idle closure.
Confidence: high
Scope-risk: moderate
Directive: Do not reintroduce model summary calls from reflection paths; trace_summary owns capture.summarize.
Tested: Memory embedding/reflection/reward/span/feedback tests (39 passed); Memory typecheck; git diff --check.
Not-tested: Live provider latency and retry behavior.