### PR TITLE
feat(desktop): localize startup splash

### DIFF
--- a/App/shell/desktop/src/main/main.ts
+++ b/App/shell/desktop/src/main/main.ts
@@ -89,6 +89,11 @@ import {
 } from "./logger.js";
 import { persistSharedAnalyticsClientId } from "./analytics-client-id-store.js";
 import { backupSqliteDatabase } from "./sqlite-backup.js";
+import {
+  resolveStartupSplashHtml,
+  resolveStartupSplashLanguage,
+  type StartupSplashLanguage
+} from "./startup-splash.js";
 
 let mainWindow: BrowserWindow | null = null;
 let petWindow: BrowserWindow | null = null;
@@ -1315,7 +1320,7 @@ async function writeWindowsUpdatePromptLanguage(language: WindowsUpdatePromptLan
 async function ensureWindowsUpdatePromptLanguageFile(): Promise<string> {
   const languagePath = resolveWindowsUpdatePromptLanguagePath();
   if (!existsSync(languagePath)) {
-    await writeWindowsUpdatePromptLanguage(resolveDefaultWindowsUpdatePromptLanguage());
+    await writeWindowsUpdatePromptLanguage(resolveDefaultDesktopDisplayLanguage());
   }
   return languagePath;
 }
@@ -1335,15 +1340,15 @@ function resolveWindowsUpdatePromptLanguageFromAppSettings(): WindowsUpdatePromp
     void writePackagedStartupLog(`windows-update-prompt-language-failed:${String(error)}`);
   }
 
-  return resolveDefaultWindowsUpdatePromptLanguage();
+  return resolveDefaultDesktopDisplayLanguage();
 }
 
 /**
- * Windows update prompt language used when the app has no explicitly selected language.
+ * Display language used before the app settings are available.
  *
  * @returns The default display language of the current edition.
  */
