### PR TITLE
release: prepare Memmy v1.0.6

### DIFF
--- a/.github/release-notes/v1.0.6.md
+++ b/.github/release-notes/v1.0.6.md
@@ -1,0 +1,28 @@
+# Memmy v1.0.6
+
+## Highlights
+
+- Expanded Cross-Agent access with built-in Pi and qwenwork history scanning, first-report sampling, and on-demand shared Memory through the Memmy Skill.
+- Made **Add another Agent** easier and safer with presets for Kimi Code, Zcode, MiniMax Code, and Coder, plus custom names. Memmy now verifies a real local installation before importing history or installing a Skill, and hides unverified drafts.
+- Reworked Agent and Memory failure notices with localized guidance, expandable technical details, clearer quota-exhaustion states, scheduled-retry status, and direct retry or settings actions.
+
+## Agent and integration improvements
+
+- Fixed Windows Hook commands so paths are quoted correctly for `cmd.exe` and PowerShell.
+- Claude Code tool results are no longer mistaken for the user's query when completed turns are captured into Memory.
+- The OpenAI-compatible Chat Completions endpoint now reports real prompt, completion, and total token usage, including aggregated usage when an empty response is retried.
+
+## Desktop and Memory improvements
+
+- User UTC offsets now flow consistently through Agent configuration, Memory capture and retrieval, date filters, dashboard grouping, and displayed timestamps.
+- Improved search precision for one- and two-character ASCII terms by preventing generic JSON metadata keys from outranking real Memory matches.
+- Account email addresses and phone numbers are now masked in the sidebar and Settings.
+- Fixed the conversation composer so multiline drafts continue growing and remain scrollable instead of clipping wrapped text.
+- Onboarding reports no longer expose internal report or task-context wrapper tags.
+- The startup splash now follows the saved language or package edition, international first-run Settings correctly show English, and Windows tray settings use platform-appropriate copy.
+
+## Packaging and reliability
+
+- Windows packaged builds now keep runtime and application data under the installation directory and migrate existing per-user data when needed.
+- Added a guarded `clear-all-windows.ps1` utility for removing verified Memmy installations, runtime data, updater state, and CLI artifacts.
+- macOS packages now use edition-specific Chinese or English microphone permission descriptions.

--- a/App/memmy-agent/package-lock.json
+++ b/App/memmy-agent/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "memmy-agent",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "memmy-agent",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.100.1",
         "@aws-sdk/client-bedrock-runtime": "^3.1061.0",

--- a/App/memmy-agent/package.json
+++ b/App/memmy-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memmy-agent",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "TypeScript refactor of memmy's agent runtime.",
   "type": "module",
   "main": "./dist/index.js",

--- a/App/shell/desktop/package.json
+++ b/App/shell/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memmy/desktop",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "private": true,
   "type": "module",
   "description": "Memmy desktop client.",

--- a/Memory/package.json
+++ b/Memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memmy/memory",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "private": true,
   "type": "module",
   "main": "./dist/src/index.js",

--- a/Memory/src/cli/npm/package.json
+++ b/Memory/src/cli/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memtensor/memmy-memory-cli",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Memmy Memory CLI for local agent memory.",
   "type": "module",
   "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "memmy-agent",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "memmy-agent",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "workspaces": [
         "Migrations",
         "Memory",
@@ -86,7 +86,7 @@
     },
     "App/shell/desktop": {
       "name": "@memmy/desktop",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "dependencies": {
         "@memmy/backend": "0.0.0",
         "@memmy/desktop-interface": "0.0.0",
@@ -222,7 +222,7 @@
     },
     "Memory": {
       "name": "@memmy/memory",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "dependencies": {
         "@huggingface/transformers": "^3.8.0",
         "better-sqlite3": "^12.6.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memmy-agent",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "private": true,
   "type": "module",
   "description": "Local-first agent memory substrate with desktop and CLI surfaces.",

--- a/tests/release-workflow.test.ts
+++ b/tests/release-workflow.test.ts
@@ -50,6 +50,16 @@ describe("GitHub release workflow", () => {
     expect(agentLock.packages?.[""].version).toBe(version);
   });
 
+  it("tracks release notes whose title matches the current project version", () => {
+    const version = readJson("package.json").version;
+    const notes = readFileSync(
+      resolve(repoRoot, `.github/release-notes/v${version}.md`),
+      "utf8",
+    );
+
+    expect(notes.split(/\r?\n/, 1)[0]).toBe(`# Memmy v${version}`);
+  });
+
   it("uses the trusted base workflow for merged release/vX.Y.Z PRs targeting main", () => {
     expect(workflow.on.pull_request_target).toEqual({ types: ["closed"], branches: ["main"] });
     expect(workflow.on.pull_request).toBeUndefined();


### PR DESCRIPTION
## Summary

- align all managed project manifests and lockfiles to `1.0.6`
- add curated Memmy v1.0.6 release notes
- require the current project version to have a matching versioned release-notes file
- prepare the trusted `release/v1.0.6 -> main` trigger path

## Checks completed

- `npm run version:check`
- `npm run test:release-workflow` (11 tests)
- `git diff --check`
- four expected v1.0.6 OSS objects respond successfully and expose matching `Content-MD5` / ETag metadata
- targeted flaky retry: `App/memmy-agent/tests/core/agent-runtime/task-cancel.test.ts` (21 tests)

## Do not merge yet

This PR is intentionally Draft. Merging it will immediately trigger the GitHub Release workflow, so the following release blockers must be resolved first:

1. Rebuild and replace all four OSS installers from this release commit. A read-only sample of the current Windows CN and macOS CN artifacts found outer app metadata at `1.0.6`, but the bundled `dist/runtime/memmy-agent/package.json` is still `1.0.5`.
2. Re-run artifact integrity checks after replacement (public URL, size, Content-MD5, SHA-256, and packaged runtime version).
3. Resolve the Full gate distribution-boundary failure: all four Electron Builder configs currently bundle the repository-root `.env`. A complete fix must preserve the desktop and standalone `memmy` / `memmy-memory` runtime configuration path while packaging only allowlisted public configuration; do not merge the old partial patch from PR #176 because it breaks standalone CLI configuration.
4. Re-run Project Harness Full on the final clean commit. The first Full run otherwise passed lint, typecheck, local API contracts, desktop assertions, critical smoke, full build, and diff sanity. The Agent suite had two timeout-only failures that passed 21/21 on immediate targeted retry.
5. Obtain independent MemTensor maintainer review. The author must not self-review.

## Release behavior

After these blockers are cleared and this exact `release/v1.0.6` PR is merged into `main`, the trusted base workflow will create and publish tag/Release `v1.0.6`. Do not manually dispatch it while this PR is Draft.
