### PR TITLE
fix: local embedding error

### DIFF
--- a/App/backend/src/index.ts
+++ b/App/backend/src/index.ts
@@ -56,7 +56,7 @@ export interface CreateLocalBackendOptions {
   desktopInstallFingerprint?: string;
   /** Agent source auto scan interval in ms. Defaults to one hour. */
   agentSourceAutoScanIntervalMs?: number;
-  /** Agent source auto scan initial delay in ms. Defaults to the interval. */
+  /** Agent source startup scan delay in ms. Defaults to five minutes. */
   agentSourceAutoScanInitialDelayMs?: number;
 }
 

--- a/App/backend/src/services/agent-source-auto-scan-service.ts
+++ b/App/backend/src/services/agent-source-auto-scan-service.ts
@@ -2,8 +2,10 @@
 import type { ScanPreferences } from "@memmy/local-api-contracts";
 
 export const DEFAULT_AGENT_SOURCE_AUTO_SCAN_INTERVAL_MS = 60 * 60 * 1000;
+export const DEFAULT_AGENT_SOURCE_AUTO_SCAN_INITIAL_DELAY_MS = 5 * 60 * 1000;
 
 type Timer = ReturnType<typeof setTimeout>;
+type ScanTrigger = "startup" | "recurring";
 
 export interface AgentSourceAutoScanService {
   start(): void;
@@ -24,33 +26,37 @@ export function createAgentSourceAutoScanService(
   options: CreateAgentSourceAutoScanServiceOptions
 ): AgentSourceAutoScanService {
   const intervalMs = options.intervalMs ?? DEFAULT_AGENT_SOURCE_AUTO_SCAN_INTERVAL_MS;
-  const initialDelayMs = options.initialDelayMs ?? intervalMs;
+  const initialDelayMs = options.initialDelayMs ?? DEFAULT_AGENT_SOURCE_AUTO_SCAN_INITIAL_DELAY_MS;
   const fetchFn = options.fetchFn ?? fetch;
   let timer: Timer | null = null;
   let abortController: AbortController | null = null;
   let closed = false;
   let running = false;
 
-  const schedule = (delayMs: number) => {
+  const schedule = (delayMs: number, trigger: ScanTrigger) => {
     if (closed) {
       return;
     }
 
     timer = setTimeout(() => {
       timer = null;
-      void runScan().finally(() => schedule(intervalMs));
+      void runScan(trigger).finally(() => schedule(intervalMs, "recurring"));
     }, delayMs);
     timer.unref?.();
   };
 
-  const runScan = async () => {
+  const runScan = async (trigger: ScanTrigger) => {
     if (running || closed) {
       return;
     }
 
     running = true;
     try {
-      if (!options.getScanPreferences().watchFileChanges) {
+      const preferences = options.getScanPreferences();
+      const enabled = trigger === "startup"
+        ? preferences.autoScanKnownAgents
+        : preferences.watchFileChanges;
+      if (!enabled) {
         return;
       }
 
@@ -76,7 +82,11 @@ export function createAgentSourceAutoScanService(
         return;
       }
 
-      schedule(initialDelayMs);
+      const startupScanEnabled = options.getScanPreferences().autoScanKnownAgents;
+      schedule(
+        startupScanEnabled ? initialDelayMs : intervalMs,
+        startupScanEnabled ? "startup" : "recurring"
+      );
     },
 
     close() {

--- a/App/backend/src/services/tests/agent-source-auto-scan-service.test.ts
+++ b/App/backend/src/services/tests/agent-source-auto-scan-service.test.ts
@@ -1,6 +1,9 @@
 /** Agent source auto scan service tests. */
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { createAgentSourceAutoScanService } from "../agent-source-auto-scan-service.js";
+import {
+  createAgentSourceAutoScanService,
+  DEFAULT_AGENT_SOURCE_AUTO_SCAN_INITIAL_DELAY_MS
+} from "../agent-source-auto-scan-service.js";
 import type { ScanPreferences } from "@memmy/local-api-contracts";
 
 const enabledPreferences: ScanPreferences = {
@@ -14,20 +17,19 @@ afterEach(() => {
 });
 
 describe("agent source auto scan service", () => {
-  it("posts to the local scan endpoint on the configured interval", async () => {
+  it("runs the startup scan after the default five-minute delay", async () => {
     vi.useFakeTimers();
     const fetchFn = vi.fn(async () => ({} as Response));
     const service = createAgentSourceAutoScanService({
       baseUrl: "http://127.0.0.1:19001",
       localToken: "test-token",
       intervalMs: 1_000,
-      initialDelayMs: 1_000,
       fetchFn,
       getScanPreferences: () => enabledPreferences
     });
 
     service.start();
-    await vi.advanceTimersByTimeAsync(999);
+    await vi.advanceTimersByTimeAsync(DEFAULT_AGENT_SOURCE_AUTO_SCAN_INITIAL_DELAY_MS - 1);
     expect(fetchFn).not.toHaveBeenCalled();
 
     await vi.advanceTimersByTimeAsync(1);
@@ -39,6 +41,70 @@ describe("agent source auto scan service", () => {
       },
       signal: expect.any(AbortSignal)
     });
+    service.close();
+  });
+
+  it("runs one startup scan when hourly incremental sync is disabled", async () => {
+    vi.useFakeTimers();
+    const fetchFn = vi.fn(async () => ({} as Response));
+    const service = createAgentSourceAutoScanService({
+      baseUrl: "http://127.0.0.1:19001",
+      localToken: "test-token",
+      intervalMs: 1_000,
+      initialDelayMs: 100,
+      fetchFn,
+      getScanPreferences: () => ({ ...enabledPreferences, watchFileChanges: false })
+    });
+
+    service.start();
+    await vi.advanceTimersByTimeAsync(100);
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    service.close();
+  });
+
+  it("waits for the hourly interval when startup scanning is disabled", async () => {
+    vi.useFakeTimers();
+    const fetchFn = vi.fn(async () => ({} as Response));
+    const service = createAgentSourceAutoScanService({
+      baseUrl: "http://127.0.0.1:19001",
+      localToken: "test-token",
+      intervalMs: 1_000,
+      initialDelayMs: 100,
+      fetchFn,
+      getScanPreferences: () => ({ ...enabledPreferences, autoScanKnownAgents: false })
+    });
+
+    service.start();
+    await vi.advanceTimersByTimeAsync(999);
+    expect(fetchFn).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    service.close();
+  });
+
+  it("does not scan when both automatic scan preferences are disabled", async () => {
+    vi.useFakeTimers();
+    const fetchFn = vi.fn(async () => ({} as Response));
+    const service = createAgentSourceAutoScanService({
+      baseUrl: "http://127.0.0.1:19001",
+      localToken: "test-token",
+      intervalMs: 100,
+      initialDelayMs: 10,
+      fetchFn,
+      getScanPreferences: () => ({
+        ...enabledPreferences,
+        autoScanKnownAgents: false,
+        watchFileChanges: false
+      })
+    });
+
+    service.start();
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(fetchFn).not.toHaveBeenCalled();
     service.close();
   });
 
@@ -88,24 +154,5 @@ describe("agent source auto scan service", () => {
     await vi.advanceTimersByTimeAsync(100);
 
     expect(fetchFn).not.toHaveBeenCalled();
-  });
-
-  it("skips scans when hourly incremental sync is disabled", async () => {
-    vi.useFakeTimers();
-    const fetchFn = vi.fn(async () => ({} as Response));
-    const service = createAgentSourceAutoScanService({
-      baseUrl: "http://127.0.0.1:19001",
-      localToken: "test-token",
-      intervalMs: 100,
-      initialDelayMs: 100,
-      fetchFn,
-      getScanPreferences: () => ({ ...enabledPreferences, watchFileChanges: false })
-    });
-
-    service.start();
-    await vi.advanceTimersByTimeAsync(100);
-
-    expect(fetchFn).not.toHaveBeenCalled();
-    service.close();
   });
 });

--- a/Memory/src/model/embedder.ts
+++ b/Memory/src/model/embedder.ts
@@ -1,3 +1,5 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
 import type { EmbeddingConfig } from "../config/index.js";
 import { createMemoryLogger, memoryErrorFields } from "../logging/logger.js";
 import { stableHash } from "../utils/id.js";
@@ -29,6 +31,12 @@ interface CohereEmbeddingResponse {
 
 type FeatureExtractor = (text: string, options?: Record<string, unknown>) => Promise<{ data?: ArrayLike<number> | Iterable<number> }>;
 type PipelineFn = (task: string, model: string, options?: Record<string, unknown>) => Promise<unknown>;
+interface TransformersModule {
+  env: {
+    cacheDir: string | null;
+  };
+  pipeline: PipelineFn;
+}
 
 let localExtractorPromise: Promise<FeatureExtractor> | null = null;
 let localExtractorModel: string | null = null;
@@ -297,7 +305,9 @@ async function ensureLocalExtractor(model: string): Promise<FeatureExtractor> {
   localExtractorModel = model;
   localExtractorPromise = (async () => {
     const mod = await import("@huggingface/transformers");
-    const pipeline = (mod as unknown as { pipeline: PipelineFn }).pipeline;
+    const transformers = mod as unknown as TransformersModule;
+    transformers.env.cacheDir = join(homedir(), ".memmy", "memory-service", "model-cache");
+    const pipeline = transformers.pipeline;
     return await pipeline("feature-extraction", model, {
       dtype: "q8",
       device: "cpu"

--- a/Memory/tests/embedder.test.ts
+++ b/Memory/tests/embedder.test.ts
@@ -1,17 +1,24 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { DEFAULT_MEMMY_CONFIG } from "../src/config/index.js";
 import { createEmbedder } from "../src/model/embedder.js";
 
 const transformerMocks = vi.hoisted(() => ({
+  env: {
+    cacheDir: "module-default-cache" as string | null
+  },
   extractor: vi.fn(),
   pipeline: vi.fn()
 }));
 
 vi.mock("@huggingface/transformers", () => ({
+  env: transformerMocks.env,
   pipeline: transformerMocks.pipeline
 }));
 
 afterEach(() => {
+  transformerMocks.env.cacheDir = "module-default-cache";
   transformerMocks.extractor.mockReset();
   transformerMocks.pipeline.mockReset();
   vi.unstubAllGlobals();
@@ -57,6 +64,9 @@ describe("embedder", () => {
     });
 
     await expect(embedder.embedOne("local memory")).resolves.toEqual([3, 4]);
+    expect(transformerMocks.env.cacheDir).toBe(
+      join(homedir(), ".memmy", "memory-service", "model-cache")
+    );
     expect(transformerMocks.extractor).toHaveBeenCalledWith("local memory", {
       pooling: "mean",
       normalize: false


### PR DESCRIPTION
Fixes #88 

Configure `@huggingface/transformers` to use the writable model cache directory
`~/.memmy/memory-service/model-cache`, preventing packaged Electron builds from
attempting to write inside `app.asar`.