-function resolveDefaultWindowsUpdatePromptLanguage(): WindowsUpdatePromptLanguage {
+function resolveDefaultDesktopDisplayLanguage(): StartupSplashLanguage {
   return resolveCurrentDesktopEdition() === "intl" ? "en-US" : "zh-CN";
 }
 
@@ -3113,23 +3118,6 @@ let splashCloseTimer: ReturnType<typeof setTimeout> | null = null;
 const SPLASH_MAX_VISIBLE_MS = 15 * 1000;
 
 /**
- * The splash page HTML (purely static, inline data URL, no extra files or preload needed).
- *
- * @returns The splash HTML string.
- */
-function resolveSplashHtml(): string {
-  return `<!doctype html><html><head><meta charset="utf-8"><style>
-html,body{margin:0;height:100%;overflow:hidden;font-family:-apple-system,"Segoe UI",sans-serif;}
-body{display:flex;align-items:center;justify-content:center;background:#1f2937;color:#f9fafb;-webkit-user-select:none;cursor:default;}
-.box{display:flex;flex-direction:column;align-items:center;gap:16px;}
-.title{font-size:22px;font-weight:600;letter-spacing:1px;}
-.hint{font-size:13px;color:#9ca3af;}
-.spinner{width:28px;height:28px;border:3px solid rgba(255,255,255,.2);border-top-color:#34d399;border-radius:50%;animation:spin .8s linear infinite;}
-@keyframes spin{to{transform:rotate(360deg);}}
-</style></head><body><div class="box"><div class="spinner"></div><div class="title">Memmy</div><div class="hint">正在启动…</div></div></body></html>`;
-}
-
-/**
  * Shows the startup splash. Only called on the normal boot path; creation failures do not affect the boot flow.
  *
  * @returns Nothing.
@@ -3160,7 +3148,11 @@ function showSplashWindow(): void {
         splash.show();
       }
     });
-    void splash.loadURL(`data:text/html;charset=utf-8,${encodeURIComponent(resolveSplashHtml())}`);
+    const language = resolveStartupSplashLanguage(
+      join(app.getPath("userData"), "app.sqlite"),
+      resolveDefaultDesktopDisplayLanguage()
+    );
+    void splash.loadURL(`data:text/html;charset=utf-8,${encodeURIComponent(resolveStartupSplashHtml(language))}`);
     splashCloseTimer = setTimeout(closeSplashWindow, SPLASH_MAX_VISIBLE_MS);
     splashCloseTimer.unref?.();
   } catch (error) {

--- a/App/shell/desktop/src/main/startup-splash.ts
+++ b/App/shell/desktop/src/main/startup-splash.ts
@@ -1,0 +1,39 @@
+import { existsSync } from "node:fs";
+import { DatabaseSync } from "node:sqlite";
+
+export type StartupSplashLanguage = "zh-CN" | "en-US";
+
+export function resolveStartupSplashLanguage(
+  databasePath: string,
+  fallback: StartupSplashLanguage
+): StartupSplashLanguage {
+  if (!existsSync(databasePath)) {
+    return fallback;
+  }
+
+  let database: DatabaseSync | null = null;
+  try {
+    database = new DatabaseSync(databasePath, { readOnly: true });
+    const row = database
+      .prepare("SELECT language FROM app_settings WHERE id = 'default'")
+      .get() as { language?: unknown } | undefined;
+    return row?.language === "zh-CN" || row?.language === "en-US" ? row.language : fallback;
+  } catch {
+    return fallback;
+  } finally {
+    database?.close();
+  }
+}
+
+export function resolveStartupSplashHtml(language: StartupSplashLanguage): string {
+  const hint = language === "en-US" ? "Starting…" : "正在启动…";
+  return `<!doctype html><html><head><meta charset="utf-8"><style>
+html,body{margin:0;height:100%;overflow:hidden;font-family:-apple-system,"Segoe UI",sans-serif;}
+body{display:flex;align-items:center;justify-content:center;background:#1f2937;color:#f9fafb;-webkit-user-select:none;cursor:default;}
+.box{display:flex;flex-direction:column;align-items:center;gap:16px;}
+.title{font-size:22px;font-weight:600;letter-spacing:1px;}
+.hint{font-size:13px;color:#9ca3af;}
+.spinner{width:28px;height:28px;border:3px solid rgba(255,255,255,.2);border-top-color:#34d399;border-radius:50%;animation:spin .8s linear infinite;}
+@keyframes spin{to{transform:rotate(360deg);}}
+</style></head><body><div class="box"><div class="spinner"></div><div class="title">Memmy</div><div class="hint">${hint}</div></div></body></html>`;
+}

--- a/App/shell/desktop/tests/startup-splash.test.ts
+++ b/App/shell/desktop/tests/startup-splash.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import {
+  resolveStartupSplashHtml,
+  resolveStartupSplashLanguage,
+  type StartupSplashLanguage
+} from "../src/main/startup-splash.js";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe("startup splash localization", () => {
+  it.each<StartupSplashLanguage>(["zh-CN", "en-US"])("reads the persisted %s application language", (language) => {
+    const databasePath = createSettingsDatabase(language);
+
+    expect(resolveStartupSplashLanguage(databasePath, language === "zh-CN" ? "en-US" : "zh-CN")).toBe(language);
+  });
+
+  it.each(["system", "fr-FR", null])("falls back for an unsupported or missing setting: %s", (language) => {
+    const databasePath = createSettingsDatabase(language);
+
+    expect(resolveStartupSplashLanguage(databasePath, "en-US")).toBe("en-US");
+  });
+
+  it("falls back when the database table or file is unavailable", () => {
+    const directory = createTemporaryDirectory();
+    const emptyDatabasePath = join(directory, "empty.sqlite");
+    new DatabaseSync(emptyDatabasePath).close();
+
+    expect(resolveStartupSplashLanguage(emptyDatabasePath, "zh-CN")).toBe("zh-CN");
+    expect(resolveStartupSplashLanguage(join(directory, "missing.sqlite"), "en-US")).toBe("en-US");
+  });
+
+  it("renders only the selected language hint", () => {
+    const englishHtml = resolveStartupSplashHtml("en-US");
+    const chineseHtml = resolveStartupSplashHtml("zh-CN");
+
+    expect(englishHtml).toContain("Starting…");
+    expect(englishHtml).not.toContain("正在启动…");
+    expect(chineseHtml).toContain("正在启动…");
+    expect(chineseHtml).not.toContain("Starting…");
+  });
+});
+
+function createSettingsDatabase(language: string | null): string {
+  const databasePath = join(createTemporaryDirectory(), "app.sqlite");
+  const database = new DatabaseSync(databasePath);
+  database.exec("CREATE TABLE app_settings (id TEXT PRIMARY KEY, language TEXT NOT NULL)");
+  if (language !== null) {
+    database.prepare("INSERT INTO app_settings (id, language) VALUES ('default', ?)").run(language);
+  }
+  database.close();
+  return databasePath;
+}
+
+function createTemporaryDirectory(): string {
+  const directory = mkdtempSync(join(tmpdir(), "memmy-startup-splash-"));
+  temporaryDirectories.push(directory);
+  return directory;
+}


### PR DESCRIPTION
## Summary

- localize the pre-backend Electron startup splash for Chinese and English
- read the persisted app language from `app.sqlite` without creating or migrating it
- fall back to the CN/Intl edition language when the setting is `system` or unavailable
- keep the existing splash visuals and lifecycle unchanged

## Verification

- `npm --prefix App/shell/desktop exec -- vitest run tests/startup-splash.test.ts tests/dev-cli-launcher.test.ts` (14 passed)
- `npm test -w @memmy/desktop` (160 passed)
- `npm run typecheck -w @memmy/desktop`
- manual CN and Intl launches: responsive Electron window, correct edition marker, and localized startup hint resolution