### PR TITLE
fix: preserve YAML runtime modules in desktop packages

### DIFF
--- a/App/shell/desktop/electron-builder.unsigned.yml
+++ b/App/shell/desktop/electron-builder.unsigned.yml
@@ -13,6 +13,7 @@ files:
   - "!**/node_modules/**/{test,tests,__tests__,doc,docs,example,examples,coverage,.github}/**/*"
   - "!**/node_modules/**/*.{test,spec}.*"
   - "!**/node_modules/**/{README,README*.md,README*.mdown,README*.markdown,README*.rst,README*.txt,CHANGELOG,CHANGELOG*.md,CHANGELOG*.mdown,CHANGELOG*.markdown,CHANGELOG*.rst,CHANGELOG*.txt,CONTRIBUTING,CONTRIBUTING*.md,CONTRIBUTING*.mdown,CONTRIBUTING*.markdown,CONTRIBUTING*.rst,CONTRIBUTING*.txt,CODE_OF_CONDUCT,CODE_OF_CONDUCT*.md,CODE_OF_CONDUCT*.mdown,CODE_OF_CONDUCT*.markdown,CODE_OF_CONDUCT*.rst,CODE_OF_CONDUCT*.txt,SECURITY,SECURITY*.md,SECURITY*.mdown,SECURITY*.markdown,SECURITY*.rst,SECURITY*.txt}"
+  - "!**/node_modules/**/*.map"
 
 asar: true
 asarUnpack:
@@ -37,6 +38,10 @@ extraResources:
     to: .env
 
 mac:
+  files:
+    - from: .
+      filter:
+        - "**/node_modules/yaml/dist/doc/*.js"
   icon: build/icon.icns
   category: public.app-category.productivity
   extendInfo:

--- a/App/shell/desktop/electron-builder.win.unsigned.yml
+++ b/App/shell/desktop/electron-builder.win.unsigned.yml
@@ -13,6 +13,7 @@ files:
   - "!**/node_modules/**/{test,tests,__tests__,doc,docs,example,examples,coverage,.github}/**/*"
   - "!**/node_modules/**/*.{test,spec}.*"
   - "!**/node_modules/**/{README,README*.md,README*.mdown,README*.markdown,README*.rst,README*.txt,CHANGELOG,CHANGELOG*.md,CHANGELOG*.mdown,CHANGELOG*.markdown,CHANGELOG*.rst,CHANGELOG*.txt,CONTRIBUTING,CONTRIBUTING*.md,CONTRIBUTING*.mdown,CONTRIBUTING*.markdown,CONTRIBUTING*.rst,CONTRIBUTING*.txt,CODE_OF_CONDUCT,CODE_OF_CONDUCT*.md,CODE_OF_CONDUCT*.mdown,CODE_OF_CONDUCT*.markdown,CODE_OF_CONDUCT*.rst,CODE_OF_CONDUCT*.txt,SECURITY,SECURITY*.md,SECURITY*.mdown,SECURITY*.markdown,SECURITY*.rst,SECURITY*.txt}"
+  - "!**/node_modules/**/*.map"
 
 asar: true
 asarUnpack:
@@ -35,6 +36,10 @@ extraResources:
     to: icon.ico
 
 win:
+  files:
+    - from: .
+      filter:
+        - "**/node_modules/yaml/dist/doc/*.js"
   icon: build/icon.ico
   target:
     - target: nsis

--- a/App/shell/desktop/electron-builder.win.yml
+++ b/App/shell/desktop/electron-builder.win.yml
@@ -13,6 +13,7 @@ files:
   - "!**/node_modules/**/{test,tests,__tests__,doc,docs,example,examples,coverage,.github}/**/*"
   - "!**/node_modules/**/*.{test,spec}.*"
   - "!**/node_modules/**/{README,README*.md,README*.mdown,README*.markdown,README*.rst,README*.txt,CHANGELOG,CHANGELOG*.md,CHANGELOG*.mdown,CHANGELOG*.markdown,CHANGELOG*.rst,CHANGELOG*.txt,CONTRIBUTING,CONTRIBUTING*.md,CONTRIBUTING*.mdown,CONTRIBUTING*.markdown,CONTRIBUTING*.rst,CONTRIBUTING*.txt,CODE_OF_CONDUCT,CODE_OF_CONDUCT*.md,CODE_OF_CONDUCT*.mdown,CODE_OF_CONDUCT*.markdown,CODE_OF_CONDUCT*.rst,CODE_OF_CONDUCT*.txt,SECURITY,SECURITY*.md,SECURITY*.mdown,SECURITY*.markdown,SECURITY*.rst,SECURITY*.txt}"
