### PR TITLE
fix(desktop): keep conversation composer growing and scrollable

### DIFF
--- a/App/frontend/desktop/src/pages/home-page.tsx
+++ b/App/frontend/desktop/src/pages/home-page.tsx
@@ -1511,6 +1511,13 @@ export function HomePage() {
     });
   }
 
+  useLayoutEffect(() => {
+    if (!inputRef.current) {
+      return;
+    }
+    resizeComposerInput(inputRef.current);
+  }, [input, hasActiveConversation]);
+
   /**
    * Resets the input box height after sending, so the next empty input does not inherit the previous height.
    */

--- a/App/frontend/desktop/src/pages/tests/home-page.test.tsx
+++ b/App/frontend/desktop/src/pages/tests/home-page.test.tsx
@@ -472,6 +472,13 @@ describe("HomePage", () => {
     expect(computed.lineHeight).toBe("24px");
     expect(computed.paddingTop).toBe("14px");
     expect(computed.paddingBottom).toBe("14px");
+    // Must stay scrollable if wrapped content briefly lags behind single-line detection.
+    expect(computed.overflowY).toBe("auto");
+  });
+
+  it("resyncs composer height when the draft or conversation chrome changes", () => {
+    const source = readFileSync(homePageSourcePath, "utf8");
+    expect(source).toContain("useLayoutEffect(() => {\n    if (!inputRef.current) {\n      return;\n    }\n    resizeComposerInput(inputRef.current);\n  }, [input, hasActiveConversation]);");
   });
 
   it("applies the composer single-line treatment only while the textarea is one line", () => {

--- a/App/frontend/desktop/src/styles.css
+++ b/App/frontend/desktop/src/styles.css
@@ -2217,12 +2217,14 @@ button {
   padding: 12px 16px 4px;
 }
 
-/* Keep this more specific than `.agent-composer-shell textarea` above so its generic line-height cannot shift the caret. */
+/* Keep this more specific than `.agent-composer-shell textarea` above so its generic line-height cannot shift the caret.
+   Keep overflow-y:auto (not hidden): if single-line detection lags behind wrapped content, the field must stay scrollable. */
 .agent-composer-shell textarea.agent-composer-input--single {
   height: 52px;
   padding-top: 14px;
   padding-bottom: 14px;
-  overflow: hidden;
+  overflow-x: hidden;
+  overflow-y: auto;
   line-height: 24px;
 }
 


### PR DESCRIPTION
Resync textarea height on draft/chrome changes, and stop locking single-line mode behind overflow:hidden so wrapped input is not clipped.