### PR TITLE
fix(memory): open model configuration from errors

### DIFF
--- a/App/frontend/desktop/src/pages/memory-page.tsx
+++ b/App/frontend/desktop/src/pages/memory-page.tsx
@@ -12,6 +12,7 @@ import type { MessageKey } from "../i18n/messages.js";
 import { useTranslation } from "../i18n/use-translation.js";
 import { appActions } from "../state/app-actions.js";
 import { useAppState } from "../state/app-state.js";
+import { writeSettingsTabHash } from "./settings-nav.js";
 import { SidebarResizeHandle, useCodexResizableSidebar } from "./sidebar-resize.js";
 import { AnalyticsSubPage } from "./memory/analytics-sub-page.js";
 import { LogsSubPage } from "./memory/logs-sub-page.js";
@@ -139,7 +140,10 @@ export function MemoryPage(props: MemoryPageProps) {
         <MemoriesSubPage
           client={client}
           openRequest={referenceRequest?.page === "memories" ? referenceRequest : undefined}
-          onOpenSettings={() => dispatch(appActions.navigate("/settings"))}
+          onOpenSettings={() => {
+            writeSettingsTabHash("model");
+            dispatch(appActions.navigate("/settings"));
+          }}
         />
       ),
       tasks: <TasksSubPage client={client} openRequest={referenceRequest?.page === "tasks" ? referenceRequest : undefined} />,

--- a/App/frontend/desktop/src/pages/tests/memory-page-model-settings.interaction.test.tsx
+++ b/App/frontend/desktop/src/pages/tests/memory-page-model-settings.interaction.test.tsx
@@ -1,0 +1,115 @@
+// @vitest-environment happy-dom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { I18nProvider } from "../../i18n/i18n-provider.js";
+import { appActions } from "../../state/app-actions.js";
+import { MemoryPage } from "../memory-page.js";
+
+const mocks = vi.hoisted(() => ({
+  dispatch: vi.fn(),
+  track: vi.fn()
+}));
+
+vi.mock("../../app/providers.js", () => ({
+  useApiClients: () => ({ clients: null, setClients: vi.fn() })
+}));
+
+vi.mock("../../state/app-state.js", () => ({
+  useAppState: () => ({ state: null, dispatch: mocks.dispatch })
+}));
+
+vi.mock("../../analytics/use-analytics.js", () => ({
+  useAnalytics: () => ({ track: mocks.track, ready: false })
+}));
+
+vi.mock("../memory/memories-sub-page.js", async () => {
+  const { createElement } = await import("react");
+
+  return {
+    MemoriesSubPage: (props: { onOpenSettings?: () => void }) => createElement(
+      "button",
+      { type: "button", onClick: props.onOpenSettings },
+      "Check model settings"
+    )
+  };
+});
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe("MemoryPage model settings navigation", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      value: new MapStorage()
+    });
+    Object.defineProperty(window, "sessionStorage", {
+      configurable: true,
+      value: new MapStorage()
+    });
+    window.history.replaceState({ keep: true }, "", "/memory#about");
+    container = document.createElement("div");
+    document.body.append(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    document.body.replaceChildren();
+    window.history.replaceState(null, "", "/");
+  });
+
+  it("opens the model configuration tab instead of reusing a stale settings hash", () => {
+    act(() => {
+      root.render(
+        <I18nProvider language="zh-CN">
+          <MemoryPage initialSubPage="memories" />
+        </I18nProvider>
+      );
+    });
+
+    const button = [...container.querySelectorAll("button")]
+      .find((candidate) => candidate.textContent === "Check model settings");
+    expect(button).toBeDefined();
+
+    act(() => button?.click());
+
+    expect(mocks.dispatch).toHaveBeenCalledTimes(1);
+    expect(mocks.dispatch).toHaveBeenCalledWith(appActions.navigate("/settings"));
+    expect(window.location.hash).toBe("#model-config");
+    expect(window.history.state).toEqual({ keep: true });
+  });
+});
+
+class MapStorage implements Storage {
+  private readonly values = new Map<string, string>();
+
+  get length(): number {
+    return this.values.size;
+  }
+
+  clear(): void {
+    this.values.clear();
+  }
+
+  getItem(key: string): string | null {
+    return this.values.get(key) ?? null;
+  }
+
+  key(index: number): string | null {
+    return [...this.values.keys()][index] ?? null;
+  }
+
+  removeItem(key: string): void {
+    this.values.delete(key);
+  }
+
+  setItem(key: string, value: string): void {
+    this.values.set(key, value);
+  }
+}


### PR DESCRIPTION
## Summary

- replace stale settings hashes before navigating from the memory error state
- always open the model configuration tab while preserving history state
- add a regression interaction test starting from `#about`

## Verification

- Project Harness / Memmy Harness Standard: passed (7/7)
- frontend workspace test suite: passed
- frontend typecheck and changed lint: passed
- final diff review: no blockers