### PR TITLE
fix(openai-api): report turn token usage

### DIFF
--- a/App/memmy-agent/src/core/agent-runtime/loop.ts
+++ b/App/memmy-agent/src/core/agent-runtime/loop.ts
@@ -62,6 +62,7 @@ type AgentLoopResult = [
   hadInjections: boolean,
   finalContentStreamed: boolean,
   errorCategory: ProviderErrorCategory | null,
+  usage: Record<string, any>,
 ];
 
 export enum TurnState {
@@ -102,6 +103,7 @@ export class TurnContext {
   finalContent: string | null = null;
   finalContentStreamed = false;
   errorCategory: ProviderErrorCategory | null = null;
+  usage: Record<string, any> = {};
   toolsUsed: string[] = [];
   allMessages: Record<string, any>[] = [];
   stopReason = "";
@@ -1647,7 +1649,8 @@ export class AgentLoop {
         injectionCallback: ({ limit = 3 } = {}) => this.drainPendingQueue(pendingQueue, limit, session?.key ?? sessionKey),
       }),
     );
-    this.lastUsage = normalizeUsageRecord(result.usage ?? result.response?.usage);
+    const turnUsage = normalizeUsageRecord(result.usage ?? result.response?.usage);
+    this.lastUsage = turnUsage;
     const toolsUsed = (result.toolCalls ?? []).map((call: any) => call?.function?.name ?? call?.name).filter(Boolean);
     return [
       result.finalContent ?? result.content ?? EMPTY_FINAL_RESPONSE_MESSAGE,
@@ -1657,6 +1660,7 @@ export class AgentLoop {
       Boolean(result.hadInjections),
       Boolean(result.finalContentStreamed),
       result.response?.errorCategory ?? null,
+      turnUsage,
     ];
   }
 
@@ -1666,11 +1670,12 @@ export class AgentLoop {
     allMessages: Record<string, any>[],
     stopReason: string,
     hadInjections: boolean,
-    { turnLatencyMs = null, tools = null, finalContentStreamed = false, errorCategory = null }: {
+    { turnLatencyMs = null, tools = null, finalContentStreamed = false, errorCategory = null, usage = null }: {
       turnLatencyMs?: number | null;
       tools?: ToolRegistryInstance | null;
       finalContentStreamed?: boolean;
       errorCategory?: ProviderErrorCategory | null;
+      usage?: Record<string, any> | null;
     } = {},
   ): OutboundMessage | null {
     void allMessages;
@@ -1687,6 +1692,7 @@ export class AgentLoop {
         ...(finalContentStreamed && !["error", "toolError"].includes(stopReason) ? { streamed: true } : {}),
         ...(turnLatencyMs != null ? { latencyMs: Math.trunc(turnLatencyMs) } : {}),
         ...(errorCategory === "quota_exhausted" ? { modelErrorCategory: errorCategory } : {}),
+        ...(usage ? { usage } : {}),
       },
     });
   }
