### PR TITLE
fix(desktop): archive confirm click and outline style

### DIFF
--- a/App/frontend/desktop/src/pages/app-frame.tsx
+++ b/App/frontend/desktop/src/pages/app-frame.tsx
@@ -435,9 +435,12 @@ export function AppFrame(props: AppFrameProps) {
       }
       // Portal menus live under document.body; ignore presses inside them so item
       // onClick can run (a blanket document click would unmount first).
+      // Inline archive confirm lives in the task row (not a portal); pointerdown
+      // must not clear archiveConfirmSessionKey before its click handler runs.
       if (
         target.closest(".app-frame-sidebar-menu")
         || target.closest(".app-frame-workspace-picker-menu")
+        || target.closest(".app-frame-task-row--confirming")
       ) {
         return;
       }

--- a/App/frontend/desktop/src/styles.css
+++ b/App/frontend/desktop/src/styles.css
@@ -8099,11 +8099,11 @@ input[type="checkbox"].check-sky:checked::after {
   flex-shrink: 0;
   align-items: center;
   justify-content: center;
-  padding: 0 10px;
-  border: 0;
+  padding: 0 9px;
+  border: 1px solid var(--color-status-error);
   border-radius: var(--radius-input);
-  background: var(--color-status-error);
-  color: white;
+  background: transparent;
+  color: var(--color-status-error);
   font-family: var(--font-sans);
   font-size: var(--codex-text-xs);
   font-weight: 500;
@@ -8111,11 +8111,12 @@ input[type="checkbox"].check-sky:checked::after {
   letter-spacing: 0;
   cursor: pointer;
   transition:
-    background-color var(--duration-fast);
+    background-color var(--duration-fast),
+    color var(--duration-fast);
 }
 
 .app-frame-task-confirm:hover {
-  background: color-mix(in srgb, var(--color-status-error) 85%, black);
+  background: color-mix(in srgb, var(--color-status-error) 10%, transparent);
 }
 
 .app-frame-task-confirm:focus-visible {


### PR DESCRIPTION
## Summary
- Fix archive confirm being dismissed by document `pointerdown` before its click handler runs
- Restyle the confirm control as a red outline button instead of a solid red fill

## Test plan
- [ ] Hover a task → click archive → click 确认; task should archive
- [ ] Clicking outside the confirming row still cancels confirm
- [ ] Confirm button renders as red border / red text (not solid fill)


Made with [Cursor](https://cursor.com)