+  - "!**/node_modules/**/*.map"
 
 asar: true
 asarUnpack:
@@ -35,6 +36,10 @@ extraResources:
     to: icon.ico
 
 win:
+  files:
+    - from: .
+      filter:
+        - "**/node_modules/yaml/dist/doc/*.js"
   icon: build/icon.ico
   target:
     - target: nsis

--- a/App/shell/desktop/electron-builder.yml
+++ b/App/shell/desktop/electron-builder.yml
@@ -13,6 +13,7 @@ files:
   - "!**/node_modules/**/{test,tests,__tests__,doc,docs,example,examples,coverage,.github}/**/*"
   - "!**/node_modules/**/*.{test,spec}.*"
   - "!**/node_modules/**/{README,README*.md,README*.mdown,README*.markdown,README*.rst,README*.txt,CHANGELOG,CHANGELOG*.md,CHANGELOG*.mdown,CHANGELOG*.markdown,CHANGELOG*.rst,CHANGELOG*.txt,CONTRIBUTING,CONTRIBUTING*.md,CONTRIBUTING*.mdown,CONTRIBUTING*.markdown,CONTRIBUTING*.rst,CONTRIBUTING*.txt,CODE_OF_CONDUCT,CODE_OF_CONDUCT*.md,CODE_OF_CONDUCT*.mdown,CODE_OF_CONDUCT*.markdown,CODE_OF_CONDUCT*.rst,CODE_OF_CONDUCT*.txt,SECURITY,SECURITY*.md,SECURITY*.mdown,SECURITY*.markdown,SECURITY*.rst,SECURITY*.txt}"
+  - "!**/node_modules/**/*.map"
 
 asar: true
 asarUnpack:
@@ -37,6 +38,10 @@ extraResources:
     to: .env
 
 mac:
+  files:
+    - from: .
+      filter:
+        - "**/node_modules/yaml/dist/doc/*.js"
   icon: build/icon.icns
   category: public.app-category.productivity
   extendInfo:

--- a/App/shell/desktop/tests/packaged-runtime-boundary.test.ts
+++ b/App/shell/desktop/tests/packaged-runtime-boundary.test.ts
@@ -14,6 +14,9 @@ const signedMacArm64PackagePath = fileURLToPath(
   new URL("../../../../scripts/internal/package-mac-arm64-signed-base.sh", import.meta.url)
 );
 const packageWinX64Path = fileURLToPath(new URL("../../../../scripts/internal/package-win-x64.sh", import.meta.url));
+const verifyPackagedYamlRuntimePath = fileURLToPath(
+  new URL("../../../../scripts/internal/verify-packaged-yaml-runtime.mjs", import.meta.url)
+);
 const winX64CnUnsignedPackagePath = fileURLToPath(
   new URL("../../../../scripts/package-win-x64-cn-unsigned.sh", import.meta.url)
 );