@@ -1824,7 +1830,7 @@ export class AgentLoop {
   }
 
   async stateRun(ctx: TurnContext): Promise<string> {
-    const [finalContent, toolsUsed, allMessages, stopReason, hadInjections, finalContentStreamed, errorCategory] = await this.runAgentLoop(ctx.initialMessages, {
+    const [finalContent, toolsUsed, allMessages, stopReason, hadInjections, finalContentStreamed, errorCategory, usage] = await this.runAgentLoop(ctx.initialMessages, {
       onProgress: ctx.onProgress,
       onStream: ctx.onStream,
       onStreamEnd: ctx.onStreamEnd,
@@ -1859,6 +1865,7 @@ export class AgentLoop {
     ctx.hadInjections = hadInjections;
     ctx.finalContentStreamed = finalContentStreamed;
     ctx.errorCategory = errorCategory;
+    ctx.usage = usage;
     return "ok";
   }
 
@@ -1891,6 +1898,7 @@ export class AgentLoop {
       tools: ctx.tools,
       finalContentStreamed: ctx.finalContentStreamed,
       errorCategory: ctx.errorCategory,
+      usage: ctx.usage,
     });
     return "ok";
   }

--- a/App/memmy-agent/src/entrypoints/openai-like-api/server.ts
+++ b/App/memmy-agent/src/entrypoints/openai-like-api/server.ts
@@ -26,11 +26,33 @@ type ApiContext = {
   sessionLocks: Map<string, Promise<void>>;
 };
 
+type ChatCompletionUsage = {
+  prompt_tokens: number;
+  completion_tokens: number;
+  total_tokens: number;
+};
+
 export function errorJson(status: number, message: string, errType = "invalid_request_error"): Response {
   return Response.json({ error: { message, type: errType, code: status } }, { status });
 }
 
-export function chatCompletionResponse(content: string, model: string): Record<string, any> {
+function tokenCount(value: any): number | null {
+  if (value == null || value === "") return null;
+  const count = Number(value);
+  return Number.isFinite(count) && count >= 0 ? Math.trunc(count) : null;
+}
+
+function normalizeChatUsage(usage: Record<string, any> | null | undefined): ChatCompletionUsage {
+  const promptTokens = tokenCount(usage?.prompt_tokens) ?? 0;
+  const completionTokens = tokenCount(usage?.completion_tokens) ?? 0;
+  return {
+    prompt_tokens: promptTokens,
+    completion_tokens: completionTokens,
+    total_tokens: tokenCount(usage?.total_tokens) ?? promptTokens + completionTokens,
+  };
+}
+
+export function chatCompletionResponse(content: string, model: string, usage?: Record<string, any>): Record<string, any> {
   return {
     id: `chatcmpl-${crypto.randomUUID().slice(0, 12)}`,
     object: "chat.completion",
@@ -43,7 +65,7 @@ export function chatCompletionResponse(content: string, model: string): Record<s
         finish_reason: "stop",
       },
     ],
-    usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
+    usage: normalizeChatUsage(usage),
   };
 }
 
@@ -51,6 +73,21 @@ function responseText(value: any): string {
   if (value == null) return "";
   if (typeof value?.content === "string") return value.content;
   return String(value);
+}
+
+function responseUsage(value: any): Record<string, any> {
+  const usage = value?.metadata?.usage;
+  return usage && typeof usage === "object" && !Array.isArray(usage) ? usage : {};
+}
+
+function mergeUsageRecords(left: Record<string, any>, right: Record<string, any>): ChatCompletionUsage {
+  const leftUsage = normalizeChatUsage(left);
+  const rightUsage = normalizeChatUsage(right);
+  return {
+    prompt_tokens: leftUsage.prompt_tokens + rightUsage.prompt_tokens,
+    completion_tokens: leftUsage.completion_tokens + rightUsage.completion_tokens,
+    total_tokens: leftUsage.total_tokens + rightUsage.total_tokens,
+  };
 }
 
 export function sseChunk(delta: string, model: string, chunkId: string, finishReason: string | null = null): string {
@@ -328,14 +365,16 @@ export async function handleChatCompletions(request: Request, ctx?: ApiContext):
     const reply = await withSessionLock(context, sessionKey, async () => {
       const first = await withTimeout(Promise.resolve(callAgent(context, baseArgs)), context.requestTimeout);
       let textResponse = responseText(first);
+      let usage = responseUsage(first);
       if (!textResponse.trim()) {
         const retry = await withTimeout(Promise.resolve(callAgent(context, baseArgs)), context.requestTimeout);
         textResponse = responseText(retry);
+        usage = mergeUsageRecords(usage, responseUsage(retry));
         if (!textResponse.trim()) textResponse = EMPTY_FINAL_RESPONSE_MESSAGE;
       }
-      return textResponse;
+      return { text: textResponse, usage };
     });
-    return Response.json(chatCompletionResponse(reply, context.modelName));
+    return Response.json(chatCompletionResponse(reply.text, context.modelName, reply.usage));
   } catch (err) {
     const message = (err as Error).message ?? "";
     if (message.startsWith("Request timed out")) return errorJson(504, message);

--- a/App/memmy-agent/tests/core/agent-runtime/loop-runner-integration.test.ts
+++ b/App/memmy-agent/tests/core/agent-runtime/loop-runner-integration.test.ts
@@ -107,6 +107,29 @@ describe("AgentLoop direct processing", () => {
     });
   });
 
+  it("attaches each turn's accumulated usage to its own outbound message", async () => {
+    const agent = loop();
+    const usages = [
+      { prompt_tokens: 120, completion_tokens: 45, total_tokens: 165 },
+      { prompt_tokens: 30, completion_tokens: 8, total_tokens: 38 },
+    ];
+    let calls = 0;
+    agent.runner.run = vi.fn(async () =>
+      new AgentRunResult({
+        finalContent: "done",
+        messages: [{ role: "assistant", content: "done" }],
+        stopReason: "completed",
+        usage: usages[calls++],
+      }));
+
+    const first = await agent.processDirect("first", { sessionKey: "cli:usage-a" });
+    const second = await agent.processDirect("second", { sessionKey: "cli:usage-b" });
+
+    expect(first?.metadata.usage).toEqual(usages[0]);
+    expect(second?.metadata.usage).toEqual(usages[1]);
+    expect(agent.lastUsage).toEqual(usages[1]);
+  });
+
   it("publishes a thread session update after early-persisting WebUI user messages", async () => {
     const p = provider(["web answer"]);
     const agent = loop(p);

--- a/App/memmy-agent/tests/entrypoints/openai-like-api/openai-api.test.ts
+++ b/App/memmy-agent/tests/entrypoints/openai-like-api/openai-api.test.ts
@@ -56,6 +56,16 @@ describe("OpenAI-compatible API response helpers", () => {
     expect(result.choices[0].message.content).toBe("hello world");
     expect(result.choices[0].finish_reason).toBe("stop");
     expect(result.id).toMatch(/^chatcmpl-/);
+    expect(result.usage).toEqual({ prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 });
+  });
+
+  it("reports normalized usage when the agent supplied it", () => {
+    const result = chatCompletionResponse("hello world", "test-model", {
+      prompt_tokens: "12.9",
+      completion_tokens: 7,
+    });
+
+    expect(result.usage).toEqual({ prompt_tokens: 12, completion_tokens: 7, total_tokens: 19 });
   });
 });
 
@@ -156,6 +166,25 @@ describe("OpenAI-compatible API routing", () => {
       channel: "api",
       chat_id: API_CHAT_ID,
     });
+  });
+
+  it("propagates the turn usage carried by the agent outbound message", async () => {
+    const app = createApp(
+      {
+        processDirect: async () => ({
+          content: "metered response",
+          metadata: { usage: { prompt_tokens: 42, completion_tokens: 17, total_tokens: 59 } },
+        }),
+      },
+      "test-model",
+    );
+
+    const response = await app.fetch(request({ messages: [{ role: "user", content: "hello" }] }));
+    const body = (await response.json()) as any;
+
+    expect(response.status).toBe(200);
+    expect(body.choices[0].message.content).toBe("metered response");
+    expect(body.usage).toEqual({ prompt_tokens: 42, completion_tokens: 17, total_tokens: 59 });
   });
 
   it("uses the same fixed session key across follow-up requests", async () => {
@@ -305,6 +334,34 @@ describe("OpenAI-compatible API routing", () => {
     const fallbackResponse = await fallback.fetch(request({ messages: [{ role: "user", content: "hello" }] }));
     expect(((await fallbackResponse.json()) as any).choices[0].message.content).toBe(EMPTY_FINAL_RESPONSE_MESSAGE);
     expect(fallbackCalls).toBe(2);
+  });
+
+  it("sums usage from both calls when an empty response is retried", async () => {
+    let calls = 0;
+    const app = createApp(
+      {
+        processDirect: async () => {
+          calls += 1;
+          return calls === 1
+            ? {
+                content: "",
+                metadata: { usage: { prompt_tokens: 20, completion_tokens: 0, total_tokens: 20 } },
+              }
+            : {
+                content: "recovered",
+                metadata: { usage: { prompt_tokens: 25, completion_tokens: 9, total_tokens: 34 } },
+              };
+        },
+      },
+      "m",
+    );
+
+    const response = await app.fetch(request({ messages: [{ role: "user", content: "hello" }] }));
+    const body = (await response.json()) as any;
+
+    expect(calls).toBe(2);
+    expect(body.choices[0].message.content).toBe("recovered");
+    expect(body.usage).toEqual({ prompt_tokens: 45, completion_tokens: 9, total_tokens: 54 });
   });
 
   it("forwards media paths through AgentLoop.processDirect", async () => {


### PR DESCRIPTION
## Summary

- Supersedes #8 with a clean, one-commit branch from current `main`; the old PR remains open.
- Carries each AgentRunner turn's accumulated usage through AgentLoop outbound metadata to non-streaming `/v1/chat/completions` responses.
- Normalizes the three OpenAI usage counters and accumulates them if an empty first completion is retried.

## Root cause

The API response constructed its `usage` object as three hard-coded zeroes even though the agent runtime had already accumulated provider usage for the completed turn.

## Compatibility and scope

- Missing usage still produces the existing all-zero usage object.
- Streaming behavior is intentionally unchanged; this PR fixes the three hard-coded fields in normal chat-completion responses only.
- The branch changes four files and does not include the unrelated upstream/rebase history present in #8.

## Validation

- Targeted OpenAI API and AgentLoop integration tests: 36 passed.
- Full agent suite: 4,628 passed, 3 skipped.
- Root lint, typecheck, build, and test suites passed.
- Built API HTTP check: `/health` returned OK and `/v1/chat/completions` returned usage `42 / 17 / 59` from a local provider stub.

Supersedes #8.
