### PR TITLE
fix(settings): strengthen default model button 

### DIFF
--- a/App/frontend/desktop/src/pages/model-workspace-section.tsx
+++ b/App/frontend/desktop/src/pages/model-workspace-section.tsx
@@ -853,7 +853,7 @@ export function ModelWorkspaceSection(props: ModelWorkspaceSectionProps) {
                               type="button"
                               aria-pressed={isDefault}
                               onClick={() => chooseDefaultTaskCandidate(candidate.id)}
-                              className="ml-2 shrink-0 text-[10px] text-action-sky"
+                              className="task-model-picker__default-button ml-2 shrink-0"
                             >
                               {isDefault
                                 ? t("settings.modelWorkspace.defaultModel")

--- a/App/frontend/desktop/src/pages/tests/model-workspace-default-button-visual.test.tsx
+++ b/App/frontend/desktop/src/pages/tests/model-workspace-default-button-visual.test.tsx
@@ -1,0 +1,141 @@
+// @vitest-environment happy-dom
+
+import type { ModelConfigView } from "@memmy/local-api-contracts";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { describe, expect, it } from "vitest";
+import type { ModelProviderConfig } from "../../api/config-client.js";
+import { I18nProvider } from "../../i18n/i18n-provider.js";
+import { ModelWorkspaceSection } from "../model-workspace-section.js";
+
+const stylesSourcePath = resolve(__dirname, "..", "..", "styles.css");
+const tokensSourcePath = resolve(__dirname, "..", "..", "theme", "tokens.css");
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe("model workspace default-model button", () => {
+  it("renders the current and available default actions as recognizable buttons", async () => {
+    const style = document.createElement("style");
+    style.textContent = `${readFileSync(tokensSourcePath, "utf8")}\n${
+      readFileSync(stylesSourcePath, "utf8").replace(/^@import[^;]+;$/gm, "")
+    }`;
+    document.head.append(style);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        <I18nProvider language="zh-CN">
+          <ModelWorkspaceSection mode="byok" seedConfig={createSeedConfig()} />
+        </I18nProvider>
+      );
+    });
+
+    const pickerButton = [...container.querySelectorAll<HTMLButtonElement>('button[aria-expanded="false"]')]
+      .find((button) => button.textContent?.includes("2 个已选"));
+    if (!pickerButton) throw new Error("Missing task-model picker button");
+    act(() => pickerButton.click());
+
+    const currentDefault = [...container.querySelectorAll<HTMLButtonElement>('button[aria-pressed="true"]')]
+      .find((button) => button.textContent?.trim() === "默认");
+    const availableDefault = [...container.querySelectorAll<HTMLButtonElement>('button[aria-pressed="false"]')]
+      .find((button) => button.textContent?.trim() === "设为默认");
+    if (!currentDefault || !availableDefault) throw new Error("Missing default-model actions");
+
+    const currentStyle = getComputedStyle(currentDefault);
+    const availableStyle = getComputedStyle(availableDefault);
+    for (const computed of [currentStyle, availableStyle]) {
+      expect(computed.display).toBe("inline-flex");
+      expect(computed.minHeight).toBe("24px");
+      expect(computed.paddingLeft).toBe("9px");
+      expect(computed.paddingRight).toBe("9px");
+      expect(computed.borderTopWidth).toBe("1px");
+      expect(computed.borderTopStyle).toBe("solid");
+      expect(computed.cursor).toBe("pointer");
+    }
+    expect(currentStyle.fontWeight).toBe("700");
+    expect(currentStyle.backgroundColor).toBe("#5cbfae");
+    expect(currentStyle.color).toBe("white");
+    expect(availableStyle.fontWeight).toBe("600");
+    expect(availableStyle.backgroundColor).toBe("#ffffff");
+
+    act(() => availableDefault.click());
+    expect(currentDefault.getAttribute("aria-pressed")).toBe("false");
+    expect(availableDefault.getAttribute("aria-pressed")).toBe("true");
+    expect(getComputedStyle(currentDefault).backgroundColor).toBe("#ffffff");
+    expect(getComputedStyle(availableDefault).backgroundColor).toBe("#5cbfae");
+
+    act(() => root.unmount());
+    document.head.removeChild(style);
+    document.body.removeChild(container);
+  });
+});
+
+function createSeedConfig(): ModelProviderConfig {
+  const models = ["gpt-5.4", "gpt-4o"].map((model, index) => ({
+    presetId: `byok-${index}`,
+    provider: "openai" as const,
+    endpointId: "openai-main",
+    protocol: "openai-chat-completions" as const,
+    model,
+    source: "byok" as const,
+    capabilities: ["agent" as const],
+    available: true
+  }));
+  const catalog: ModelConfigView = {
+    configRevision: "revision-default-button-visual",
+    providers: [{
+      provider: "openai",
+      configured: true,
+      hasApiKey: true,
+      apiKeyMasked: "sk-••••test",
+      apiKey: "",
+      endpoints: [{
+        endpointId: "openai-main",
+        apiBase: "https://api.openai.com/v1",
+        protocol: "openai-chat-completions",
+        hasApiKey: true,
+        apiKeyMasked: "sk-••••test",
+        apiKey: ""
+      }],
+      accountManaged: false,
+      editable: true,
+      models
+    }],
+    modelAssignments: {
+      byok: {
+        agent: { candidates: models.map((model) => model.presetId), default: models[0]!.presetId },
+        memorySummary: null,
+        memoryEvolution: null,
+        embedding: null,
+        asr: null,
+        imageGeneration: null
+      },
+      account: {
+        agent: { candidates: [], default: null },
+        memorySummary: null,
+        memoryEvolution: null,
+        embedding: null,
+        asr: null,
+        imageGeneration: null
+      }
+    },
+    effectiveCandidates: { byok: models, account: [] },
+    configured: true,
+    updatedAt: "2026-08-12T00:00:00.000Z"
+  };
+  return {
+    catalog,
+    provider: "openai",
+    endpointId: "openai-main",
+    protocol: "openai-chat-completions",
+    endpoint: "https://api.openai.com/v1",
+    model: models[0]!.model,
+    apiKey: "",
+    apiKeyMasked: "sk-••••test",
+    configured: true
+  };
+}