@@ -243,6 +246,8 @@ describe("desktop packaged runtime boundaries", () => {
     ]) {
       const config = parseYaml(readFileSync(configPath, "utf8")) as {
         files?: string[];
+        mac?: { files?: Array<{ filter?: string[]; from?: string }> };
+        win?: { files?: Array<{ filter?: string[]; from?: string }> };
       };
       const files = config.files ?? [];
 
@@ -254,6 +259,11 @@ describe("desktop packaged runtime boundaries", () => {
         "!**/node_modules/**/{README,README*.md,README*.mdown,README*.markdown,README*.rst,README*.txt,CHANGELOG,CHANGELOG*.md,CHANGELOG*.mdown,CHANGELOG*.markdown,CHANGELOG*.rst,CHANGELOG*.txt,CONTRIBUTING,CONTRIBUTING*.md,CONTRIBUTING*.mdown,CONTRIBUTING*.markdown,CONTRIBUTING*.rst,CONTRIBUTING*.txt,CODE_OF_CONDUCT,CODE_OF_CONDUCT*.md,CODE_OF_CONDUCT*.mdown,CODE_OF_CONDUCT*.markdown,CODE_OF_CONDUCT*.rst,CODE_OF_CONDUCT*.txt,SECURITY,SECURITY*.md,SECURITY*.mdown,SECURITY*.markdown,SECURITY*.rst,SECURITY*.txt}"
       );
       expect(files).not.toContain("!**/node_modules/**/*.md");
+      expect(files).toContain("!**/node_modules/**/*.map");
+      const platformFileSets = config.win?.files ?? config.mac?.files ?? [];
+      expect(platformFileSets).toEqual([
+        { from: ".", filter: ["**/node_modules/yaml/dist/doc/*.js"] }
+      ]);
     }
   });
 
