### PR TITLE
fix(composer): reserve model action rail

### DIFF
--- a/App/frontend/desktop/src/pages/home-page.tsx
+++ b/App/frontend/desktop/src/pages/home-page.tsx
@@ -2803,7 +2803,7 @@ export function HomePage() {
                       }}
                       onKeyDown={handleComposerKeyDown}
                       onPaste={handleComposerPaste}
-                      className={`${isComposerSingleLine ? "agent-composer-input--single " : ""}${selectedComposerCommand ? "agent-composer-input--command-selected " : ""}block w-full pl-4 pr-36 py-3 text-sm resize-none focus:outline-none rounded-card-lg bg-background-paper placeholder:text-text-ink/40`}
+                      className={`${isComposerSingleLine ? "agent-composer-input--single " : ""}${selectedComposerCommand ? "agent-composer-input--command-selected " : ""}agent-composer-input--conversation block w-full pl-4 py-3 text-sm resize-none focus:outline-none rounded-card-lg bg-background-paper placeholder:text-text-ink/40`}
                     />
                     <div className={`composer-actions absolute right-2.5 z-50 ${centerComposerControls ? "top-1/2 -translate-y-1/2" : "bottom-2"}`}>
                       <AgentModelSelector

--- a/App/frontend/desktop/src/pages/tests/home-page.test.tsx
+++ b/App/frontend/desktop/src/pages/tests/home-page.test.tsx
@@ -531,9 +531,37 @@ describe("HomePage", () => {
   it("centers the composer controls only while the session composer is one line", () => {
     const source = readFileSync(homePageSourcePath, "utf8");
 
-    expect(source).toContain('${isComposerSingleLine ? "agent-composer-input--single " : ""}${selectedComposerCommand ? "agent-composer-input--command-selected " : ""}block w-full pl-4 pr-36 py-3 text-sm resize-none focus:outline-none rounded-card-lg bg-background-paper placeholder:text-text-ink/40');
+    expect(source).toContain('${isComposerSingleLine ? "agent-composer-input--single " : ""}${selectedComposerCommand ? "agent-composer-input--command-selected " : ""}agent-composer-input--conversation block w-full pl-4 py-3 text-sm resize-none focus:outline-none rounded-card-lg bg-background-paper placeholder:text-text-ink/40');
     expect(source).toContain('centerComposerControls ? "top-1/2 -translate-y-1/2" : "bottom-2"');
     expect(source).toContain("COMPOSER_SINGLE_LINE_HEIGHT_PX = 52");
+  });
+
+  it("reserves the conversation composer action rail from long text", () => {
+    const source = readFileSync(homePageSourcePath, "utf8");
+    const composerStart = source.indexOf('className="agent-conversation-composer"');
+    const textareaStart = source.indexOf("<textarea", composerStart);
+    const actionsStart = source.indexOf("composer-actions absolute", textareaStart);
+    const textareaSource = source.slice(textareaStart, actionsStart);
+
+    expect(composerStart).toBeGreaterThan(0);
+    expect(textareaStart).toBeGreaterThan(composerStart);
+    expect(actionsStart).toBeGreaterThan(textareaStart);
+    expect(textareaSource).toContain("agent-composer-input--conversation");
+    expect(textareaSource).not.toContain("pr-36");
+
+    const window = new Window();
+    const style = window.document.createElement("style");
+    style.textContent = readFileSync(stylesSourcePath, "utf8").replace(/^@import[^;]+;$/gm, "");
+    window.document.head.append(style);
+
+    const shell = window.document.createElement("div");
+    shell.className = "agent-composer-shell";
+    const textarea = window.document.createElement("textarea");
+    textarea.className = "agent-composer-input--conversation";
+    shell.append(textarea);
+    window.document.body.append(shell);
+
+    expect(window.getComputedStyle(textarea).paddingRight).toBe("304px");
   });
 
   it("keeps the single-line composer text and caret vertically centered", () => {

--- a/App/frontend/desktop/src/styles.css
+++ b/App/frontend/desktop/src/styles.css
@@ -2687,6 +2687,13 @@ button {
   padding: 12px 16px 4px;
 }
 
+/* Reserve the complete action rail: model selector (180px), three 32px
+   buttons, gaps, and the right inset. This must be explicit because the
+   committed utility sheet does not include the former `pr-36` class. */
+.agent-composer-shell textarea.agent-composer-input--conversation {
+  padding-right: 19rem;
+}
+
 /* Keep this more specific than `.agent-composer-shell textarea` above so its generic line-height cannot shift the caret.
    Keep overflow-y:auto (not hidden): if single-line detection lags behind wrapped content, the field must stay scrollable. */
 .agent-composer-shell textarea.agent-composer-input--single {

--- a/App/frontend/desktop/src/theme/tests/prototype-page-alignment.test.ts
+++ b/App/frontend/desktop/src/theme/tests/prototype-page-alignment.test.ts
@@ -54,7 +54,7 @@ describe("prototype page structure alignment", () => {
     expect(source("pages/home-page.tsx")).toContain("max-w-3xl mx-auto space-y-3");
     expect(source("pages/home-page.tsx")).toContain("relative agent-composer-shell rounded-card-lg");
     expect(source("pages/home-page.tsx")).not.toContain("relative overflow-hidden agent-composer-shell rounded-card-lg");
-    expect(source("pages/home-page.tsx")).toContain('${isComposerSingleLine ? "agent-composer-input--single " : ""}${selectedComposerCommand ? "agent-composer-input--command-selected " : ""}block w-full pl-4 pr-36 py-3 text-sm resize-none focus:outline-none rounded-card-lg bg-background-paper placeholder:text-text-ink/40');
+    expect(source("pages/home-page.tsx")).toContain('${isComposerSingleLine ? "agent-composer-input--single " : ""}${selectedComposerCommand ? "agent-composer-input--command-selected " : ""}agent-composer-input--conversation block w-full pl-4 py-3 text-sm resize-none focus:outline-none rounded-card-lg bg-background-paper placeholder:text-text-ink/40');
     expect(source("pages/home-page.tsx")).toContain('centerComposerControls ? "top-1/2 -translate-y-1/2" : "bottom-2"');
   });
 


### PR DESCRIPTION
## Summary
- reserve explicit horizontal space for the conversation composer action rail
- replace the unavailable `pr-36` utility with a scoped 304px padding rule
- add source-wiring and computed-style regression coverage

## Verification
- Project Harness Standard: 7/7 passed
- targeted frontend tests: 89 passed
- frontend typecheck passed
- final diff review and `git diff --check` passed