### PR TITLE
chore(release): add v1.0.4 notes and align versions

### DIFF
--- a/.github/release-notes/v1.0.4.md
+++ b/.github/release-notes/v1.0.4.md
@@ -1,0 +1,38 @@
+# Memmy v1.0.4
+
+## Highlights
+
+- Added project-scoped desktop workspaces. Open or create a local folder, start conversations inside that project, and keep the Agent's working directory and file access bound to the selected workspace.
+- Added built-in browser automation for web and UI tasks, including navigation, snapshots, find, click, typing, console and network inspection, screenshots, viewport controls, and safe local HTML preview.
+- Improved long-term Memory by preserving reusable subgoals from complex Agent turns and keeping failure-avoidance lessons isolated from successful strategies.
+
+## Agent improvements
+
+- Added the expanded `ui-craft` Skill for planning, implementing, previewing, and visually validating interfaces with the managed browser workflow.
+- Added on-demand Agent Memory onboarding for user-selected local AI tools, including Skill generation, initial history import, validated sync recipes, incremental synchronization, and readiness feedback.
+- Browser sessions are isolated per chat, cleaned up after idle time, and wait for Chromium preparation instead of failing during desktop startup.
+- Command cancellation and timeouts now clean up descendant process trees instead of leaving commands or output streams running.
+- Improved Agent-source synchronization by safely skipping incomplete or oversized turns, preserving retryable incremental watermarks, and separating startup scans from recurring synchronization.
+
+## Desktop and account improvements
+
+- Reworked the sidebar and composer around projects, with recent and pinned projects, per-project task groups, standalone tasks, archive views, and clearer operation feedback.
+- Added optional invitation codes during sign-in, redemption-result notifications, and referral or promotion reward details supplied by Cloud configuration.
+- Added a clearer token-usage breakdown for Agent tasks, Memory summaries, and Memory evolution alongside local BYOK usage.
+- Fixed login incorrectly showing an exhausted-token state before current quota information had loaded.
+- The Windows Data Management page now displays the actual local Memory storage path and opens that same directory.
+
+## Memory and data reliability
+
+- Long, tool-heavy Agent turns can now produce independently searchable Span memories while suppressing duplicate parent and subtask recall results.
+- Negative outcomes can become scoped failure-avoidance memories without being promoted into higher-level skills or world knowledge.
+- Completed turns become searchable sooner, explicit topic endings preserve the final reply before closing an episode, and chitchat or control-only turns no longer pollute durable Memory.
+- Improved processing and retry diagnostics, including clearer exhausted-reasoning errors, preserved failure details, and more precise negative-memory matching.
+- Memory database export now creates a consistent SQLite snapshot that includes committed WAL data instead of copying only the primary database file.
+
+## Packaging and upgrade notes
+
+- On first start, v1.0.4 runs a one-time workspace migration that binds existing desktop chats to the standalone workspace used by the new project-scoped session model. Existing messages, titles, and pinned or archived state are preserved.
+- Packaged desktop builds now include the required native runtime and migration files, with migrations unpacked correctly on Windows and a writable cache used for the local embedding model.
+- The Windows local-data path fix identified in the v1.0.3 source is included in the official v1.0.4 installers.
+- Expanded best-effort lifecycle and runtime analytics across the desktop app, Agent runtime, Memory CLI, and Agent-source workflows, with China and International edition tagging.

--- a/App/memmy-agent/package-lock.json
+++ b/App/memmy-agent/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "memmy-agent",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "memmy-agent",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.100.1",
         "@aws-sdk/client-bedrock-runtime": "^3.1061.0",

--- a/App/memmy-agent/package.json
+++ b/App/memmy-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memmy-agent",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "TypeScript refactor of memmy's agent runtime.",
   "type": "module",
   "main": "./dist/index.js",

--- a/App/shell/desktop/package.json
+++ b/App/shell/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memmy/desktop",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "private": true,
   "type": "module",
   "description": "Memmy desktop client.",

--- a/Memory/package.json
+++ b/Memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memmy/memory",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "private": true,
   "type": "module",
   "main": "./dist/src/index.js",

--- a/Memory/src/cli/npm/package.json
+++ b/Memory/src/cli/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memtensor/memmy-memory-cli",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Memmy Memory CLI for local agent memory.",
   "type": "module",
   "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "memmy-agent",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "memmy-agent",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "workspaces": [
         "Migrations",
         "Memory",
@@ -86,7 +86,7 @@
     },
     "App/shell/desktop": {
       "name": "@memmy/desktop",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "dependencies": {
         "@memmy/backend": "0.0.0",
         "@memmy/desktop-interface": "0.0.0",
@@ -222,7 +222,7 @@
     },
     "Memory": {
       "name": "@memmy/memory",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "dependencies": {
         "@huggingface/transformers": "^3.8.0",
         "better-sqlite3": "^12.6.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memmy-agent",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "private": true,
   "type": "module",
   "description": "Local-first agent memory substrate with desktop and CLI surfaces.",


### PR DESCRIPTION
## Summary

- add curated release notes for Memmy v1.0.4
- align all release-relevant package manifests and lockfiles to version 1.0.4
- leave the existing v1.0.4 tag, GitHub Release, and uploaded binaries unchanged

## Validation

- `npm run version:check`
- `npm run test:release-workflow` (10/10 tests passed)
- `git diff --check`

## Scope

This PR corrects `main` for future builds and development. It does not rewrite or move the existing `v1.0.4` tag and does not replace any previously published installer.
