### PR TITLE
fix(frontend): handle unavailable models and simplify capabilities

### DIFF
--- a/App/frontend/desktop/src/pages/home-page.tsx
+++ b/App/frontend/desktop/src/pages/home-page.tsx
@@ -166,6 +166,7 @@ const TRANSLATABLE_AGENT_ERROR_KEYS = new Set<MessageKey>([
   "home.agent.executionInterrupted",
   "home.agent.recoveryTimeout",
   "home.goal.controlUnknown",
+  "home.modelSelector.unavailable",
   "home.project.desktopRequired",
   "home.queue.removeFailed",
   "home.queue.steerFailed",

--- a/App/frontend/desktop/src/pages/model-workspace-section.tsx
+++ b/App/frontend/desktop/src/pages/model-workspace-section.tsx
@@ -15,6 +15,7 @@ import {
   getModelCandidates,
   getTaskModelCandidates,
   modelConfigInput,
+  protocolSupportsModelCapabilities,
   setModelAssignment,
   setModelConnectionAvailability,
   setDefaultTaskModel,
@@ -40,9 +41,19 @@ import {
 } from "./settings-nav.js";
 
 type TestStatus = "idle" | "testing" | "success" | "error";
-type ModelKind = "text" | "embedding" | "asr" | "image";
+export type ModelKind = "text" | "embedding" | "asr" | "image";
 
 const DEFAULT_TEXT_CAPABILITIES: ModelCapability[] = ["chat", "memorySummary", "memoryEvolution"];
+const MODEL_KIND_OPTIONS = ["text", "embedding", "asr", "image"] as const;
+
+export function modelCapabilitiesForKind(kind: ModelKind): ModelCapability[] {
+  if (kind === "text") return [...DEFAULT_TEXT_CAPABILITIES];
+  return [kind];
+}
+
+export function normalizeEditorCapabilities(capabilities: ModelCapability[]): ModelCapability[] {
+  return modelCapabilitiesForKind(modelKindForCapabilities(capabilities));
+}
 
 interface ConnectionTestState {
   status: TestStatus;
@@ -234,7 +245,7 @@ export function ModelWorkspaceSection(props: ModelWorkspaceSectionProps) {
       models: connection.modelEntries.map((entry) => ({
         presetId: entry.presetId,
         name: entry.model,
-        capabilities: entry.capabilities.map(fromCatalogCapability)
+        capabilities: normalizeEditorCapabilities(entry.capabilities.map(fromCatalogCapability))
       })),
       modelDraft: "",
       capabilityDrafts: [...DEFAULT_TEXT_CAPABILITIES],
@@ -289,11 +300,16 @@ export function ModelWorkspaceSection(props: ModelWorkspaceSectionProps) {
     const providerChanged = Boolean(
       existing && protocolFromConnection(existing.provider) !== editor.provider
     );
+    const capabilities = resolved.models.flatMap((model) => model.capabilities);
     const result = upsertModelConnection(workspace, props.mode, {
       id: editor.connectionId ?? undefined,
       provider: editor.provider,
       endpoint: editor.endpoint,
-      ...(existing && !providerChanged ? { protocol: existing.protocol } : {}),
+      protocol: editorProtocolForCapabilities(
+        editor.provider,
+        capabilities,
+        providerChanged ? undefined : existing?.protocol
+      ),
       apiKey: editor.apiKey || undefined,
       apiKeyMasked: providerChanged ? undefined : existing?.apiKeyMasked,
       models: resolved.models.map((model) => model.name),
@@ -478,7 +494,11 @@ export function ModelWorkspaceSection(props: ModelWorkspaceSectionProps) {
         ? await props.configClient.testModelConfig({
           provider: fromProtocol(editor.provider),
           endpointId: existing?.endpointId ?? editor.connectionId ?? "connection-test-new",
-          protocol: existing?.protocol ?? protocolForEditor(editor.provider, selectedModel.capabilities[0]!),
+          protocol: editorProtocolForCapabilities(
+            editor.provider,
+            selectedModel.capabilities,
+            providerChanged ? undefined : existing?.protocol
+          ),
           endpoint: editor.endpoint,
             model: selectedModel.name,
             apiKey: editor.apiKey,
@@ -1065,13 +1085,10 @@ export function ModelWorkspaceSection(props: ModelWorkspaceSectionProps) {
                   }}
                   placeholder={t("settings.modelWorkspace.modelPlaceholder")}
                 />
-                <div className="grid gap-1.5">
-                  <div className="text-xs text-text-ink/65">{t("settings.modelWorkspace.modelCapability")}</div>
-                  <ModelCapabilityPicker
-                    capabilities={editor.capabilityDrafts}
-                    onChange={(capabilityDrafts) => setEditor({ ...editor, capabilityDrafts })}
-                  />
-                </div>
+                <ModelCapabilityPicker
+                  capabilities={editor.capabilityDrafts}
+                  onChange={(capabilityDrafts) => setEditor({ ...editor, capabilityDrafts })}
+                />
               </div>
               <div className="model-editor-actions">
                 <button
@@ -1174,11 +1191,9 @@ function ProviderModelList(props: {
             {item.model}
           </span>
           <div className="flex shrink-0 items-center gap-1.5">
-            {item.capabilities.map((capability) => (
-              <span key={capability} className="rounded-tag bg-canvas-oat px-2 py-0.5 text-[10px] text-text-ink/50">
-                {t(modelCapabilityMessageKey(capability))}
-              </span>
-            ))}
+            <span className="rounded-tag bg-canvas-oat px-2 py-0.5 text-[10px] text-text-ink/50">
+              {t(modelKindMessageKey(modelKindForCapabilities(item.capabilities)))}
+            </span>
             {item.onEdit && (
               <button
                 type="button"
@@ -1331,12 +1346,23 @@ function protocolFromConnection(provider: string): Protocol {
 }
 
 function protocolForEditor(provider: Protocol, capability: ModelCapability): ModelEndpointProtocol {
-  if (provider === "anthropic") return "anthropic-messages";
-  if (provider === "gemini") return "gemini-generate-content";
   if (capability === "embedding") return "openai-embeddings";
   if (capability === "asr") return "dashscope-input-audio-chat";
-  if (capability === "image") return "openai-images";
+  if (capability === "image") return provider === "qwen" ? "dashscope-multimodal-generation" : "openai-images";
+  if (provider === "anthropic") return "anthropic-messages";
+  if (provider === "gemini") return "gemini-generate-content";
   return "openai-chat-completions";
+}
+
+export function editorProtocolForCapabilities(
+  provider: Protocol,
+  capabilities: ModelCapability[],
+  existingProtocol?: ModelEndpointProtocol
+): ModelEndpointProtocol {
+  if (existingProtocol && protocolSupportsModelCapabilities(existingProtocol, capabilities)) {
+    return existingProtocol;
+  }
+  return protocolForEditor(provider, capabilities[0] ?? "chat");
 }
 
 function modelKindForCapabilities(capabilities: ModelCapability[]): ModelKind {
@@ -1351,57 +1377,30 @@ function ModelCapabilityPicker(props: {
   onChange: (capabilities: ModelCapability[]) => void;
 }) {
   const { t } = useTranslation();
-  const detailsRef = useRef<HTMLDetailsElement | null>(null);
   const kind = modelKindForCapabilities(props.capabilities);
-  const textCapabilities = props.capabilities.filter((capability) => DEFAULT_TEXT_CAPABILITIES.includes(capability));
-  const triggerLabel = kind === "text"
-    ? `${t("settings.modelWorkspace.capability.chat")} · ${t("settings.modelWorkspace.capabilityCount", { count: textCapabilities.length })}`
-    : t(modelCapabilityMessageKey(kind));
 
   return (
-    <details ref={detailsRef} className="model-capability-picker">
-      <summary className="model-capability-picker__trigger" aria-label={t("settings.modelWorkspace.modelCapability")}>
-        <span className="model-capability-picker__value">{triggerLabel}</span>
-        <ChevronDown size={14} aria-hidden="true" />
-      </summary>
-      <div className="model-capability-picker__menu">
-        <fieldset className="model-capability-picker__text-group">
-          <legend>{t("settings.modelWorkspace.textRoles")}</legend>
-          {(["chat", "memorySummary", "memoryEvolution"] as const).map((capability) => {
-            const checked = textCapabilities.includes(capability);
-            return (
-              <label key={capability} className="model-capability-picker__option">
-                <input
-                  type="checkbox"
-                  checked={checked}
-                  onChange={() => props.onChange(toggleModelCapability(props.capabilities, capability))}
-                />
-                <span>{capability === "chat"
-                  ? t("settings.modelWorkspace.capability.agent")
-                  : t(modelCapabilityMessageKey(capability))}</span>
-              </label>
-            );
-          })}
-        </fieldset>
-        <div className="model-capability-picker__single-types" role="group" aria-label={t("settings.modelWorkspace.modelType")}>
-          {(["embedding", "asr", "image"] as const).map((capability) => (
-            <button
-              key={capability}
-              type="button"
-              className={`model-capability-picker__type ${kind === capability ? "model-capability-picker__type--selected" : ""}`}
-              onClick={() => {
-                props.onChange([capability]);
-                if (detailsRef.current) detailsRef.current.open = false;
-              }}
-            >
-              <span>{t(modelCapabilityMessageKey(capability))}</span>
-              {kind === capability && <Check size={13} aria-hidden="true" />}
-            </button>
-          ))}
-        </div>
-      </div>
-    </details>
+    <Select
+      label={t("settings.modelWorkspace.modelCapability")}
+      labelClassName="model-capability-select__label"
+      value={kind}
+      options={modelKindOptions(t)}
+      onValueChange={(value) => props.onChange(modelCapabilitiesForKind(value as ModelKind))}
+      className="select-control--subtle model-capability-select"
+      menuClassName="model-capability-select__menu"
+    />
   );
+}
+
+function modelKindOptions(t: ReturnType<typeof useTranslation>["t"]): SelectOption[] {
+  return MODEL_KIND_OPTIONS.map((kind) => ({
+    value: kind,
+    label: t(modelKindMessageKey(kind))
+  }));
+}
+
+function modelKindMessageKey(kind: ModelKind) {
+  return modelCapabilityMessageKey(kind === "text" ? "chat" : kind);
 }
 
 function modelCapabilityMessageKey(capability: ModelCapability) {
@@ -1427,14 +1426,6 @@ function toCatalogCapabilityForEditor(capability: ModelCapability) {
   if (capability === "memoryEvolution") return "memory_evolution" as const;
   if (capability === "image") return "image_generation" as const;
   return capability;
-}
-
-function toggleModelCapability(current: ModelCapability[], capability: ModelCapability): ModelCapability[] {
-  const textCapabilities: ModelCapability[] = ["chat", "memorySummary", "memoryEvolution"];
-  if (!textCapabilities.includes(capability)) return [capability];
-  const textCurrent = current.filter((item) => textCapabilities.includes(item));
-  if (!textCurrent.includes(capability)) return [...textCurrent, capability];
-  return textCurrent.length > 1 ? textCurrent.filter((item) => item !== capability) : textCurrent;
 }
 
 function platformModelName(

--- a/App/frontend/desktop/src/pages/tests/home-page.test.tsx
+++ b/App/frontend/desktop/src/pages/tests/home-page.test.tsx
@@ -1043,6 +1043,7 @@ describe("HomePage", () => {
     expect(agentErrorText("home.media.error.sendUnsupported")).toBe("当前不支持此文件格式。请上传图片、PDF、Office 文档或文本文件。");
     expect(agentErrorText("home.media.error.sendTooManyAttachments")).toBe("最多 4 个附件。");
     expect(agentErrorText("home.media.error.sendFileSize")).toBe("单个文件不能超过 10 MB。");
+    expect(agentErrorText("home.modelSelector.unavailable")).toBe("当前模型或连接已失效，无法继续调用，需要切换模型。");
     expect(agentErrorText("message_request_rejected:model_selection_unavailable")).toBe("当前模型或连接已失效，无法继续调用，需要切换模型。");
     expect(agentErrorText("asr.error.microphonePermissionDenied.mac")).toBe(
       "麦克风权限未开启。请到 系统设置 › 隐私与安全性 › 麦克风 中开启 Memmy"

--- a/App/frontend/desktop/src/pages/tests/settings-page.test.tsx
+++ b/App/frontend/desktop/src/pages/tests/settings-page.test.tsx
@@ -8,6 +8,7 @@ import { I18nProvider } from "../../i18n/i18n-provider.js";
 import { mockBootstrap } from "./fixtures/bootstrap.js";
 import { appActions } from "../../state/app-actions.js";
 import { appReducer, createInitialAppState, type AppState } from "../../state/app-reducer.js";
+import { createModelWorkspace, modelConfigInput, upsertModelConnection } from "../../state/model-workspace.js";
 import type { UpdateCoordinatorValue } from "../../app/update-coordinator.js";
 import {
   LOG_LEVEL_STORAGE_KEY,
@@ -21,7 +22,12 @@ import {
   writeLogLevel
 } from "../settings-page.js";
 import { formatMessage, zhCNMessages } from "../../i18n/messages.js";
-import { availableConnectionProtocols } from "../model-workspace-section.js";
+import {
+  availableConnectionProtocols,
+  editorProtocolForCapabilities,
+  modelCapabilitiesForKind,
+  normalizeEditorCapabilities
+} from "../model-workspace-section.js";
 
 const settingsPageSourcePath = fileURLToPath(new URL("../settings-page.tsx", import.meta.url));
 const updateCoordinatorSourcePath = fileURLToPath(new URL("../../app/update-coordinator.tsx", import.meta.url));
@@ -91,6 +97,103 @@ describe("多 BYOK endpoint 入口", () => {
     expect(available).toContain("openai");
     expect(available).toContain("anthropic");
     expect(available[0]).toBe("openai");
+  });
+});
+
+describe("自定义模型能力选择", () => {
+  it("四种单选类型映射为对应的底层能力", () => {
+    expect(modelCapabilitiesForKind("text")).toEqual(["chat", "memorySummary", "memoryEvolution"]);
+    expect(modelCapabilitiesForKind("embedding")).toEqual(["embedding"]);
+    expect(modelCapabilitiesForKind("asr")).toEqual(["asr"]);
+    expect(modelCapabilitiesForKind("image")).toEqual(["image"]);
+  });
+
+  it("旧文本用途进入编辑器时统一归一化为通用文本", () => {
+    expect(normalizeEditorCapabilities(["chat"])).toEqual(["chat", "memorySummary", "memoryEvolution"]);
+    expect(normalizeEditorCapabilities(["memorySummary"])).toEqual(["chat", "memorySummary", "memoryEvolution"]);
+    expect(normalizeEditorCapabilities(["memoryEvolution"])).toEqual(["chat", "memorySummary", "memoryEvolution"]);
+    expect(normalizeEditorCapabilities(["embedding"])).toEqual(["embedding"]);
+    expect(normalizeEditorCapabilities(["asr"])).toEqual(["asr"]);
+    expect(normalizeEditorCapabilities(["image"])).toEqual(["image"]);
+  });
+
+  it("四种编辑器类型保存为精确的 catalog 能力", () => {
+    const cases = [
+      ["text", "openai-chat-completions", ["agent", "memory_summary", "memory_evolution"]],
+      ["embedding", "openai-embeddings", ["embedding"]],
+      ["asr", "dashscope-input-audio-chat", ["asr"]],
+      ["image", "openai-images", ["image_generation"]]
+    ] as const;
+
+    for (const [kind, protocol, expectedCapabilities] of cases) {
+      const capabilities = modelCapabilitiesForKind(kind);
+      const result = upsertModelConnection(createModelWorkspace(null), "byok", {
+        provider: "openai",
+        endpoint: "https://example.com/v1",
+        protocol,
+        apiKey: "sk-test",
+        models: [`custom-${kind}`],
+        modelEntries: [{
+          model: `custom-${kind}`,
+          capability: capabilities[0]!,
+          capabilities
+        }]
+      });
+
+      expect(result.error).toBeNull();
+      expect(modelConfigInput(result.workspace).providers[0]?.models[0]?.capabilities).toEqual(expectedCapabilities);
+    }
+  });
+
+  it("编辑模型切换类型时同步切换 endpoint 协议", () => {
+    const textCapabilities = modelCapabilitiesForKind("text");
+    const created = upsertModelConnection(createModelWorkspace(null), "byok", {
+      provider: "openai",
+      endpoint: "https://example.com/v1",
+      protocol: "openai-chat-completions",
+      apiKey: "sk-test",
+      models: ["custom-model"],
+      modelEntries: [{ model: "custom-model", capability: "chat", capabilities: textCapabilities }]
+    });
+    const connection = created.workspace.spaces.byok.connections[0]!;
+    const embeddingCapabilities = modelCapabilitiesForKind("embedding");
+    const protocol = editorProtocolForCapabilities("openai", embeddingCapabilities, connection.protocol);
+    const edited = upsertModelConnection(created.workspace, "byok", {
+      id: connection.id,
+      provider: "openai",
+      endpoint: connection.endpoint,
+      protocol,
+      apiKeyMasked: connection.apiKeyMasked,
+      models: ["custom-model"],
+      modelEntries: [{
+        presetId: connection.modelEntries[0]!.presetId,
+        model: "custom-model",
+        capability: "embedding",
+        capabilities: embeddingCapabilities
+      }]
+    });
+
+    expect(protocol).toBe("openai-embeddings");
+    expect(edited.error).toBeNull();
+    expect(modelConfigInput(edited.workspace).providers[0]?.endpoints[0]?.protocol).toBe("openai-embeddings");
+    expect(modelConfigInput(edited.workspace).providers[0]?.models[0]?.capabilities).toEqual(["embedding"]);
+    expect(editorProtocolForCapabilities("openai", textCapabilities, "openai-responses")).toBe("openai-responses");
+    expect(editorProtocolForCapabilities("qwen", ["image"])).toBe("dashscope-multimodal-generation");
+  });
+
+  it("模型能力沿用标准 Select 四选一，不再拆分文本用途", () => {
+    const source = readFileSync(modelWorkspaceSourcePath, "utf8");
+
+    expect(source).toContain('const MODEL_KIND_OPTIONS = ["text", "embedding", "asr", "image"] as const;');
+    expect(source).toContain("value={kind}");
+    expect(source).toContain("options={modelKindOptions(t)}");
+    expect(source).toContain("onValueChange={(value) => props.onChange(modelCapabilitiesForKind(value as ModelKind))}");
+    expect(source).toContain('className="select-control--subtle model-capability-select"');
+    expect(source.match(/t\("settings\.modelWorkspace\.modelCapability"\)/g)).toHaveLength(1);
+    expect(source).toContain("normalizeEditorCapabilities(entry.capabilities.map(fromCatalogCapability))");
+    expect(source).not.toContain('type="checkbox"');
+    expect(source).not.toContain('t("settings.modelWorkspace.textRoles")');
+    expect(source).not.toContain('t("settings.modelWorkspace.capability.agent")');
   });
 });
 

--- a/App/frontend/desktop/src/state/model-workspace.ts
+++ b/App/frontend/desktop/src/state/model-workspace.ts
@@ -401,7 +401,7 @@ export function upsertModelConnection(
     endpointId = newId("endpoint");
   }
   const protocol = input.protocol ?? protocolFor(providerId, entries[0]!.capabilities[0]!);
-  if (!protocolSupports(protocol, entries.flatMap((entry) => entry.capabilities))) {
+  if (!protocolSupportsModelCapabilities(protocol, entries.flatMap((entry) => entry.capabilities))) {
     return { workspace, error: "invalid_model" };
   }
 
@@ -706,7 +706,7 @@ function protocolFor(provider: CatalogProviderId, capability: ModelCapability): 
   return "openai-chat-completions";
 }
 
-function protocolSupports(protocol: ModelEndpointProtocol, capabilities: ModelCapability[]): boolean {
+export function protocolSupportsModelCapabilities(protocol: ModelEndpointProtocol, capabilities: ModelCapability[]): boolean {
   return capabilities.every((capability) => protocolSupportsCatalog(protocol, toCatalogCapability(capability)));
 }
 


### PR DESCRIPTION
## Summary
- show the established unavailable-model copy immediately when a tombstoned selection blocks sending
- simplify custom model capabilities to a four-way single select: General text, Embedding, ASR, and Image
- map General text to all three internal text capabilities and normalize legacy partial text entries in the editor
- keep the endpoint protocol aligned when editing a model across capability families
- restore the standard Select styling from the earlier BYOK implementation and render a single capability label

## Testing
- `npm run typecheck -w @memmy/frontend-desktop`
- `npm test -w @memmy/frontend-desktop` (141 test files, 1399 tests)