### PR TITLE
fix(onboarding): hide first-report wrapper tags

### DIFF
--- a/App/backend/src/services/onboarding-insight-service.ts
+++ b/App/backend/src/services/onboarding-insight-service.ts
@@ -38,6 +38,11 @@ const GENERATED_REPORT_OPEN = "<memmy_report>";
 const GENERATED_REPORT_CLOSE = "</memmy_report>";
 const GENERATED_TASK_CONTEXT_OPEN = "<memmy_task_context>";
 const GENERATED_TASK_CONTEXT_CLOSE = "</memmy_task_context>";
+const GENERATED_REPORT_ALIAS_OPEN = "<report>";
+const GENERATED_REPORT_ALIAS_CLOSE = "</report>";
+const GENERATED_TASK_CONTEXT_ALIAS_OPEN = "<taskContext>";
+const GENERATED_TASK_CONTEXT_ALIAS_CLOSE = "</taskContext>";
+const GENERATED_REPORT_OPEN_MARKERS = [GENERATED_REPORT_OPEN, GENERATED_REPORT_ALIAS_OPEN] as const;
 const GENERATED_NAKED_JSON_OPEN = "\n{";
 const GENERATED_JSON_FENCE_OPEN = "\n```json";
 
@@ -871,11 +876,19 @@ function parseGeneratedFirstReport(
     return null;
   }
 
-  const reportStart = normalized.indexOf(GENERATED_REPORT_OPEN);
-  const reportContentStart = reportStart >= 0 ? reportStart + GENERATED_REPORT_OPEN.length : 0;
-  const contextSection = findGeneratedTaskContext(normalized);
-  const reportClose = normalized.indexOf(GENERATED_REPORT_CLOSE, reportContentStart);
-  const reportEnd = [reportClose, contextSection?.start ?? -1]
+  const reportOpen = findGeneratedReportOpen(normalized);
+  const reportContentStart = reportOpen ? reportOpen.index + reportOpen.marker.length : 0;
+  const reportCloseMarker = reportOpen?.marker === GENERATED_REPORT_ALIAS_OPEN
+    ? GENERATED_REPORT_ALIAS_CLOSE
+    : GENERATED_REPORT_CLOSE;
+  const reportClose = reportOpen
+    ? findFirstGeneratedMarker(normalized, [reportCloseMarker], reportContentStart)
+    : null;
+  const contextSection = findGeneratedTaskContext(
+    normalized,
+    reportClose ? reportClose.index + reportClose.marker.length : null
+  );
+  const reportEnd = [reportClose?.index ?? -1, contextSection?.start ?? -1]
     .filter((index) => index >= reportContentStart)
     .sort((left, right) => left - right)[0] ?? normalized.length;
 
@@ -892,14 +905,31 @@ function parseGeneratedFirstReport(
   return { reportMarkdown, taskContext };
 }
 