--- a/App/frontend/desktop/src/styles.css
+++ b/App/frontend/desktop/src/styles.css
@@ -6958,6 +6958,48 @@ input[type="checkbox"].check-sky:checked::after {
   font-size: 12px;
 }
 
+.task-model-picker__default-button {
+  display: inline-flex;
+  min-height: 24px;
+  align-items: center;
+  justify-content: center;
+  padding: 3px 9px;
+  border-width: 1px;
+  border-style: solid;
+  border-color: color-mix(in srgb, var(--color-action-sky) 42%, transparent);
+  border-radius: var(--radius-pill);
+  background: var(--color-background-paper);
+  color: var(--color-action-sky-hover);
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 10px;
+  font-weight: 600;
+  line-height: 1;
+  transition: border-color var(--duration-fast), background var(--duration-fast), color var(--duration-fast);
+}
+
+.task-model-picker__default-button:hover {
+  border-color: var(--color-action-sky);
+  background: color-mix(in srgb, var(--color-action-sky) 10%, transparent);
+}
+
+.task-model-picker__default-button[aria-pressed="true"] {
+  border-color: var(--color-action-sky);
+  background: var(--color-action-sky);
+  color: white;
+  font-weight: 700;
+}
+
+.task-model-picker__default-button[aria-pressed="true"]:hover {
+  border-color: var(--color-action-sky-hover);
+  background: var(--color-action-sky-hover);
+}
+
+.task-model-picker__default-button:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--color-action-sky) 55%, transparent);
+  outline-offset: 2px;
+}
+
 .task-model-picker__option:hover:not(:disabled) {
   background: var(--color-background-paper);
 }


### PR DESCRIPTION
## Summary
- render default-model actions as explicit outlined buttons
- give the active default a solid pressed state with dedicated hover and keyboard focus feedback
- preserve the existing task-model spacing intent for the separate MEMMY-239 fix

## Verification
- real ModelWorkspaceSection happy-dom visual and interaction regression passed
- related frontend tests: 3 files, 84 tests passed
- frontend typecheck passed
- Project Harness / Memmy Harness Standard: 7/7 passed
- final diff review and diff check passed