### PR TITLE
docs: expose Memmy changelog pages

### DIFF
--- a/docs/cn/changelog.mdx
+++ b/docs/cn/changelog.mdx
@@ -1,0 +1,7 @@
+---
+title: Memmy 更新日志
+description: Memmy Desktop、Agent、Memory 与 CLI 的最新更新
+full: true
+---
+
+<MemmyChangelog locale="cn" />

--- a/docs/cn/meta.json
+++ b/docs/cn/meta.json
@@ -23,6 +23,8 @@
     "---[Shield]安全---",
     "...security",
     "---[CircleQuestionMark]帮助---",
-    "...help"
+    "...help",
+    "---[History]发布---",
+    "changelog"
   ]
 }

--- a/docs/en/changelog.mdx
+++ b/docs/en/changelog.mdx
@@ -1,0 +1,7 @@
+---
+title: Memmy changelog
+description: The latest updates to Memmy Desktop, Agent, Memory, and CLI
+full: true
+---
+
+<MemmyChangelog locale="en" />

--- a/docs/en/meta.json
+++ b/docs/en/meta.json
@@ -22,6 +22,8 @@
     "---[Shield]Security---",
     "...security",
     "---[CircleQuestionMark]Help---",
-    "...help"
+    "...help",
+    "---[History]Releases---",
+    "changelog"
   ]
 }


### PR DESCRIPTION
## 目标

在 Memmy 中英文文档导航中暴露 Changelog 页面入口。本 PR 只新增 MDX 入口和导航，不包含发布自动化。

## 依赖与合并顺序

这是阶段 C，**不要先合并**：

1. 先合并 Changelog 数据 PR。
2. 再合并并验证 memmy-web 页面 MR。
3. 国内/国际静态预发布通过后，最后合并本 PR。

如果前两步尚未完成，本 PR 合并后文档站可能无法解析 Changelog 组件或数据。

## 变更范围

- 新增 `docs/cn/changelog.mdx`
- 新增 `docs/en/changelog.mdx`
- 在中英文 `meta.json` 增加导航入口

## 安全边界

- [ ] 不自动合并
- [ ] 不触发 production
- [ ] 不启用 Webhook、106 Doc Agent 或自动 Publish