-function findGeneratedTaskContext(output: string): { start: number; taskContext: OnboardingTaskContextSummary | null } | null {
-  const taggedStart = output.indexOf(GENERATED_TASK_CONTEXT_OPEN);
-  if (taggedStart >= 0) {
-    const contentStart = taggedStart + GENERATED_TASK_CONTEXT_OPEN.length;
-    const taggedEnd = output.indexOf(GENERATED_TASK_CONTEXT_CLOSE, contentStart);
+function findGeneratedReportOpen(output: string): { index: number; marker: string } | null {
+  if (output.startsWith(GENERATED_REPORT_ALIAS_OPEN)) {
+    return { index: 0, marker: GENERATED_REPORT_ALIAS_OPEN };
+  }
+  return findFirstGeneratedMarker(output, [GENERATED_REPORT_OPEN]);
+}
+
+function findGeneratedTaskContext(
+  output: string,
+  aliasSearchStart: number | null
+): { start: number; taskContext: OnboardingTaskContextSummary | null } | null {
+  const canonical = findFirstGeneratedMarker(output, [GENERATED_TASK_CONTEXT_OPEN]);
+  const alias = aliasSearchStart === null
+    ? null
+    : findFirstGeneratedMarker(output, [GENERATED_TASK_CONTEXT_ALIAS_OPEN], aliasSearchStart);
+  const taggedStart = !canonical || (alias && alias.index < canonical.index) ? alias : canonical;
+  if (taggedStart) {
+    const contentStart = taggedStart.index + taggedStart.marker.length;
+    const closeMarker = taggedStart.marker === GENERATED_TASK_CONTEXT_ALIAS_OPEN
+      ? GENERATED_TASK_CONTEXT_ALIAS_CLOSE
+      : GENERATED_TASK_CONTEXT_CLOSE;
+    const taggedEnd = findFirstGeneratedMarker(output, [closeMarker], contentStart);
     return {
-      start: taggedStart,
-      taskContext: parseGeneratedTaskContext(output.slice(contentStart, taggedEnd >= 0 ? taggedEnd : output.length))
+      start: taggedStart.index,
+      taskContext: parseGeneratedTaskContext(output.slice(contentStart, taggedEnd?.index ?? output.length))
     };
   }
 
@@ -1095,6 +1125,7 @@ function renderFallbackTrajectory(input: {
 class FirstReportStreamParser {
   private mode: "prefix" | "report" | "hidden" | "plain" = "prefix";
   private buffer = "";
+  private reportCloseMarker: string = GENERATED_REPORT_CLOSE;
 
   push(delta: string): string[] {
     if (this.mode === "hidden") {
@@ -1103,10 +1134,11 @@ class FirstReportStreamParser {
     this.buffer += delta;
     if (this.mode === "prefix") {
       const candidate = this.buffer.trimStart();
-      if (!candidate || GENERATED_REPORT_OPEN.startsWith(candidate)) {
+      const reportOpen = findLeadingGeneratedMarker(candidate, GENERATED_REPORT_OPEN_MARKERS);
+      if (!candidate || (!reportOpen && isGeneratedMarkerPrefix(candidate, GENERATED_REPORT_OPEN_MARKERS))) {
         return [];
       }
-      if (!candidate.startsWith(GENERATED_REPORT_OPEN)) {
+      if (!reportOpen) {
         this.mode = "plain";
         return this.drainVisibleText([
           GENERATED_TASK_CONTEXT_OPEN,
@@ -1116,7 +1148,10 @@ class FirstReportStreamParser {
         ]);
       }
       this.mode = "report";
-      this.buffer = candidate.slice(GENERATED_REPORT_OPEN.length);
+      this.reportCloseMarker = reportOpen === GENERATED_REPORT_ALIAS_OPEN
+        ? GENERATED_REPORT_ALIAS_CLOSE
+        : GENERATED_REPORT_CLOSE;
+      this.buffer = candidate.slice(reportOpen.length);
     }
     return this.mode === "plain"
       ? this.drainVisibleText([
@@ -1126,7 +1161,7 @@ class FirstReportStreamParser {
           GENERATED_NAKED_JSON_OPEN
         ])
       : this.drainVisibleText([
-          GENERATED_REPORT_CLOSE,
+          this.reportCloseMarker,
           GENERATED_TASK_CONTEXT_OPEN,
           GENERATED_JSON_FENCE_OPEN,
           GENERATED_NAKED_JSON_OPEN
@@ -1137,24 +1172,23 @@ class FirstReportStreamParser {
     if (this.mode === "prefix" || this.mode === "report" || this.mode === "plain") {
       const remainder = this.buffer;
       this.buffer = "";
-      const isPartialInternalMarker = [
-        GENERATED_REPORT_CLOSE,
+      const internalMarkers = [
+        ...(this.mode === "prefix" ? GENERATED_REPORT_OPEN_MARKERS : []),
+        this.mode === "report" ? this.reportCloseMarker : GENERATED_REPORT_CLOSE,
         GENERATED_TASK_CONTEXT_OPEN,
         GENERATED_JSON_FENCE_OPEN,
         GENERATED_NAKED_JSON_OPEN
-      ].some((marker) => marker.startsWith(remainder));
+      ];
+      const isPartialInternalMarker = isGeneratedMarkerPrefix(remainder, internalMarkers);
       return remainder && !isPartialInternalMarker ? [remainder] : [];
     }
     return [];
   }
 
   private drainVisibleText(delimiters: readonly string[]): string[] {
-    const delimiterIndex = delimiters
-      .map((delimiter) => this.buffer.indexOf(delimiter))
-      .filter((index) => index >= 0)
-      .sort((left, right) => left - right)[0];
-    if (delimiterIndex !== undefined) {
-      const report = this.buffer.slice(0, delimiterIndex);
+    const delimiter = findFirstGeneratedMarker(this.buffer, delimiters);
+    if (delimiter) {
+      const report = this.buffer.slice(0, delimiter.index);
       this.buffer = "";
       this.mode = "hidden";
       return report ? [report] : [];
@@ -1174,6 +1208,29 @@ function matchingDelimiterSuffixLength(value: string, delimiter: string): number
     }
   }
   return 0;
+}
+
+function findFirstGeneratedMarker(
+  value: string,
+  markers: readonly string[],
+  start = 0
+): { index: number; marker: string } | null {
+  let first: { index: number; marker: string } | null = null;
+  for (const marker of markers) {
+    const index = value.indexOf(marker, start);
+    if (index >= 0 && (!first || index < first.index)) {
+      first = { index, marker };
+    }
+  }
+  return first;
+}
+
+function findLeadingGeneratedMarker(value: string, markers: readonly string[]): string | null {
+  return markers.find((marker) => value.startsWith(marker)) ?? null;
+}
+
+function isGeneratedMarkerPrefix(value: string, markers: readonly string[]): boolean {
+  return markers.some((marker) => marker.startsWith(value));
 }
 
 function renderChineseReport(profile: OnboardingInsightProfileSignals, sample: SampleBundle): string {
@@ -2126,11 +2183,7 @@ function extractLlmDelta(body: unknown): string | null {
 }
 
 function sanitizeGeneratedReport(report: string | null): string | null {
-  const withoutInternalContext = (report ?? "")
-    .replaceAll(GENERATED_REPORT_OPEN, "")
-    .split(GENERATED_REPORT_CLOSE, 1)[0]
-    ?.split(GENERATED_TASK_CONTEXT_OPEN, 1)[0] ?? "";
-  const trimmed = stripActionCopyFromReport(withoutInternalContext).trim();
+  const trimmed = stripActionCopyFromReport(report ?? "").trim();
   return trimmed ? trimmed.slice(0, 4_000) : null;
 }
 

--- a/App/backend/src/services/tests/onboarding-insight-service.test.ts
+++ b/App/backend/src/services/tests/onboarding-insight-service.test.ts
@@ -550,6 +550,121 @@ describe("onboarding insight service", () => {
     }));
   });
 
+  it("accepts simplified report tags without exposing markup or task context", async () => {
+    const write = vi.fn(async () => undefined);
+    const taskContext = {
+      topic: "Memmy 初见报告",
+      userGoal: "生成不含内部协议标签的初见报告。",
+      latestRequest: "兼容模型输出的简化标签。",
+      status: "completed",
+      currentState: "报告正文已经生成。",
+      agentActions: ["生成了初见报告。"],
+      verifiedResults: ["报告正文可正常展示。"],
+      unresolvedItems: [],
+      continuationPoint: "",
+      trajectorySummary: "模型使用了简化包装标签，报告正文仍应正常展示，内部任务上下文不得泄漏。"
+    };
+    const service = createOnboardingInsightService({
+      samplers: [sampler("codex", "Codex", [query("codex", "1", "生成我的初见报告")])],
+      reportGenerator: {
+        async generateReport() {
+          throw new Error("generateReport not used");
+        },
+        async *streamReport() {
+          yield "<rep";
+          yield "ort>Hi jiacz，\n\n## 你的偏好\n偏好简洁、可执行的结论。";
+          yield "</rep";
+          yield "ort>\n<task";
+          yield `Context>${JSON.stringify(taskContext)}</taskContext>`;
+        }
+      },
+      memoryWriter: { write },
+      now: () => 100
+    });
+
+    const events = await collectStreamEvents(service.streamReport({ locale: "zh-CN" }));
+    const visibleText = events
+      .filter((event): event is { type: "chunk"; delta: string } =>
+        Boolean(event && typeof event === "object" && (event as { type?: unknown }).type === "chunk"))
+      .map((event) => event.delta)
+      .join("");
+    const done = events.find((event) =>
+      event && typeof event === "object" && (event as { type?: unknown }).type === "done"
+    ) as { response: { reportMarkdown: string } } | undefined;
+
+    expect(visibleText).toBe("Hi jiacz，\n\n## 你的偏好\n偏好简洁、可执行的结论。");
+    expect(visibleText).not.toContain("<report>");
+    expect(visibleText).not.toContain("<taskContext>");
+    expect(visibleText).not.toContain("trajectorySummary");
+    expect(done?.response.reportMarkdown).toBe("Hi jiacz，\n\n## 你的偏好\n偏好简洁、可执行的结论。");
+    expect(write).toHaveBeenCalledWith(expect.objectContaining({
+      reportMarkdown: "Hi jiacz，\n\n## 你的偏好\n偏好简洁、可执行的结论。",
+      taskContext
+    }));
+  });
+
+  it("preserves simplified tag names when they are part of ordinary report text", async () => {
+    const reportText = "Hi。最近修复了 `<report>` 与 `<taskContext>` 标签泄漏。";
+    const service = createOnboardingInsightService({
+      samplers: [sampler("codex", "Codex", [query("codex", "1", "总结标签清理任务")])],
+      reportGenerator: {
+        async generateReport() {
+          throw new Error("generateReport not used");
+        },
+        async *streamReport() {
+          yield "Hi。最近修复了 `<rep";
+          yield "ort>` 与 `<task";
+          yield "Context>` 标签泄漏。";
+        }
+      },
+      now: () => 100
+    });
+
+    const events = await collectStreamEvents(service.streamReport({ locale: "zh-CN" }));
+    const visibleText = events
+      .filter((event): event is { type: "chunk"; delta: string } =>
+        Boolean(event && typeof event === "object" && (event as { type?: unknown }).type === "chunk"))
+      .map((event) => event.delta)
+      .join("");
+    const done = events.find((event) =>
+      event && typeof event === "object" && (event as { type?: unknown }).type === "done"
+    ) as { response: { reportMarkdown: string } } | undefined;
+
+    expect(visibleText).toBe(reportText);
+    expect(done?.response.reportMarkdown).toBe(reportText);
+  });
+
+  it("preserves simplified tag names inside a wrapped report body", async () => {
+    const reportText = "Hi。正文会说明 `<taskContext>` 标签的兼容处理。";
+    const service = createOnboardingInsightService({
+      samplers: [sampler("codex", "Codex", [query("codex", "1", "总结标签兼容方案")])],
+      reportGenerator: {
+        async generateReport() {
+          throw new Error("generateReport not used");
+        },
+        async *streamReport() {
+          yield "<report>Hi。正文会说明 `<task";
+          yield "Context>` 标签的兼容处理。</rep";
+          yield "ort>";
+        }
+      },
+      now: () => 100
+    });
+
+    const events = await collectStreamEvents(service.streamReport({ locale: "zh-CN" }));
+    const visibleText = events
+      .filter((event): event is { type: "chunk"; delta: string } =>
+        Boolean(event && typeof event === "object" && (event as { type?: unknown }).type === "chunk"))
+      .map((event) => event.delta)
+      .join("");
+    const done = events.find((event) =>
+      event && typeof event === "object" && (event as { type?: unknown }).type === "done"
+    ) as { response: { reportMarkdown: string } } | undefined;
+
+    expect(visibleText).toBe(reportText);
+    expect(done?.response.reportMarkdown).toBe(reportText);
+  });
+
   it("keeps a naked task-context JSON out of the streamed and final report", async () => {
     const write = vi.fn(async () => undefined);
     const taskContext = {

--- a/App/backend/src/tests/index.test.ts
+++ b/App/backend/src/tests/index.test.ts
@@ -593,11 +593,12 @@ describe("local api", () => {
     });
     expect(deleteResponse.status).toBe(200);
     await expect(deleteResponse.json()).resolves.toEqual({ ok: true });
-    expect(cloudClient.calls).toHaveLength(4);
+    expect(cloudClient.calls).toHaveLength(5);
     expect(cloudClient.calls[0]).toMatch(/^listIntegrationCapabilities:mct_/);
     expect(cloudClient.calls[1]).toMatch(/^authorizeIntegration:mct_.*:github$/);
     expect(cloudClient.calls[2]).toMatch(/^listIntegrationConnections:mct_/);
-    expect(cloudClient.calls[3]).toMatch(/^deleteIntegrationConnection:mct_.*:conn-github$/);
+    expect(cloudClient.calls[3]).toMatch(/^listIntegrationConnections:mct_/);
+    expect(cloudClient.calls[4]).toMatch(/^deleteIntegrationConnection:mct_.*:conn-github$/);
     expect(new Set(cloudClient.calls.map(readRecordedMachineToken)).size).toBe(1);
   });
 
@@ -978,6 +979,14 @@ describe("local api", () => {
         {
           method: "POST",
           url: "/api/composio/integrations/airtable/authorize",
+          body: {},
+          apiKey: undefined,
+          authorization: undefined,
+          machineComposioToken: expect.stringMatching(/^mct_/)
+        },
+        {
+          method: "GET",
+          url: "/api/composio/connections",
           body: {},
           apiKey: undefined,
           authorization: undefined,


### PR DESCRIPTION
## Summary

- accept simplified `<report>` and `<taskContext>` wrappers in onboarding first-report generation
- exclude wrapper markup and internal task-context JSON from streamed, final, and persisted report text while retaining task-context parsing
- align integration route assertions with the existing pre-delete connection lookup

## Tests

- `npm run test -w @memmy/backend` — 100 files, 738 tests passed
- `npm run typecheck -w @memmy/backend`
- `npm run lint -w @memmy/backend`
- Project Harness Full evidence: all selected checks pass except the known `distribution_boundary`

## Known baseline issue

`distribution_boundary` still detects the existing electron-builder inclusion of the repository `.env`. Those packaging configurations are unchanged and intentionally outside this PR scope.