### PR TITLE
fix: support writable Memmy data on non-system drives

### DIFF
--- a/App/backend/src/infrastructure/cli-binary/index.ts
+++ b/App/backend/src/infrastructure/cli-binary/index.ts
@@ -6,7 +6,8 @@ import type { RuntimeConfig } from "@memmy/local-api-contracts";
 
 /** Handles resolve default runtime config path. */
 export function resolveDefaultRuntimeConfigPath(): string {
-  return join(homedir(), ".memmy", "runtime.json");
+  return process.env.MEMMY_RUNTIME_CONFIG_PATH?.trim() ||
+    join(process.env.MEMMY_HOME?.trim() || join(homedir(), ".memmy"), "runtime.json");
 }
 
 /** Handles resolve default cli symlink path. */

--- a/App/backend/src/infrastructure/memmy-config/index.ts
+++ b/App/backend/src/infrastructure/memmy-config/index.ts
@@ -195,7 +195,8 @@ export function createMemmyConfigWriter(options: CreateMemmyConfigWriterOptions 
  * @returns the absolute path to ~/.memmy/config.yaml.
  */
 export function resolveDefaultMemmyConfigPath(homeDirectory = homedir()): string {
-  return join(homeDirectory, ".memmy", "config.yaml");
+  return process.env.MEMMY_CONFIG?.trim() ||
+    join(process.env.MEMMY_HOME?.trim() || join(homeDirectory, ".memmy"), "config.yaml");
 }
 
 /**

--- a/App/backend/src/services/index.ts
+++ b/App/backend/src/services/index.ts
@@ -126,7 +126,7 @@ export function createBackendServices(options: CreateBackendServicesOptions): Ba
       createCursorSkillTarget({ memmyConfigPath: options.memmyConfigPath }),
       createClaudeCodeSkillTarget({ memmyConfigPath: options.memmyConfigPath }),
       createCodexSkillTarget({ memmyConfigPath: options.memmyConfigPath }),
-      createOpencodeSkillTarget(),
+      createOpencodeSkillTarget({ memmyConfigPath: options.memmyConfigPath }),
       createOpenclawSkillTarget({ memmyConfigPath: options.memmyConfigPath }),
       createHermesSkillTarget({ memmyConfigPath: options.memmyConfigPath }),
       createWorkbuddySkillTarget()

--- a/App/backend/src/services/tests/agent-source-config-paths.test.ts
+++ b/App/backend/src/services/tests/agent-source-config-paths.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -18,6 +18,14 @@ afterEach(() => {
 });
 
 describe("agent source and config path separation", () => {
+  it("passes the active Memmy config path to every built-in Skill target", () => {
+    const source = readFileSync(new URL("../index.ts", import.meta.url), "utf8");
+
+    expect(source).toContain(
+      "createOpencodeSkillTarget({ memmyConfigPath: options.memmyConfigPath })"
+    );
+  });
+
   it("installs OpenCode Skill when the database exists but the config directory does not", async () => {
     tempDirectory = mkdtempSync(join(tmpdir(), "memmy-opencode-paths-"));
     const databasePath = join(tempDirectory, "data", "opencode.db");

--- a/App/memmy-agent/src/config/loader.ts
+++ b/App/memmy-agent/src/config/loader.ts
@@ -8,7 +8,9 @@ import { Config, FileMemoryConfig } from "./schema.js";
 let configPathOverride: string | null = null;
 
 function expandHome(value: string): string {
-  return value === "~" || value.startsWith("~/") ? path.join(os.homedir(), value.slice(2)) : value;
+  return value === "~" || value.startsWith("~/") || value.startsWith("~\\")
+    ? path.join(os.homedir(), value.slice(2))
+    : value;
 }
 
 export function setConfigPath(configPath: string | null): void {
@@ -17,7 +19,10 @@ export function setConfigPath(configPath: string | null): void {
 
 export function getConfigPath(): string {
   if (configPathOverride) return expandHome(configPathOverride);
-  return expandHome(process.env.MEMMY_CONFIG || "~/.memmy/config.yaml");
+  return expandHome(
+    process.env.MEMMY_CONFIG ||
+    path.join(process.env.MEMMY_HOME || "~/.memmy", "config.yaml")
+  );
 }
 
 export function resolveConfigEnvVars(config: Config): Config {

--- a/App/memmy-agent/src/config/paths.ts
+++ b/App/memmy-agent/src/config/paths.ts
@@ -4,7 +4,9 @@ import path from "node:path";
 import { getConfigPath as getActiveConfigPath } from "./loader.js";
 
 function expandHome(value: string): string {
-  return value === "~" || value.startsWith("~/") ? path.join(os.homedir(), value.slice(2)) : value;
+  return value === "~" || value.startsWith("~/") || value.startsWith("~\\")
+    ? path.join(os.homedir(), value.slice(2))
+    : value;
 }
 
 function ensureDir(value: string): string {
@@ -13,7 +15,10 @@ function ensureDir(value: string): string {
 }
 
 function defaultWorkspacePath(): string {
-  return expandHome(process.env.MEMMY_AGENT_WORKSPACE || "~/.memmy/workspace");
+  return expandHome(
+    process.env.MEMMY_AGENT_WORKSPACE ||
+    path.join(process.env.MEMMY_HOME || "~/.memmy", "workspace")
+  );
 }
 
 export function getConfigPath(): string {
@@ -45,7 +50,7 @@ export function getWebuiDir(): string {
 }
 
 export function getWorkspacePath(workspace?: string | null): string {
-  return ensureDir(expandHome(workspace || process.env.MEMMY_AGENT_WORKSPACE || "~/.memmy/workspace"));
+  return ensureDir(expandHome(workspace || defaultWorkspacePath()));
 }
 
 export function isDefaultWorkspace(workspace?: string | null): boolean {
@@ -54,9 +59,9 @@ export function isDefaultWorkspace(workspace?: string | null): boolean {
 }
 
 export function getCliHistoryPath(): string {
-  return path.join(os.homedir(), ".memmy", "history", "cli_history");
+  return path.join(getRuntimeSubdir("history"), "cli_history");
 }
 
 export function getBridgeInstallDir(): string {
-  return path.join(os.homedir(), ".memmy", "bridge");
+  return getRuntimeSubdir("bridge");
 }

--- a/App/memmy-agent/src/config/schema.ts
+++ b/App/memmy-agent/src/config/schema.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import { CronSchedule } from "../cron/types.js";
 import { PROVIDERS, findByName, normalizeProviderName } from "../providers/registry.js";
 import { DEFAULT_MAX_TOKENS } from "../token-budget.js";
@@ -292,7 +293,7 @@ export class ModelPresetConfig extends Base {
 }
 
 export class AgentDefaults extends Base {
-  workspace = "~/.memmy/workspace";
+  workspace = path.join(process.env.MEMMY_HOME || "~/.memmy", "workspace");
   modelPreset: string | null = null;
   model = "anthropic/claude-opus-4-5";
   provider = "auto";

--- a/App/memmy-agent/src/integrations/byok-token-usage/register.ts
+++ b/App/memmy-agent/src/integrations/byok-token-usage/register.ts
@@ -69,7 +69,12 @@ function createProviderNameResolver(config: Config): (modelId: string | null) =>
 
 function resolveRuntimeConfigPath(options: ByokTokenUsageInstallOptions): string {
   if (options.runtimeConfigPath) return options.runtimeConfigPath;
-  return path.join(options.homeDir ?? os.homedir(), ".memmy", "runtime.json");
+  const env = options.env ?? process.env;
+  if (env.MEMMY_RUNTIME_CONFIG_PATH?.trim()) return env.MEMMY_RUNTIME_CONFIG_PATH;
+  return path.join(
+    env.MEMMY_HOME?.trim() || path.join(options.homeDir ?? os.homedir(), ".memmy"),
+    "runtime.json"
+  );
 }
 
 function readRuntimeConfig(filePath: string): ByokTokenUsageRuntimeConfig | null {

--- a/App/memmy-agent/src/memmy-memory/discovery.ts
+++ b/App/memmy-agent/src/memmy-memory/discovery.ts
@@ -20,9 +20,10 @@ function expandHome(value: string, homeDir: string): string {
 export function memmyMemoryConfigPaths(options: MemmyMemoryDiscoveryOptions = {}): string[] {
   const env = options.env ?? process.env;
   const homeDir = options.homeDir ?? os.homedir();
+  const memmyHome = env.MEMMY_HOME?.trim() || path.join(homeDir, ".memmy");
   return [
     env.MEMMY_CONFIG,
-    path.join(homeDir, ".memmy", "config.yaml"),
+    path.join(memmyHome, "config.yaml"),
   ]
     .filter((value): value is string => Boolean(value))
     .map((value) => path.resolve(expandHome(value, homeDir)));
@@ -45,8 +46,11 @@ function readTokenFile(file: string | null | undefined, homeDir: string): string
 }
 
 function runtimePath(env: DiscoveryEnv, homeDir: string): string {
-  void env;
-  return path.join(homeDir, ".memmy", "memory-service", "runtime.json");
+  return path.join(
+    env.MEMMY_HOME?.trim() || path.join(homeDir, ".memmy"),
+    "memory-service",
+    "runtime.json"
+  );
 }
 
 function readRuntimeDiscovery(env: DiscoveryEnv, homeDir: string): Record<string, any> {

--- a/App/memmy-agent/src/session-dag/paths.ts
+++ b/App/memmy-agent/src/session-dag/paths.ts
@@ -12,7 +12,7 @@ export function sessionDagRoot(env: NodeJS.ProcessEnv = process.env): string {
   const override = env[SESSION_DAG_DIR_ENV];
   return override && override.trim()
     ? path.resolve(override)
-    : path.join(os.homedir(), ".memmy", "session-dag");
+    : path.join(env.MEMMY_HOME?.trim() || path.join(os.homedir(), ".memmy"), "session-dag");
 }
 
 export function sessionDagDbPath(sessionKey: string, env: NodeJS.ProcessEnv = process.env): string {

--- a/App/memmy-agent/tests/config/config-paths.test.ts
+++ b/App/memmy-agent/tests/config/config-paths.test.ts
@@ -18,6 +18,7 @@ import {
 } from "../../src/config/paths.js";
 
 const originalConfig = process.env.MEMMY_CONFIG;
+const originalMemmyHome = process.env.MEMMY_HOME;
 const originalDataDir = process.env.MEMMY_AGENT_DATA_DIR;
 const originalWorkspace = process.env.MEMMY_AGENT_WORKSPACE;
 const roots: string[] = [];
@@ -36,6 +37,8 @@ afterEach(() => {
   setConfigPath(null);
   if (originalConfig === undefined) delete process.env.MEMMY_CONFIG;
   else process.env.MEMMY_CONFIG = originalConfig;
+  if (originalMemmyHome === undefined) delete process.env.MEMMY_HOME;
+  else process.env.MEMMY_HOME = originalMemmyHome;
   if (originalDataDir === undefined) delete process.env.MEMMY_AGENT_DATA_DIR;
   else process.env.MEMMY_AGENT_DATA_DIR = originalDataDir;
   if (originalWorkspace === undefined) delete process.env.MEMMY_AGENT_WORKSPACE;
@@ -112,6 +115,19 @@ describe("config path helpers", () => {
   it("keeps shared paths global", () => {
     expect(getCliHistoryPath()).toBe(path.join(os.homedir(), ".memmy", "history", "cli_history"));
     expect(getBridgeInstallDir()).toBe(path.join(os.homedir(), ".memmy", "bridge"));
+  });
+
+  it("derives config, workspace, history, and bridge paths from MEMMY_HOME", () => {
+    const memmyHome = path.join(tmpRoot(), ".memmy");
+    process.env.MEMMY_HOME = memmyHome;
+    delete process.env.MEMMY_CONFIG;
+    delete process.env.MEMMY_AGENT_DATA_DIR;
+    delete process.env.MEMMY_AGENT_WORKSPACE;
+
+    expect(getConfigPath()).toBe(path.join(memmyHome, "config.yaml"));
+    expect(getWorkspacePath()).toBe(path.join(memmyHome, "workspace"));
+    expect(getCliHistoryPath()).toBe(path.join(memmyHome, "history", "cli_history"));
+    expect(getBridgeInstallDir()).toBe(path.join(memmyHome, "bridge"));
   });
 
   it("resolves workspace paths explicitly", () => {

--- a/App/memmy-agent/tests/memmy-memory/discovery.test.ts
+++ b/App/memmy-agent/tests/memmy-memory/discovery.test.ts
@@ -73,6 +73,29 @@ describe("memmy memory discovery", () => {
     ]);
   });
 
+  it("derives config and runtime discovery from MEMMY_HOME", () => {
+    const root = tempRoot();
+    const memmyHome = path.join(root, "relocated", ".memmy");
+    const runtimeDir = path.join(memmyHome, "memory-service");
+    fs.mkdirSync(runtimeDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(runtimeDir, "runtime.json"),
+      JSON.stringify({ url: "http://relocated.test", token: "relocated-token" }),
+      "utf8"
+    );
+
+    expect(memmyMemoryConfigPaths({ env: { MEMMY_HOME: memmyHome }, homeDir: root }))
+      .toEqual([path.join(memmyHome, "config.yaml")]);
+    expect(discoverMemmyMemoryConnection({
+      env: { MEMMY_HOME: memmyHome },
+      homeDir: root
+    })).toMatchObject({
+      baseUrl: "http://relocated.test",
+      token: "relocated-token",
+      source: path.join(runtimeDir, "runtime.json")
+    });
+  });
+
   it("parses memmyMemory.enabled and preserves service fields from memmy-agent config", () => {
     const enabled = new Config({
       app: {

--- a/App/shell/desktop/build/installer-win-unsigned.nsh
+++ b/App/shell/desktop/build/installer-win-unsigned.nsh
@@ -2,6 +2,10 @@
   !define MEMMY_WM_SETTINGCHANGE 0x001A
 !endif
 
+!ifndef MEMMY_LANG_SIMPCHINESE
+  !define MEMMY_LANG_SIMPCHINESE 2052
+!endif
+
 !macro customHeader
   !ifdef BUILD_UNINSTALLER
     ; Keep unsigned QA uninstallers usable if Windows or transfer tools touch the NSIS stub.
@@ -17,6 +21,174 @@
 !macro customInstallMode
   StrCpy $isForceCurrentInstall "1"
 !macroend
+
+!ifndef BUILD_UNINSTALLER
+  !macro customPageAfterChangeDir
+    Page custom MemmyValidateInstallDirectoryPage
+
+    Function MemmyProbeInstallDirectory
+      ${StrContains} $R4 "${APP_FILENAME}" $INSTDIR
+      ${If} $R4 == ""
+        StrCpy $INSTDIR "$INSTDIR\${APP_FILENAME}"
+      ${EndIf}
+
+      StrCpy $R0 "$INSTDIR"
+      Call MemmyProbeWritableDirectory
+    FunctionEnd
+
+    ; Input: $R0 is the exact directory to validate. Output: pushes "1" when
+    ; that directory supports create/write/delete operations, else "0".
+    Function MemmyProbeWritableDirectory
+      StrCpy $R1 ""
+      StrCpy $R2 ""
+      StrCpy $R3 ""
+      StrCpy $R5 "0"
+
+      ; Probe the final target instead of walking upward, so an inaccessible
+      ; existing path cannot be mistaken for a missing path with a writable parent.
+      ; Remove the target afterward only when this probe created it.
+      IfFileExists "$R0\*.*" memmy_writable_probe_target_ready
+      ClearErrors
+      CreateDirectory "$R0"
+      IfErrors memmy_writable_probe_failed
+      StrCpy $R5 "1"
+
+      memmy_writable_probe_target_ready:
+        ClearErrors
+        GetTempFileName $R1 "$R0"
+        IfErrors memmy_writable_probe_failed
+        Delete "$R1"
+        IfErrors memmy_writable_probe_cleanup_failed
+        CreateDirectory "$R1"
+        IfErrors memmy_writable_probe_cleanup_failed
+        StrCpy $R2 "$R1\write-test.tmp"
+        FileOpen $R3 "$R2" w
+        IfErrors memmy_writable_probe_cleanup_failed
+        FileWrite $R3 "Memmy"
+        IfErrors memmy_writable_probe_close_failed
+        FileClose $R3
+        StrCpy $R3 ""
+        ClearErrors
+        Delete "$R2"
+        IfErrors memmy_writable_probe_cleanup_failed
+        StrCpy $R2 ""
+        ClearErrors
+        RMDir "$R1"
+        IfErrors memmy_writable_probe_cleanup_failed
+        StrCpy $R1 ""
+        ${If} $R5 == "1"
+          ClearErrors
+          RMDir "$R0"
+          IfErrors memmy_writable_probe_failed
+          StrCpy $R5 "0"
+        ${EndIf}
+        Push "1"
+        Return
+
+      memmy_writable_probe_close_failed:
+        FileClose $R3
+        StrCpy $R3 ""
+
+      memmy_writable_probe_cleanup_failed:
+        ClearErrors
+        ${If} $R2 != ""
+          Delete "$R2"
+        ${EndIf}
+        ${If} $R1 != ""
+          Delete "$R1"
+          RMDir "$R1"
+        ${EndIf}
+        ClearErrors
+
+      memmy_writable_probe_failed:
+        ${If} $R5 == "1"
+          ClearErrors
+          RMDir "$R0"
+        ${EndIf}
+        Push "0"
+    FunctionEnd
+
+    ; Keep the install-time preflight aligned with resolveMemmyDataRoot in the
+    ; desktop main process: retain existing legacy data, otherwise place new
+    ; data beside a non-system-drive installation.
+    Function MemmyResolveDataDirectory
+      ClearErrors
+      ReadEnvStr $R6 "MEMMY_HOME"
+      IfErrors memmy_data_no_explicit_home
+      StrCmp $R6 "" memmy_data_no_explicit_home
+      StrCmp $R6 "~" memmy_data_use_legacy
+      StrCpy $R7 $R6 2
+      StrCmp $R7 "~\" memmy_data_expand_explicit_home
+      StrCmp $R7 "~/" memmy_data_expand_explicit_home
+      Return
+
+      memmy_data_expand_explicit_home:
+        StrCpy $R7 $R6 "" 2
+        StrCpy $R6 "$PROFILE\$R7"
+        Return
+
+      memmy_data_no_explicit_home:
+      IfFileExists "$PROFILE\.memmy\*.*" memmy_data_use_legacy
+
+      ${GetRoot} "$INSTDIR" $R6
+      ${GetRoot} "$WINDIR" $R7
+      StrCmp $R6 "" memmy_data_use_legacy
+      StrCmp $R6 $R7 memmy_data_use_legacy
+      StrCpy $R6 "$R6\MemmyData\.memmy"
+      Return
+
+      memmy_data_use_legacy:
+        StrCpy $R6 "$PROFILE\.memmy"
+    FunctionEnd
+
+    Function MemmyValidateInstallDirectoryPage
+      GetDlgItem $0 $HWNDPARENT 1
+      EnableWindow $0 1
+
+      ${If} ${Silent}
+        Abort
+      ${EndIf}
+      ${If} ${isUpdated}
+        Abort
+      ${EndIf}
+
+      Call MemmyProbeInstallDirectory
+      Pop $1
+      StrCmp $1 "1" 0 memmy_install_directory_invalid
+
+      Call MemmyResolveDataDirectory
+      StrCpy $R0 "$R6"
+      Call MemmyProbeWritableDirectory
+      Pop $1
+      StrCmp $1 "1" 0 memmy_data_directory_invalid
+      Abort
+
+      memmy_install_directory_invalid:
+        StrCpy $3 "The selected directory is not writable.$\r$\n$\r$\nChoose a directory your Windows account can write to, such as D:\Memmy. To keep silent updates working, do not choose a directory that requires administrator permission, such as Program Files."
+        StrCmp $LANGUAGE ${MEMMY_LANG_SIMPCHINESE} 0 memmy_install_directory_create_page
+        StrCpy $3 "所选目录无法写入。$\r$\n$\r$\n请选择当前 Windows 账户可写入的目录，例如 D:\Memmy。为保证静默升级，请勿选择需要管理员权限的目录，例如 Program Files。"
+        Goto memmy_install_directory_create_page
+
+      memmy_data_directory_invalid:
+        StrCpy $3 "The Memmy data directory is not writable: $R6.$\r$\n$\r$\nChoose an installation drive whose root directory your Windows account can write to, or install Memmy on the Windows system drive."
+        StrCmp $LANGUAGE ${MEMMY_LANG_SIMPCHINESE} 0 memmy_install_directory_create_page
+        StrCpy $3 "Memmy 数据目录无法写入：$R6。$\r$\n$\r$\n请选择当前 Windows 账户可写入根目录的安装盘，或将 Memmy 安装到 Windows 系统盘。"
+
+      memmy_install_directory_create_page:
+        nsDialogs::Create 1018
+        Pop $2
+        StrCmp $2 error 0 memmy_install_directory_show
+        Abort
+
+      memmy_install_directory_show:
+        ${NSD_CreateLabel} 0 0 100% 70u "$3"
+        Pop $4
+        GetDlgItem $0 $HWNDPARENT 1
+        EnableWindow $0 0
+        nsDialogs::Show
+    FunctionEnd
+  !macroend
+!endif
 
 !ifndef BUILD_UNINSTALLER
   !macro customInstall

--- a/App/shell/desktop/src/main/main.ts
+++ b/App/shell/desktop/src/main/main.ts
@@ -73,13 +73,17 @@ import {
   opencodeBinaryCandidates
 } from "./agent-tool-terminal.js";
 import {
-  desktopRuntimeHomeDirectoryName,
   desktopUserDataDirectoryName,
   resolveDesktopEdition,
   resolveDesktopPackageSigning,
   type DesktopEdition,
   type DesktopPackageSigning
 } from "./desktop-edition.js";
+import {
+  applyMemmyDataRootEnvironment,
+  assertMemmyDataRootWritable,
+  resolveMemmyDataRoot
+} from "./memmy-data-root.js";
 import {
   getCurrentLogLevel,
   initLogger,
@@ -285,6 +289,7 @@ async function stopPackagedRendererServer(): Promise<void> {
  */
 async function boot(): Promise<void> {
   try {
+    await assertMemmyDataRootWritable(process.env.MEMMY_HOME!);
     process.env.MEMMY_APP_EDITION = resolveCurrentDesktopEdition();
     initLogger();
     forceLightWindowChrome();
@@ -332,19 +337,19 @@ async function boot(): Promise<void> {
  */
 function configureAppIdentity(): void {
   const edition = resolveCurrentDesktopEdition();
-  const memmyHome = join(homedir(), desktopRuntimeHomeDirectoryName(edition));
+  const dataRoot = resolveMemmyDataRoot({
+    platform: process.platform,
+    homeDirectory: homedir(),
+    executablePath: process.execPath,
+    isPackaged: app.isPackaged,
+    env: process.env
+  });
   app.setName("Memmy");
   if (process.platform === "win32") {
     app.setAppUserModelId(WINDOWS_APP_USER_MODEL_ID);
   }
   app.setPath("userData", join(app.getPath("appData"), desktopUserDataDirectoryName(edition)));
-  if (app.isPackaged) {
-    process.env.MEMMY_HOME = memmyHome;
-    process.env.MEMMY_CONFIG = join(memmyHome, "config.yaml");
-  } else {
-    process.env.MEMMY_HOME ??= memmyHome;
-    process.env.MEMMY_CONFIG ??= join(memmyHome, "config.yaml");
-  }
+  applyMemmyDataRootEnvironment(dataRoot);
 }
 
 /**
@@ -5103,7 +5108,8 @@ async function exportDiagnosticsReport(owner: BrowserWindow | null): Promise<Dia
 function buildDiagnosticsReport(): string {
   const logsDirectory = resolveLogsDirectory();
   const configPath = resolvePathValue(process.env.MEMMY_CONFIG ?? "~/.memmy/config.yaml");
-  const agentWorkspace = process.env.MEMMY_AGENT_WORKSPACE ?? join(homedir(), ".memmy", "workspace");
+  const agentWorkspace = process.env.MEMMY_AGENT_WORKSPACE ??
+    join(process.env.MEMMY_HOME ?? join(homedir(), ".memmy"), "workspace");
   const memoryDatabasePath = runtimeServices?.memory.databasePath ?? "<not-started>";
   const runtimeBaseUrl = runtimeConfig?.baseUrl ?? "<not-ready>";
   const agentGatewayBaseUrl = runtimeConfig?.agentGateway?.baseUrl ?? "<not-ready>";
@@ -5170,7 +5176,9 @@ async function resolveMemoryDatabasePathForExport(): Promise<string> {
 
   const configPath = resolvePathValue(process.env.MEMMY_CONFIG ?? "~/.memmy/config.yaml");
   const configuredPath = await readMemoryDatabasePathFromConfig(configPath);
-  return configuredPath ? resolvePathValue(configuredPath) : join(homedir(), ".memmy", "memory-service", "memory.sqlite");
+  return configuredPath
+    ? resolvePathValue(configuredPath)
+    : join(process.env.MEMMY_HOME ?? join(homedir(), ".memmy"), "memory-service", "memory.sqlite");
 }
 
 async function readMemoryDatabasePathFromConfig(configPath: string): Promise<string | null> {

--- a/App/shell/desktop/src/main/memmy-data-root.ts
+++ b/App/shell/desktop/src/main/memmy-data-root.ts
@@ -1,0 +1,90 @@
+import { randomUUID } from "node:crypto";
+import { existsSync } from "node:fs";
+import { mkdir, unlink, writeFile } from "node:fs/promises";
+import { posix, win32, type PlatformPath } from "node:path";
+
+type RuntimeEnv = Record<string, string | undefined>;
+
+export interface ResolveMemmyDataRootOptions {
+  platform: NodeJS.Platform;
+  homeDirectory: string;
+  executablePath: string;
+  isPackaged: boolean;
+  env: RuntimeEnv;
+  directoryExists?: (path: string) => boolean;
+}
+
+export const resolveMemmyDataRoot = (
+  options: ResolveMemmyDataRootOptions
+): string => {
+  const path = platformPath(options.platform);
+  const explicitRoot = options.env.MEMMY_HOME?.trim();
+  if (explicitRoot) {
+    return resolveHomePath(explicitRoot, options.homeDirectory, path);
+  }
+
+  const legacyRoot = path.join(options.homeDirectory, ".memmy");
+  if (options.platform !== "win32" || !options.isPackaged) {
+    return legacyRoot;
+  }
+
+  const directoryExists = options.directoryExists ?? existsSync;
+  if (directoryExists(legacyRoot)) {
+    return legacyRoot;
+  }
+
+  const installationRoot = win32.parse(options.executablePath).root;
+  const systemRoot = win32.parse(options.env.SystemDrive || options.homeDirectory).root;
+  if (!installationRoot || sameWindowsRoot(installationRoot, systemRoot)) {
+    return legacyRoot;
+  }
+
+  return win32.join(installationRoot, "MemmyData", ".memmy");
+};
+
+export const applyMemmyDataRootEnvironment = (
+  dataRoot: string,
+  env: RuntimeEnv = process.env,
+  platform: NodeJS.Platform = process.platform
+): void => {
+  const path = platformPath(platform);
+  env.MEMMY_HOME = dataRoot;
+  env.MEMMY_CONFIG = path.join(dataRoot, "config.yaml");
+  env.MEMMY_RUNTIME_CONFIG_PATH = path.join(dataRoot, "runtime.json");
+  env.MEMMY_AGENT_DATA_DIR = dataRoot;
+  env.MEMMY_AGENT_SESSION_DAG_DIR = path.join(dataRoot, "session-dag");
+};
+
+export const assertMemmyDataRootWritable = async (dataRoot: string): Promise<void> => {
+  const probePath = platformPath(process.platform).join(
+    dataRoot,
+    `.memmy-write-probe-${process.pid}-${randomUUID()}`
+  );
+  try {
+    await mkdir(dataRoot, { recursive: true });
+    await writeFile(probePath, "", { flag: "wx" });
+    await unlink(probePath);
+  } catch (error) {
+    await unlink(probePath).catch(() => undefined);
+    throw new Error(`Memmy data directory is not writable: ${dataRoot}`, { cause: error });
+  }
+};
+
+const platformPath = (platform: NodeJS.Platform): PlatformPath =>
+  platform === "win32" ? win32 : posix;
+
+const resolveHomePath = (
+  value: string,
+  homeDirectory: string,
+  path: PlatformPath
+): string => {
+  if (value === "~") return homeDirectory;
+  if (value.startsWith("~/") || value.startsWith("~\\")) {
+    return path.resolve(homeDirectory, value.slice(2));
+  }
+  return path.resolve(value);
+};
+
+const sameWindowsRoot = (left: string, right: string): boolean =>
+  left.replace(/[\\/]+$/u, "").toLowerCase() ===
+  right.replace(/[\\/]+$/u, "").toLowerCase();

--- a/App/shell/desktop/src/main/runtime-services.ts
+++ b/App/shell/desktop/src/main/runtime-services.ts
@@ -222,14 +222,38 @@ export async function preparePackagedRuntimeConfig(
     changed = true;
   }
   changed = repairMemoryActiveProfile(memmyMemory) || changed;
+  const legacyHome = resolvePath("~/.memmy");
   const defaultWorkspace = join(memmyHome, "workspace");
-  const configuredWorkspace = stringValue(defaults.workspace);
+  let configuredWorkspace = stringValue(defaults.workspace);
+  if (
+    configuredWorkspace &&
+    !samePath(memmyHome, legacyHome) &&
+    samePath(resolvePath(configuredWorkspace), join(legacyHome, "workspace"))
+  ) {
+    configuredWorkspace = defaultWorkspace;
+    defaults.workspace = defaultWorkspace;
+    changed = true;
+  }
+  const defaultMemoryDatabasePath = join(memmyHome, "memory-service", "memory.sqlite");
+  let configuredMemoryDatabasePath = stringValue(storage.sqlitePath);
+  if (
+    configuredMemoryDatabasePath &&
+    !samePath(memmyHome, legacyHome) &&
+    samePath(
+      resolvePath(configuredMemoryDatabasePath),
+      join(legacyHome, "memory-service", "memory.sqlite")
+    )
+  ) {
+    configuredMemoryDatabasePath = defaultMemoryDatabasePath;
+    storage.sqlitePath = defaultMemoryDatabasePath;
+    changed = true;
+  }
   const agentWorkspace = resolvePath(env.MEMMY_AGENT_WORKSPACE ?? configuredWorkspace ?? defaultWorkspace);
   const memoryDatabasePath = resolvePath(
     env.MEMMY_MEMORY_DB ??
       env.MEMORY_SERVICE_DB ??
-      stringValue(storage.sqlitePath) ??
-      join(memmyHome, "memory-service", "memory.sqlite")
+      configuredMemoryDatabasePath ??
+      defaultMemoryDatabasePath
   );
 
   changed = setMissing(storage, "mode", "local") || changed;
@@ -1255,6 +1279,12 @@ function numberValue(value: unknown): number | undefined {
 
 function resolvePath(path: string): string {
   return resolve(expandHome(path));
+}
+
+function samePath(left: string, right: string): boolean {
+  return process.platform === "win32"
+    ? left.toLowerCase() === right.toLowerCase()
+    : left === right;
 }
 
 function expandHome(path: string): string {

--- a/App/shell/desktop/tests/memmy-data-root.test.ts
+++ b/App/shell/desktop/tests/memmy-data-root.test.ts
@@ -1,0 +1,114 @@
+import { mkdir, mkdtemp, readdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  applyMemmyDataRootEnvironment,
+  assertMemmyDataRootWritable,
+  resolveMemmyDataRoot
+} from "../src/main/memmy-data-root.js";
+
+const tempRoots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempRoots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe("Memmy data root", () => {
+  it("keeps an explicit MEMMY_HOME override", () => {
+    expect(resolveMemmyDataRoot({
+      platform: "win32",
+      homeDirectory: "C:\\Users\\lee",
+      executablePath: "D:\\Apps\\Memmy\\Memmy.exe",
+      isPackaged: true,
+      env: { MEMMY_HOME: "E:\\MemmyCustom" },
+      directoryExists: () => false
+    })).toBe("E:\\MemmyCustom");
+  });
+
+  it("keeps macOS on ~/.memmy", () => {
+    expect(resolveMemmyDataRoot({
+      platform: "darwin",
+      homeDirectory: "/Users/lee",
+      executablePath: "/Applications/Memmy.app/Contents/MacOS/Memmy",
+      isPackaged: true,
+      env: {},
+      directoryExists: () => false
+    })).toBe("/Users/lee/.memmy");
+  });
+
+  it("prefers the existing Windows user directory", () => {
+    expect(resolveMemmyDataRoot({
+      platform: "win32",
+      homeDirectory: "C:\\Users\\lee",
+      executablePath: "D:\\Apps\\Memmy\\Memmy.exe",
+      isPackaged: true,
+      env: { SystemDrive: "C:" },
+      directoryExists: (path) => path === "C:\\Users\\lee\\.memmy"
+    })).toBe("C:\\Users\\lee\\.memmy");
+  });
+
+  it.each([true, false])(
+    "uses the non-system installation drive (target exists: %s)",
+    (targetExists) => {
+      expect(resolveMemmyDataRoot({
+        platform: "win32",
+        homeDirectory: "C:\\Users\\lee",
+        executablePath: "D:\\Apps\\Memmy\\Memmy.exe",
+        isPackaged: true,
+        env: { SystemDrive: "C:" },
+        directoryExists: (path) => targetExists && path === "D:\\MemmyData\\.memmy"
+      })).toBe("D:\\MemmyData\\.memmy");
+    }
+  );
+
+  it("uses the user directory for a system-drive or development launch", () => {
+    for (const input of [
+      { executablePath: "C:\\Program Files\\Memmy\\Memmy.exe", isPackaged: true },
+      { executablePath: "D:\\repo\\node.exe", isPackaged: false }
+    ]) {
+      expect(resolveMemmyDataRoot({
+        platform: "win32",
+        homeDirectory: "C:\\Users\\lee",
+        ...input,
+        env: { SystemDrive: "C:" },
+        directoryExists: () => false
+      })).toBe("C:\\Users\\lee\\.memmy");
+    }
+  });
+
+  it("exports every root-derived compatibility path", () => {
+    const env: Record<string, string | undefined> = {};
+    applyMemmyDataRootEnvironment("D:\\MemmyData\\.memmy", env, "win32");
+
+    expect(env).toEqual({
+      MEMMY_HOME: "D:\\MemmyData\\.memmy",
+      MEMMY_CONFIG: "D:\\MemmyData\\.memmy\\config.yaml",
+      MEMMY_RUNTIME_CONFIG_PATH: "D:\\MemmyData\\.memmy\\runtime.json",
+      MEMMY_AGENT_DATA_DIR: "D:\\MemmyData\\.memmy",
+      MEMMY_AGENT_SESSION_DAG_DIR: "D:\\MemmyData\\.memmy\\session-dag"
+    });
+  });
+
+  it("creates and verifies the selected root without leaving a probe file", async () => {
+    const parent = await mkdtemp(join(tmpdir(), "memmy-data-root-"));
+    tempRoots.push(parent);
+    const dataRoot = join(parent, "nested", ".memmy");
+
+    await assertMemmyDataRootWritable(dataRoot);
+
+    await expect(readdir(dataRoot)).resolves.toEqual([]);
+  });
+
+  it("reports the selected root when it is not writable", async () => {
+    const parent = await mkdtemp(join(tmpdir(), "memmy-data-root-"));
+    tempRoots.push(parent);
+    const blockingFile = join(parent, "blocked");
+    const dataRoot = join(blockingFile, ".memmy");
+    await mkdir(parent, { recursive: true });
+    await writeFile(blockingFile, "not a directory", "utf8");
+
+    await expect(assertMemmyDataRootWritable(dataRoot))
+      .rejects.toThrow(`Memmy data directory is not writable: ${dataRoot}`);
+  });
+});

--- a/App/shell/desktop/tests/packaged-runtime-boundary.test.ts
+++ b/App/shell/desktop/tests/packaged-runtime-boundary.test.ts
@@ -393,6 +393,44 @@ describe("desktop packaged runtime boundaries", () => {
     expect(includeSource).toContain("CRCCheck off");
   });
 
+  it("validates interactive Windows install directories before extraction", () => {
+    const signedBuilderConfig = readFileSync(winElectronBuilderPath, "utf8");
+    const unsignedBuilderConfig = readFileSync(winUnsignedBuilderPath, "utf8");
+    const includeSource = readFileSync(winUnsignedInstallerIncludePath, "utf8");
+
+    for (const builderConfig of [signedBuilderConfig, unsignedBuilderConfig]) {
+      expect(builderConfig).toContain("perMachine: false");
+      expect(builderConfig).toContain("allowElevation: false");
+      expect(builderConfig).toContain("allowToChangeInstallationDirectory: true");
+    }
+
+    expect(includeSource).toContain("!macro customPageAfterChangeDir");
+    expect(includeSource).toContain("Page custom MemmyValidateInstallDirectoryPage");
+    expect(includeSource).toContain("${Silent}");
+    expect(includeSource).toContain("${isUpdated}");
+    expect(includeSource).toContain("GetTempFileName");
+    expect(includeSource).toContain('CreateDirectory "$R0"');
+    expect(includeSource).toContain('StrCpy $R5 "1"');
+    expect(includeSource).toContain('RMDir "$R0"');
+    expect(includeSource).toContain("FileOpen");
+    expect(includeSource).toContain("FileWrite");
+    expect(includeSource).toContain("Delete");
+    expect(includeSource).toContain("RMDir");
+    expect(includeSource).toContain("Function MemmyResolveDataDirectory");
+    expect(includeSource).toContain('ReadEnvStr $R6 "MEMMY_HOME"');
+    expect(includeSource).toContain('StrCmp $R6 "~" memmy_data_use_legacy');
+    expect(includeSource).toContain('${GetRoot} "$INSTDIR" $R6');
+    expect(includeSource).toContain('StrCpy $R6 "$PROFILE\\.memmy"');
+    expect(includeSource).toContain('StrCpy $R6 "$R6\\MemmyData\\.memmy"');
+    expect(includeSource).toContain("Call MemmyResolveDataDirectory");
+    expect(includeSource).toContain("Call MemmyProbeWritableDirectory");
+    expect(includeSource).toContain("The Memmy data directory is not writable");
+    expect(includeSource).toContain("Memmy 数据目录无法写入");
+    expect(includeSource).toContain("EnableWindow $0 0");
+    expect(includeSource).toContain("D:\\Memmy");
+    expect(includeSource).toContain("Program Files");
+  });
+
   it("adds packaged Windows CLI launchers to the user PATH", () => {
     const signedBuilderConfig = readFileSync(winElectronBuilderPath, "utf8");
     const unsignedBuilderConfig = readFileSync(winUnsignedBuilderPath, "utf8");
@@ -511,7 +549,9 @@ describe("desktop packaged runtime boundaries", () => {
     expect(exportSource).not.toContain("filters:");
     expect(exportSource).not.toContain("All Files");
     expect(source).toContain('import { backupSqliteDatabase } from "./sqlite-backup.js"');
-    expect(source).toContain('join(homedir(), ".memmy", "memory-service", "memory.sqlite")');
+    expect(source).toContain(
+      'join(process.env.MEMMY_HOME ?? join(homedir(), ".memmy"), "memory-service", "memory.sqlite")'
+    );
   });
 
   it("saves and copies generated images through native desktop APIs", () => {
@@ -592,6 +632,9 @@ describe("desktop packaged runtime boundaries", () => {
     expect(agentPackage.bin).toEqual({ memmy: "./dist/main.js" });
     expect(agentPackageLock.packages?.[""]?.bin).toEqual({ memmy: "dist/main.js" });
     expect(mainSource).toContain('const memmyCli = join(cliDirectory, "memmy")');
+    expect(mainSource).toContain("resolveMemmyDataRoot({");
+    expect(mainSource).toContain("applyMemmyDataRootEnvironment(dataRoot)");
+    expect(mainSource).toContain("await assertMemmyDataRootWritable(process.env.MEMMY_HOME!)");
     expect(mainSource).toContain('await Promise.all([access(memoryCli), access(memmyCli)])');
     expect(mainSource).toContain('installSymlink(memmyCli, join(binDirectory, "memmy"))');
     expect(mainSource).not.toContain(['join(cliDirectory, "', 'memmy-agent', '")'].join(""));
@@ -602,6 +645,9 @@ describe("desktop packaged runtime boundaries", () => {
     expect(windowsPackageSource).toContain('create_windows_cli_launcher "$CLI_BIN_DIR/memmy.cmd"');
     expect(windowsPackageSource).toContain('for %%I in ("%RESOURCES_DIR%\\..") do set "APP_DIR=%%~fI"');
     expect(windowsPackageSource).toContain('set "APP_EXEC=%APP_DIR%\\Memmy.exe"');
+    expect(windowsPackageSource).toContain('if exist "%USERPROFILE%\\.memmy"');
+    expect(windowsPackageSource).toContain('set "MEMMY_HOME=%APP_DRIVE%\\MemmyData\\.memmy"');
+    expect(windowsPackageSource).toContain('set "MEMMY_CONFIG=%MEMMY_HOME%\\config.yaml"');
     expect(windowsPackageSource).not.toContain('set "APP_EXEC=%RESOURCES_DIR%\\Memmy.exe"');
     expect(windowsPackageSource).not.toContain(['create_windows_cli_launcher "$CLI_BIN_DIR/', 'memmy-agent', '.cmd"'].join(""));
   });

--- a/App/shell/desktop/tests/runtime-services.test.ts
+++ b/App/shell/desktop/tests/runtime-services.test.ts
@@ -2,7 +2,7 @@ import { type ChildProcess } from "node:child_process";
 import { EventEmitter } from "node:events";
 import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { createServer, type Server } from "node:http";
-import { tmpdir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import YAML from "yaml";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -163,6 +163,37 @@ describe("packaged desktop runtime config", () => {
     });
     await expect(stat(join(memmyHome, "workspace"))).resolves.toBeTruthy();
     await expect(stat(join(memmyHome, "memory-service"))).resolves.toBeTruthy();
+  });
+
+  it("rebases copied legacy default paths to the selected data root", async () => {
+    const memmyHome = await makeTempRoot();
+    const configPath = join(memmyHome, "config.yaml");
+    await writeFile(configPath, YAML.stringify({
+      agents: {
+        defaults: {
+          workspace: join(homedir(), ".memmy", "workspace")
+        }
+      },
+      memmyMemory: {
+        storage: {
+          sqlitePath: join(homedir(), ".memmy", "memory-service", "memory.sqlite")
+        }
+      }
+    }), "utf8");
+
+    const runtime = await preparePackagedRuntimeConfig({
+      ensureDirectories: false,
+      env: { MEMMY_HOME: memmyHome },
+      secretFactory: () => "stable-secret"
+    });
+    const config = await readYaml(configPath);
+
+    expect(runtime.agentWorkspace).toBe(join(memmyHome, "workspace"));
+    expect(runtime.memoryDatabasePath).toBe(join(memmyHome, "memory-service", "memory.sqlite"));
+    expect(recordValue(recordValue(config, "agents"), "defaults").workspace)
+      .toBe(join(memmyHome, "workspace"));
+    expect(recordValue(recordValue(config, "memmyMemory"), "storage").sqlitePath)
+      .toBe(join(memmyHome, "memory-service", "memory.sqlite"));
   });
 
   it("preserves existing user model, memory, and websocket settings", async () => {

--- a/Memory/src/cli/config.ts
+++ b/Memory/src/cli/config.ts
@@ -50,7 +50,7 @@ export function loadCliMemoryConfig(configPath?: string): {
 export function defaultConfigPaths(): string[] {
   return [
     process.env.MEMMY_CONFIG ? resolve(expandHome(process.env.MEMMY_CONFIG)) : undefined,
-    join(homedir(), ".memmy", "config.yaml")
+    join(resolve(process.env.MEMMY_HOME?.trim() || join(homedir(), ".memmy")), "config.yaml")
   ].filter((value): value is string => Boolean(value));
 }
 

--- a/Memory/src/cli/setup.ts
+++ b/Memory/src/cli/setup.ts
@@ -34,7 +34,7 @@ export interface MemoryCliSetupOptions {
 }
 
 export async function initMemoryCli(options: MemoryCliSetupOptions = {}): Promise<Record<string, unknown>> {
-  const home = resolve(expandHome(options.home ?? "~/.memmy"));
+  const home = resolve(expandHome(options.home ?? process.env.MEMMY_HOME ?? "~/.memmy"));
   const configPath = resolve(expandHome(options.configPath ?? join(home, "config.yaml")));
   const dbPath = resolve(expandHome(options.dbPath ?? join(home, "memory-service", "memory.sqlite")));
   const endpoint = options.endpoint ?? "http://127.0.0.1:18960";
@@ -75,7 +75,7 @@ export async function initMemoryCli(options: MemoryCliSetupOptions = {}): Promis
 }
 
 export async function installMemoryCli(options: MemoryCliSetupOptions = {}): Promise<Record<string, unknown>> {
-  const home = resolve(expandHome(options.home ?? "~/.memmy"));
+  const home = resolve(expandHome(options.home ?? process.env.MEMMY_HOME ?? "~/.memmy"));
   const binPath = resolve(expandHome(options.binPath ?? join(home, "bin", "memmy-memory")));
   const source = resolve(expandHome(options.sourcePath ?? join(process.cwd(), "dist", "src", "cli", "index.js")));
 

--- a/Memory/src/config/index.ts
+++ b/Memory/src/config/index.ts
@@ -244,6 +244,13 @@ const ACCOUNT_EVOLUTION_THINKING_BUDGET = 1_000;
 const ASYNC_EVOLUTION_TIMEOUT_MS = 3 * 60_000;
 export const MEMORY_SUMMARY_MAX_TOKENS = 512;
 
+export function resolveMemmyHome(
+  env: Record<string, string | undefined> = process.env,
+  homeDirectory: string = homedir()
+): string {
+  return resolve(env.MEMMY_HOME?.trim() || join(homeDirectory, ".memmy"));
+}
+
 export const DEFAULT_MEMMY_CONFIG: MemmyConfig = {
   version: 1,
   domain: "",
@@ -251,7 +258,7 @@ export const DEFAULT_MEMMY_CONFIG: MemmyConfig = {
   storage: {
     mode: "local",
     backend: "sqlite",
-    sqlitePath: join(homedir(), ".memmy", "memory-service", "memory.sqlite"),
+    sqlitePath: join(resolveMemmyHome(), "memory-service", "memory.sqlite"),
     endpoint: "http://127.0.0.1:18960",
     token: undefined
   },
@@ -443,7 +450,7 @@ export const DEFAULT_MEMMY_CONFIG: MemmyConfig = {
 export function defaultConfigPaths(): string[] {
   return [
     process.env.MEMMY_CONFIG,
-    join(homedir(), ".memmy", "config.yaml")
+    join(resolveMemmyHome(), "config.yaml")
   ].filter((value): value is string => Boolean(value));
 }
 

--- a/Memory/src/model/embedder.ts
+++ b/Memory/src/model/embedder.ts
@@ -1,6 +1,5 @@
-import { homedir } from "node:os";
 import { join } from "node:path";
-import type { EmbeddingConfig } from "../config/index.js";
+import { resolveMemmyHome, type EmbeddingConfig } from "../config/index.js";
 import { createMemoryLogger, memoryErrorFields } from "../logging/logger.js";
 import { stableHash } from "../utils/id.js";
 import { bearer, postJsonWithRetry, trimTrailingSlash } from "./http.js";
@@ -306,7 +305,7 @@ async function ensureLocalExtractor(model: string): Promise<FeatureExtractor> {
   localExtractorPromise = (async () => {
     const mod = await import("@huggingface/transformers");
     const transformers = mod as unknown as TransformersModule;
-    transformers.env.cacheDir = join(homedir(), ".memmy", "memory-service", "model-cache");
+    transformers.env.cacheDir = join(resolveMemmyHome(), "memory-service", "model-cache");
     const pipeline = transformers.pipeline;
     return await pipeline("feature-extraction", model, {
       dtype: "q8",

--- a/Memory/src/model/token-usage.ts
+++ b/Memory/src/model/token-usage.ts
@@ -1,7 +1,7 @@
 import { existsSync, readFileSync } from "node:fs";
-import { homedir } from "node:os";
 import { join } from "node:path";
 import { randomUUID } from "node:crypto";
+import { resolveMemmyHome } from "../config/index.js";
 
 export type MemoryLlmModelRole = "memory_summary" | "memory_evolution";
 export type MemoryTokenUsageKind = MemoryLlmModelRole | "embedding";
@@ -45,7 +45,7 @@ const EVENT_PATH = "/api/app/byok-token-usage/events";
 const RUNTIME_TOKEN_HEADER = "x-memmy-local-token";
 
 export function resolveDefaultRuntimeConfigPath(): string {
-  return join(homedir(), ".memmy", "runtime.json");
+  return join(resolveMemmyHome(), "runtime.json");
 }
 
 export function extractModelTokenUsage(response: unknown): ModelTokenUsage {

--- a/Memory/src/storage/db.ts
+++ b/Memory/src/storage/db.ts
@@ -1,8 +1,8 @@
 import Database from "better-sqlite3";
 import { existsSync, mkdirSync } from "node:fs";
 import { dirname, join } from "node:path";
-import { homedir } from "node:os";
 import { getLoadablePath as getSqliteVecLoadablePath } from "sqlite-vec";
+import { resolveMemmyHome } from "../config/index.js";
 import { getSchemaVersion, migrate, SCHEMA_VERSION } from "./schema.js";
 import { SQLITE_VEC_VERSION } from "./sqlite-vec-store.js";
 
@@ -74,6 +74,6 @@ export function defaultDatabasePath(): string {
   const baseDir =
     process.env.MEMMY_MEMORY_HOME ??
     process.env.MEMORY_SERVICE_HOME ??
-    join(homedir(), ".memmy", "memory-service");
+    join(resolveMemmyHome(), "memory-service");
   return join(baseDir, "memory.sqlite");
 }

--- a/Memory/tests/config.test.ts
+++ b/Memory/tests/config.test.ts
@@ -299,14 +299,14 @@ describe("memmy memory config", () => {
     expect(config.evolution.thinkingBudget).toBeUndefined();
   });
 
-  it("uses only MEMMY_CONFIG and the default config.yaml candidate", () => {
+  it("uses MEMMY_CONFIG and the MEMMY_HOME config.yaml candidate", () => {
     const root = tempRoot();
     setEnv("MEMMY_CONFIG", join(root, "custom.yaml"));
     setEnv("MEMMY_HOME", join(root, "ignored-home"));
 
     expect(defaultConfigPaths()).toEqual([
       join(root, "custom.yaml"),
-      join(homedir(), ".memmy", "config.yaml")
+      join(root, "ignored-home", "config.yaml")
     ]);
   });
 });

--- a/docs/cn/help/faq.mdx
+++ b/docs/cn/help/faq.mdx
@@ -11,4 +11,6 @@ icon: MessageCircleQuestionMark
 
 先运行 Memory 服务，再安装 CLI，然后 为 Codex、Cursor、Claude Code、Opencode、OpenClaw 或 Hermes 安装对应 Skill。
 
-默认在 `~/.memmy` 下，包括配置、workspace、Memory SQLite 数据库和运行时文件。 扫描和入库都在本地完成，记忆写入本地 SQLite。是否参与「记忆改进计划」由隐私设置中的开关显式控制。
+默认在 `~/.memmy` 下，包括配置、workspace、Memory SQLite 数据库和运行时文件。Windows 新安装到非系统盘且用户目录下没有 `.memmy` 时，数据位于安装盘根目录的 `MemmyData\.memmy`，例如 `D:\MemmyData\.memmy`。扫描和入库都在本地完成，记忆写入本地 SQLite。是否参与「记忆改进计划」由隐私设置中的开关显式控制。
+
+已有 Windows 用户可以手动迁移：先完全退出 Memmy（包括托盘和后台进程），把整个 `%USERPROFILE%\.memmy` 复制到应用安装磁盘创建MemmyData目录下，比如安装在D盘 `D:\MemmyData\.memmy`，再把原目录改名为备份后启动 Memmy。原目录仍存在时 Memmy 会继续优先使用它；请确认项目、会话和记忆数据都正常后再删除备份。

--- a/docs/en/help/faq.mdx
+++ b/docs/en/help/faq.mdx
@@ -21,4 +21,6 @@ First run the Memory service, then install the CLI, and finally install the corr
 
 **Where is my data stored? Does scanning upload it?**
 
-Everything defaults to `~/.memmy`, including config, workspace, the Memory SQLite database, and runtime files. Scanning and ingestion happen entirely locally, with memories written to local SQLite. Participation in the "memory improvement program" is explicitly controlled by a toggle in privacy settings.
+Everything defaults to `~/.memmy`, including config, workspace, the Memory SQLite database, and runtime files. On Windows, a fresh installation on a non-system drive uses `MemmyData\.memmy` at that drive's root when no legacy `.memmy` directory exists in the user profile, for example `D:\MemmyData\.memmy`. Scanning and ingestion happen entirely locally, with memories written to local SQLite. Participation in the "memory improvement program" is explicitly controlled by a toggle in privacy settings.
+
+To migrate an existing Windows installation manually, fully quit Memmy (including its tray and background processes), copy the entire `%USERPROFILE%\.memmy` directory to `D:\MemmyData\.memmy`, then rename the original directory as a backup before starting Memmy. Memmy deliberately keeps using the original while it still exists. Delete the backup only after verifying that projects, conversations, and Memory data are available from the new location.

--- a/scripts/internal/package-win-x64.sh
+++ b/scripts/internal/package-win-x64.sh
@@ -311,7 +311,24 @@ if not exist "%APP_EXEC%" (
   exit /b 1
 )
 
-if not defined MEMMY_CONFIG if exist "%USERPROFILE%\.memmy\config.yaml" set "MEMMY_CONFIG=%USERPROFILE%\.memmy\config.yaml"
+if defined MEMMY_HOME goto memmy_home_ready
+if exist "%USERPROFILE%\.memmy" (
+  set "MEMMY_HOME=%USERPROFILE%\.memmy"
+  goto memmy_home_ready
+)
+for %%I in ("%APP_DIR%") do set "APP_DRIVE=%%~dI"
+if not defined SystemDrive for %%I in ("%USERPROFILE%") do set "SystemDrive=%%~dI"
+if /I not "%APP_DRIVE%"=="%SystemDrive%" (
+  set "MEMMY_HOME=%APP_DRIVE%\MemmyData\.memmy"
+  goto memmy_home_ready
+)
+set "MEMMY_HOME=%USERPROFILE%\.memmy"
+
+:memmy_home_ready
+if not defined MEMMY_CONFIG set "MEMMY_CONFIG=%MEMMY_HOME%\config.yaml"
+if not defined MEMMY_RUNTIME_CONFIG_PATH set "MEMMY_RUNTIME_CONFIG_PATH=%MEMMY_HOME%\runtime.json"
+if not defined MEMMY_AGENT_DATA_DIR set "MEMMY_AGENT_DATA_DIR=%MEMMY_HOME%"
+if not defined MEMMY_AGENT_SESSION_DAG_DIR set "MEMMY_AGENT_SESSION_DAG_DIR=%MEMMY_HOME%\session-dag"
 set "ELECTRON_RUN_AS_NODE=1"
 if not defined NODE_ENV set "NODE_ENV=production"
 


### PR DESCRIPTION
## Summary
- relocate new packaged Windows data roots beside non-system-drive installs
- propagate the resolved Memmy data root across desktop, backend, agent, and Memory services
- validate both install and data-directory writability in interactive NSIS installs
- keep silent updates and existing legacy data behavior unchanged

## Verification
- 116 targeted tests passed
- full workspace typecheck passed
- actual unsigned Windows package and final NSIS rebuild passed
- full Memory suite has the same 14 Windows EPERM failures on clean upstream/v1.0.5 (2 symlink permissions, 12 temp SQLite cleanup permissions)