### PR TITLE
fix(settings): retain connection test status

### DIFF
--- a/App/frontend/desktop/src/pages/model-workspace-connection-test-state.ts
+++ b/App/frontend/desktop/src/pages/model-workspace-connection-test-state.ts
@@ -1,0 +1,99 @@
+import type { ModelConnection } from "../state/model-workspace.js";
+
+export const MODEL_CONNECTION_TEST_STATE_STORAGE_KEY = "memmy.modelWorkspace.connectionTests.v1";
+
+export type StoredConnectionTestStatus = "success" | "error";
+
+export interface StoredConnectionTestState {
+  status: StoredConnectionTestStatus;
+  signature: string;
+}
+
+export function connectionTestSignature(connection: ModelConnection): string {
+  const models = connection.modelEntries
+    .map((entry) => ({
+      presetId: entry.presetId,
+      model: entry.model.trim(),
+      capabilities: [...entry.capabilities].sort()
+    }))
+    .sort((left, right) => (
+      left.presetId.localeCompare(right.presetId)
+      || left.model.localeCompare(right.model)
+    ));
+  return JSON.stringify({
+    provider: connection.provider,
+    endpointId: connection.endpointId,
+    endpoint: connection.endpoint.trim().replace(/\/+$/, ""),
+    protocol: connection.protocol,
+    apiKeyMasked: connection.apiKeyMasked.trim(),
+    models
+  });
+}
+
+export function readConnectionTestStates(
+  connections: readonly ModelConnection[],
+  storage?: Pick<Storage, "getItem">
+): Record<string, StoredConnectionTestState> {
+  const stored = readStoredStates(storage);
+  return Object.fromEntries(connections.flatMap((connection) => {
+    const state = stored[connection.id];
+    return state?.signature === connectionTestSignature(connection)
+      ? [[connection.id, state]]
+      : [];
+  }));
+}
+
+export function writeConnectionTestState(
+  connection: ModelConnection,
+  status: StoredConnectionTestStatus,
+  storage?: Pick<Storage, "getItem" | "setItem">
+): void {
+  if (!storage) return;
+  const states = readStoredStates(storage);
+  states[connection.id] = { status, signature: connectionTestSignature(connection) };
+  try {
+    storage.setItem(MODEL_CONNECTION_TEST_STATE_STORAGE_KEY, JSON.stringify(states));
+  } catch {
+    // Losing this session-only UI hint must not block saving the model catalog.
+  }
+}
+
+export function removeConnectionTestState(
+  connectionId: string,
+  storage?: Pick<Storage, "getItem" | "setItem" | "removeItem">
+): void {
+  if (!storage) return;
+  const states = readStoredStates(storage);
+  if (!(connectionId in states)) return;
+  delete states[connectionId];
+  try {
+    if (Object.keys(states).length > 0) {
+      storage.setItem(MODEL_CONNECTION_TEST_STATE_STORAGE_KEY, JSON.stringify(states));
+    } else {
+      storage.removeItem(MODEL_CONNECTION_TEST_STATE_STORAGE_KEY);
+    }
+  } catch {
+    // Losing this session-only UI hint must not block catalog mutations.
+  }
+}
+
+function readStoredStates(storage?: Pick<Storage, "getItem">): Record<string, StoredConnectionTestState> {
+  try {
+    const raw = storage?.getItem(MODEL_CONNECTION_TEST_STATE_STORAGE_KEY);
+    if (!raw) return {};
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
+    return Object.fromEntries(Object.entries(parsed).flatMap(([connectionId, value]) => (
+      isStoredConnectionTestState(value) ? [[connectionId, value]] : []
+    )));
+  } catch {
+    return {};
+  }
+}
+
+function isStoredConnectionTestState(value: unknown): value is StoredConnectionTestState {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const candidate = value as Partial<StoredConnectionTestState>;
+  return (candidate.status === "success" || candidate.status === "error")
+    && typeof candidate.signature === "string";
+}