@@ -1049,6 +1059,7 @@ describe("desktop packaged runtime boundaries", () => {
     expect(source).toContain('prune_node_modules_non_runtime_files "$RUNTIME_DIR"');
     expect(source).toContain("-name tests");
     expect(source).toContain("-name docs");
+    expect(source).toContain('! -path "*/node_modules/yaml/dist/doc"');
     expect(source).toContain('-iname "README*.md"');
     expect(source).toContain('-iname "README*.mdown"');
     expect(source).toContain('-iname "CHANGELOG*.md"');
@@ -1063,6 +1074,21 @@ describe("desktop packaged runtime boundaries", () => {
     expect(source.indexOf('prune_node_modules_non_runtime_files "$RUNTIME_DIR"')).toBeLessThan(
       source.indexOf("npx electron-builder"),
     );
+  });
+
+  it("verifies YAML Document runtime modules in packaged app archives", () => {
+    const macSource = readFileSync(packageMacDmgPath, "utf8");
+    const winSource = readFileSync(packageWinX64Path, "utf8");
+    const verifierSource = readFileSync(verifyPackagedYamlRuntimePath, "utf8");
+
+    for (const source of [macSource, winSource]) {
+      expect(source).toContain("verify-packaged-yaml-runtime.mjs");
+      expect(source).toContain("app.asar");
+    }
+    expect(verifierSource).toContain("listPackage");
+    expect(verifierSource).toContain("yaml/dist/compose/composer.js");
+    expect(verifierSource).toContain("yaml/dist/doc/directives.js");
+    expect(verifierSource).toContain("yaml/dist/doc/Document.js");
   });
 
   it("sets an explicit edition in macOS package wrappers", () => {

--- a/scripts/internal/package-mac-dmg.sh
+++ b/scripts/internal/package-mac-dmg.sh
@@ -456,7 +456,7 @@ prune_node_modules_non_runtime_files() {
         -name examples -o \
         -name coverage -o \
         -name .github \
-      \) > "$disposable_list"
+      \) ! -path "*/node_modules/yaml/dist/doc" > "$disposable_list"
 
     local disposable_dir
     while IFS= read -r disposable_dir; do
@@ -576,8 +576,10 @@ verify_packaged_mac_unpacked_artifacts() {
   local app_path
   app_path="$(resolve_packaged_mac_app_path "$target_cpu")"
   local unpacked_runtime="$app_path/Contents/Resources/app.asar.unpacked/dist/runtime"
+  local app_asar="$app_path/Contents/Resources/app.asar"
 
-  require_packaged_runtime_file "$app_path/Contents/Resources/app.asar"
+  require_packaged_runtime_file "$app_asar"
+  node "$ROOT_DIR/scripts/internal/verify-packaged-yaml-runtime.mjs" "$app_asar"
   require_packaged_runtime_glob "$unpacked_runtime/memory/node_modules/onnxruntime-node/bin/napi-v3/darwin/$target_cpu/libonnxruntime*.dylib"
   require_packaged_runtime_glob "$unpacked_runtime/memory/node_modules/@img/sharp-libvips-darwin-$target_cpu/lib/libvips*.dylib"
   require_packaged_runtime_file "$unpacked_runtime/memmy-agent/node_modules/@memmy/migrations/dist/index.js"

--- a/scripts/internal/package-win-x64.sh
+++ b/scripts/internal/package-win-x64.sh
@@ -444,8 +444,10 @@ verify_windows_agent_native_artifacts() {
 
 verify_packaged_windows_unpacked_artifacts() {
   local unpacked_runtime="$DESKTOP_DIR/release/win-unpacked/resources/app.asar.unpacked/dist/runtime"
+  local app_asar="$DESKTOP_DIR/release/win-unpacked/resources/app.asar"
 
-  require_packaged_runtime_file "$DESKTOP_DIR/release/win-unpacked/resources/app.asar"
+  require_packaged_runtime_file "$app_asar"
+  node "$ROOT_DIR/scripts/internal/verify-packaged-yaml-runtime.mjs" "$app_asar"
   require_packaged_runtime_file "$unpacked_runtime/memory/node_modules/onnxruntime-node/bin/napi-v3/win32/x64/onnxruntime.dll"
   require_packaged_runtime_glob "$unpacked_runtime/memory/node_modules/onnxruntime-node/bin/napi-v3/win32/x64/*.dll"
   require_packaged_runtime_glob "$unpacked_runtime/memory/node_modules/@img/sharp-win32-x64/lib/libvips*.dll"

--- a/scripts/internal/verify-packaged-yaml-runtime.mjs
+++ b/scripts/internal/verify-packaged-yaml-runtime.mjs
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+
+import { listPackage } from "@electron/asar";
+
+const asarPath = process.argv[2];
+if (!asarPath) {
+  throw new Error("Usage: verify-packaged-yaml-runtime.mjs <app.asar>");
+}
+
+const entries = new Set(
+  listPackage(asarPath).map((entry) => entry.replaceAll("\\", "/"))
+);
+const composerSuffix = "/node_modules/yaml/dist/compose/composer.js";
+const requiredRuntimeSuffixes = [
+  "/node_modules/yaml/dist/doc/directives.js",
+  "/node_modules/yaml/dist/doc/Document.js"
+];
+const composerPaths = [...entries].filter((entry) => entry.endsWith(composerSuffix));
+
+if (composerPaths.length === 0) {
+  throw new Error(`No packaged yaml/dist/compose/composer.js entries found in ${asarPath}`);
+}
+
+const missing = [];
+for (const composerPath of composerPaths) {
+  const packagePrefix = composerPath.slice(0, -composerSuffix.length);
+  for (const runtimeSuffix of requiredRuntimeSuffixes) {
+    const requiredPath = `${packagePrefix}${runtimeSuffix}`;
+    if (!entries.has(requiredPath)) {
+      missing.push(requiredPath);
+    }
+  }
+}
+
+if (missing.length > 0) {
+  throw new Error(
+    `Missing YAML Document runtime modules in ${asarPath}:\n${missing.join("\n")}`
+  );
+}
+
+console.log(`Verified YAML Document runtime modules for ${composerPaths.length} packaged copies.`);


### PR DESCRIPTION
## Summary
- restore only `yaml/dist/doc/*.js` after the generic third-party docs exclusion in all desktop builder variants
- keep macOS runtime pruning from deleting YAML's runtime Document module
- exclude third-party source maps so the fix reduces rather than increases package size
- fail Windows/macOS packaging when any packaged YAML copy lacks required Document runtime modules

## Verification
- packaged archive: 4 composer copies, 4 directives copies, 4 Document copies, 0 node_modules source maps
- packaged `Memmy.exe` loaded YAML from `app.asar` and parsed a document successfully
- required native runtime DLL/Node addon/migrations artifacts remain present
- app.asar: 964,159,678 -> 761,047,617 bytes (-203,112,061)
- installer: 299,242,822 -> 272,922,035 bytes (-26,320,787)
- packaged-runtime-boundary tests: 49 passed
- full workspace typecheck passed
- Windows and macOS packaging shell syntax checks passed
- final review found no Critical or Important issues