--- a/App/frontend/desktop/src/pages/model-workspace-section.tsx
+++ b/App/frontend/desktop/src/pages/model-workspace-section.tsx
@@ -39,6 +39,14 @@ import {
   settingsTabHash,
   shouldOpenAddModelFromHash
 } from "./settings-nav.js";
+import {
+  connectionTestSignature,
+  readConnectionTestStates,
+  removeConnectionTestState,
+  writeConnectionTestState,
+  type StoredConnectionTestState,
+  type StoredConnectionTestStatus
+} from "./model-workspace-connection-test-state.js";
 
 type TestStatus = "idle" | "testing" | "success" | "error";
 export type ModelKind = "text" | "embedding" | "asr" | "image";
@@ -110,8 +118,12 @@ export function ModelWorkspaceSection(props: ModelWorkspaceSectionProps) {
   const [savePending, setSavePending] = useState(false);
   const saveInFlightRef = useRef(false);
   const hasMutatedRef = useRef(false);
-  const [testStates, setTestStates] = useState<Record<string, ConnectionTestState>>({});
+  const [testStates, setTestStates] = useState<Record<string, StoredConnectionTestState>>({});
   const space = workspace.spaces[props.mode];
+  const connectionTestIdentity = space.connections
+    .map((connection) => `${connection.id}:${connectionTestSignature(connection)}`)
+    .sort()
+    .join("|");
   const textCandidates = getModelCandidates(workspace, props.mode, "chat");
   const memorySummaryCandidates = getModelCandidates(workspace, props.mode, "memorySummary");
   const memoryEvolutionCandidates = getModelCandidates(workspace, props.mode, "memoryEvolution");
@@ -130,7 +142,7 @@ export function ModelWorkspaceSection(props: ModelWorkspaceSectionProps) {
   const nextAvailableProvider = availableProviders[0];
   const canAddConnection = Boolean(nextAvailableProvider);
 
-  function commitWorkspace(next: typeof workspace): boolean {
+  function commitWorkspace(next: typeof workspace, onSaved?: (savedWorkspace: typeof workspace) => void): boolean {
     if (saveInFlightRef.current) return false;
     setWorkspace(next);
     setSaveError(null);
@@ -141,8 +153,10 @@ export function ModelWorkspaceSection(props: ModelWorkspaceSectionProps) {
       void (async () => {
         try {
           const saved = await props.configClient!.saveModelCatalog(modelConfigInput(next));
-          setWorkspace(createModelWorkspace(saved));
+          const savedWorkspace = createModelWorkspace(saved);
+          setWorkspace(savedWorkspace);
           props.onConfigSaved?.(saved);
+          onSaved?.(savedWorkspace);
         } catch (error) {
           setSaveError(error instanceof Error && error.message ? error.message : t("settings.modelWorkspace.saveFailed"));
           try {
@@ -157,6 +171,8 @@ export function ModelWorkspaceSection(props: ModelWorkspaceSectionProps) {
           setSavePending(false);
         }
       })();
+    } else {
+      onSaved?.(next);
     }
     return true;
   }
@@ -164,6 +180,22 @@ export function ModelWorkspaceSection(props: ModelWorkspaceSectionProps) {
   useEffect(() => {
     if (!saveInFlightRef.current) setWorkspace(createModelWorkspace(props.seedConfig));
   }, [props.seedConfig]);
+
+  useEffect(() => {
+    const restored = readConnectionTestStates(
+      space.connections,
+      modelConnectionTestStorage()
+    );
+    setTestStates((current) => {
+      const currentValid = Object.fromEntries(space.connections.flatMap((connection) => {
+        const state = current[connection.id];
+        return state?.signature === connectionTestSignature(connection)
+          ? [[connection.id, state]]
+          : [];
+      }));
+      return { ...restored, ...currentValid };
+    });
+  }, [connectionTestIdentity]);
 
   useEffect(() => {
     if (!props.configClient) return;
@@ -234,8 +266,11 @@ export function ModelWorkspaceSection(props: ModelWorkspaceSectionProps) {
 
   function openEditConnection(connection: ModelConnection) {
     const provider = protocolFromConnection(connection.provider);
+    const savedTest = connectionTestState(connection, testStates);
     setFormError(null);
-    setEditorTest(testStates[connection.id] ?? { status: "idle", message: null });
+    setEditorTest(savedTest
+      ? { status: savedTest, message: connectionTestMessage(savedTest, t) }
+      : { status: "idle", message: null });
     setShowEditorApiKey(false);
     setEditor({
       connectionId: connection.id,
@@ -361,10 +396,35 @@ export function ModelWorkspaceSection(props: ModelWorkspaceSectionProps) {
           [...new Set([...existingTaskIds, ...savedTaskIds])]
         )
       : workspaceWithAvailability;
-    if (commitWorkspace(nextWorkspace)) {
-      if (savedConnection && editorTest.status !== "idle") {
-        setTestStates((current) => ({ ...current, [savedConnection.id]: editorTest }));
+    const savedTestStatus: StoredConnectionTestStatus | null = editorTest.status === "success" || editorTest.status === "error"
+      ? editorTest.status
+      : null;
+    const persistTestState = (savedWorkspace: typeof workspace) => {
+      const storage = modelConnectionTestStorage();
+      if (editor.connectionId && editor.connectionId !== savedConnection?.id) {
+        removeConnectionTestState(editor.connectionId, storage);
       }
+      if (!savedConnection) return;
+      const canonicalConnection = savedWorkspace.spaces[props.mode].connections
+        .find((connection) => connection.id === savedConnection.id);
+      if (savedTestStatus && canonicalConnection) {
+        writeConnectionTestState(canonicalConnection, savedTestStatus, storage);
+      } else {
+        removeConnectionTestState(savedConnection.id, storage);
+      }
+    };
+    if (commitWorkspace(nextWorkspace, persistTestState)) {
+      setTestStates((current) => {
+        const next = { ...current };
+        if (editor.connectionId) delete next[editor.connectionId];
+        if (savedConnection && savedTestStatus) {
+          next[savedConnection.id] = {
+            status: savedTestStatus,
+            signature: connectionTestSignature(savedConnection)
+          };
+        }
+        return next;
+      });
       closeEditor();
     }
   }
@@ -455,12 +515,21 @@ export function ModelWorkspaceSection(props: ModelWorkspaceSectionProps) {
 
   function confirmDeleteConnection() {
     if (!deleteTarget) return;
+    const deletedConnectionId = deleteTarget.id;
     const result = deleteModelConnection(workspace, props.mode, deleteTarget.id);
     if (result.error) {
       setSaveError(t("settings.modelWorkspace.saveFailed"));
       return;
     }
-    if (commitWorkspace(result.workspace)) {
+    if (commitWorkspace(result.workspace, () => removeConnectionTestState(
+      deletedConnectionId,
+      modelConnectionTestStorage()
+    ))) {
+      setTestStates((current) => {
+        const next = { ...current };
+        delete next[deletedConnectionId];
+        return next;
+      });
       setDeleteTarget(null);
     }
   }
@@ -706,11 +775,14 @@ export function ModelWorkspaceSection(props: ModelWorkspaceSectionProps) {
           )}
 
           {space.connections.map((connection) => {
-            const test = testStates[connection.id] ?? (
+            const storedTestStatus = connectionTestState(connection, testStates);
+            const test = storedTestStatus
+              ? { status: storedTestStatus, message: connectionTestMessage(storedTestStatus, t) }
+              : (
               connection.available === false
                 ? { status: "error" as const, message: t("settings.modelWorkspace.testFailed") }
                 : { status: "idle" as const, message: null }
-            );
+              );
             return (
               <article key={connection.id} className="rounded-card border-content-panel bg-canvas-oat/40 p-4">
                 <div className="flex items-start justify-between gap-3">
@@ -1303,6 +1375,32 @@ function ConnectionStatus(props: { status: TestStatus }) {
       )}
     </span>
   );
+}
+
+function connectionTestState(
+  connection: ModelConnection,
+  states: Record<string, StoredConnectionTestState>
+): StoredConnectionTestStatus | null {
+  const state = states[connection.id];
+  return state?.signature === connectionTestSignature(connection) ? state.status : null;
+}
+
+function connectionTestMessage(
+  status: StoredConnectionTestStatus,
+  t: ReturnType<typeof useTranslation>["t"]
+): string {
+  return t(status === "success"
+    ? "settings.modelWorkspace.testSuccess"
+    : "settings.modelWorkspace.testFailed");
+}
+
+function modelConnectionTestStorage(): Storage | undefined {
+  if (typeof window === "undefined") return undefined;
+  try {
+    return window.sessionStorage;
+  } catch {
+    return undefined;
+  }
 }
 
 function candidateOption(

--- a/App/frontend/desktop/src/pages/tests/model-workspace-connection-status.interaction.test.tsx
+++ b/App/frontend/desktop/src/pages/tests/model-workspace-connection-status.interaction.test.tsx
@@ -1,0 +1,194 @@
+// @vitest-environment happy-dom
+
+import type { ModelConfigView } from "@memmy/local-api-contracts";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ModelProviderConfig } from "../../api/config-client.js";
+import { I18nProvider } from "../../i18n/i18n-provider.js";
+import { createModelWorkspace } from "../../state/model-workspace.js";
+import {
+  MODEL_CONNECTION_TEST_STATE_STORAGE_KEY,
+  readConnectionTestStates,
+  writeConnectionTestState
+} from "../model-workspace-connection-test-state.js";
+import { ModelWorkspaceSection } from "../model-workspace-section.js";
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe("ModelWorkspaceSection connection test status", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    window.sessionStorage.clear();
+    window.history.replaceState(null, "", "/settings#model-config");
+    container = document.createElement("div");
+    document.body.append(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    document.body.replaceChildren();
+  });
+
+  it("keeps a successful connection state after leaving and reopening model settings", async () => {
+    const seedConfig = createSeedConfig({ revision: "revision-before-save", apiKeyMasked: "••••test" });
+    const savedConfig = createSeedConfig({ revision: "revision-after-save", apiKeyMasked: "sk-••••test" });
+    let currentConfig = seedConfig;
+    const configClient = {
+      getModelConfig: vi.fn(async () => currentConfig),
+      saveModelCatalog: vi.fn(async () => {
+        currentConfig = savedConfig;
+        return savedConfig;
+      }),
+      testModelConfig: vi.fn(async () => ({
+        ok: true,
+        message: "ok",
+        checkedAt: "2026-08-12T00:00:00.000Z"
+      }))
+    };
+
+    await renderWorkspace(seedConfig, configClient);
+    expect(container.textContent).toContain("未测试");
+    expect(container.textContent).not.toContain("连接成功");
+    act(() => getButtonByLabel("编辑 openai 配置").click());
+
+    await act(async () => {
+      getButtonByText("测试").click();
+      await Promise.resolve();
+    });
+    expect(getButtonByText("连接成功")).toBeDefined();
+
+    await act(async () => {
+      getButtonByLabel("保存").click();
+      await Promise.resolve();
+    });
+    expect(configClient.testModelConfig).toHaveBeenCalledTimes(1);
+    expect(configClient.saveModelCatalog).toHaveBeenCalledTimes(1);
+    expect(container.textContent).toContain("连接成功");
+
+    act(() => root.unmount());
+    root = createRoot(container);
+    await renderWorkspace(currentConfig, configClient);
+
+    expect(container.textContent).toContain("连接成功");
+    expect(container.textContent).not.toContain("未测试");
+  });
+
+  it("does not restore a cached result for changed connection details or malformed storage", () => {
+    const original = createModelWorkspace(createSeedConfig()).spaces.byok.connections[0]!;
+    writeConnectionTestState(original, "success", window.sessionStorage);
+    expect(readConnectionTestStates([original], window.sessionStorage)[original.id]?.status).toBe("success");
+
+    const changed = createModelWorkspace(createSeedConfig({ endpoint: "https://changed.example.com/v1" }))
+      .spaces.byok.connections[0]!;
+    expect(readConnectionTestStates([changed], window.sessionStorage)).toEqual({});
+
+    window.sessionStorage.setItem(MODEL_CONNECTION_TEST_STATE_STORAGE_KEY, "{");
+    expect(readConnectionTestStates([original], window.sessionStorage)).toEqual({});
+  });
+
+  async function renderWorkspace(
+    seedConfig: ModelProviderConfig,
+    configClient: ModelWorkspaceSectionProps["configClient"]
+  ) {
+    await act(async () => {
+      root.render(
+        <I18nProvider language="zh-CN">
+          <ModelWorkspaceSection mode="byok" seedConfig={seedConfig} configClient={configClient} />
+        </I18nProvider>
+      );
+      await Promise.resolve();
+    });
+  }
+
+  function getButtonByLabel(label: string): HTMLButtonElement {
+    const button = container.querySelector<HTMLButtonElement>(`button[aria-label="${label}"]`);
+    if (!button) throw new Error(`Missing button: ${label}`);
+    return button;
+  }
+
+  function getButtonByText(text: string): HTMLButtonElement {
+    const button = [...container.querySelectorAll<HTMLButtonElement>("button")]
+      .find((candidate) => candidate.textContent?.trim() === text);
+    if (!button) throw new Error(`Missing button text: ${text}`);
+    return button;
+  }
+});
+
+type ModelWorkspaceSectionProps = Parameters<typeof ModelWorkspaceSection>[0];
+
+function createSeedConfig(options: {
+  revision?: string;
+  apiKeyMasked?: string;
+  endpoint?: string;
+} = {}): ModelProviderConfig {
+  const apiKeyMasked = options.apiKeyMasked ?? "••••test";
+  const endpoint = options.endpoint ?? "https://api.openai.com/v1";
+  const model = {
+    presetId: "preset-openai",
+    provider: "openai" as const,
+    endpointId: "endpoint-openai",
+    protocol: "openai-chat-completions" as const,
+    model: "gpt-4o",
+    source: "byok" as const,
+    capabilities: ["agent" as const],
+    available: true
+  };
+  const catalog: ModelConfigView = {
+    configRevision: options.revision ?? "revision-connection-status",
+    providers: [{
+      provider: "openai",
+      configured: true,
+      hasApiKey: true,
+      apiKeyMasked,
+      apiKey: "",
+      endpoints: [{
+        endpointId: model.endpointId,
+        apiBase: endpoint,
+        protocol: model.protocol,
+        hasApiKey: true,
+        apiKeyMasked,
+        apiKey: ""
+      }],
+      accountManaged: false,
+      editable: true,
+      models: [model]
+    }],
+    modelAssignments: {
+      byok: {
+        agent: { candidates: [model.presetId], default: model.presetId },
+        memorySummary: null,
+        memoryEvolution: null,
+        embedding: null,
+        asr: null,
+        imageGeneration: null
+      },
+      account: {
+        agent: { candidates: [], default: null },
+        memorySummary: null,
+        memoryEvolution: null,
+        embedding: null,
+        asr: null,
+        imageGeneration: null
+      }
+    },
+    effectiveCandidates: { byok: [model], account: [] },
+    configured: true,
+    updatedAt: "2026-08-12T00:00:00.000Z"
+  };
+
+  return {
+    catalog,
+    provider: "openai",
+    endpointId: model.endpointId,
+    protocol: model.protocol,
+    endpoint,
+    model: model.model,
+    apiKey: "",
+    apiKeyMasked,
+    configured: true
+  };
+}


### PR DESCRIPTION
## Summary
- retain the last terminal model connection test result for the current app session
- bind restored status to the exact connection identity and invalidate it after configuration changes or deletion
- persist only after the canonical model catalog save succeeds

## Verification
- targeted frontend Vitest: 3 files, 85 tests passed
- frontend typecheck passed
- Project Harness / Memmy Harness Standard: 7/7 passed
- final diff review and diff check passed