### PR TITLE
feat(frontend): show token usage details inline

### DIFF
--- a/App/frontend/desktop/src/pages/settings-page.tsx
+++ b/App/frontend/desktop/src/pages/settings-page.tsx
@@ -1,6 +1,6 @@
 /** Settings page for account, model, token usage, and desktop preferences. */
 import { useCallback, useEffect, useRef, useState, type CSSProperties, type Dispatch, type ReactNode } from "react";
-import { Brain, Palette, Rocket, Settings2, Shield, User, Zap, ArrowRight, ArrowLeft, Bell, ExternalLink, FolderOpen, Gift, Info, KeyRound, LogOut, Wrench, Search, Eye, EyeOff, ChevronDown, ChevronUp, ChevronRight, Database, Loader2, CheckCircle2, XCircle, Check, AlertTriangle, Mic, Image as ImageIcon, Copy} from "lucide-react";
+import { Brain, Palette, Rocket, Settings2, Shield, User, Zap, ArrowRight, Bell, ExternalLink, FolderOpen, Gift, Info, KeyRound, LogOut, Wrench, Eye, EyeOff, ChevronDown, ChevronUp, Database, Loader2, CheckCircle2, XCircle, Check, AlertTriangle, Mic, Image as ImageIcon, Copy} from "lucide-react";
 import type { AccountInvitationView, AppSettingsDto, ByokTokenUsageByKind, ByokTokenUsageByModel, ByokTokenUsageCapability, ByokTokenUsageKind, ByokTokenUsageSummary, Language, PrivacySettingsDto, TokenQuotaEligibility, TokenSceneUsageDto, TokenUsageDto } from "@memmy/local-api-contracts";
 import { useApiClients } from "../app/providers.js";
 import { copyInvitationCode } from "../app/invitation-analytics.js";
@@ -11,7 +11,7 @@ import { useAnalytics } from "../analytics/use-analytics.js";
 import type { AccountClient } from "../api/account-client.js";
 import type { ByokTokenUsageClient } from "../api/byok-token-usage-client.js";
 import type { TokenQuotaClient } from "../api/token-quota-client.js";
-import type { ConfigClient, ModelProviderConfig } from "../api/config-client.js";
+import type { ConfigClient } from "../api/config-client.js";
 import {
   readCloseMainWindowAction,
   writeCloseMainWindowAction,
@@ -224,15 +224,11 @@ export function SettingsPage() {
   const { track } = useAnalytics();
   const { t } = useTranslation();
   const update = useUpdateCoordinator();
-  const [showUsageDetail, setShowUsageDetail] = useState(false);
   const [activeTab, setActiveTab] = useState<SettingsTabId>(() => {
     return readInitialSettingsTab(typeof window === "undefined" ? undefined : window.location.hash);
   });
 
   function selectSettingsTab(tab: SettingsTabId) {
-    // Sidebar clicks must leave the usage-detail sub-page; otherwise the
-    // highlighted section changes while the detail view stays on screen.
-    setShowUsageDetail(false);
     setActiveTab(tab);
     writeSettingsTabHash(tab);
   }
@@ -240,7 +236,6 @@ export function SettingsPage() {
   return (
     <AppFrame
       title={t("settings.title")}
-      reserveTopBar={!showUsageDetail}
       settingsNav={{
         activeTab,
         onSelectTab: selectSettingsTab
@@ -257,8 +252,6 @@ export function SettingsPage() {
         update={update}
         track={track}
         activeTab={activeTab}
-        showUsageDetail={showUsageDetail}
-        onUsageDetailVisibleChange={setShowUsageDetail}
       />
     </AppFrame>
   );
@@ -276,7 +269,6 @@ export function SettingsPage() {
  * - byokTokenUsageClient: The BYOK API Key Token usage client; may be omitted in SSR tests.
  * - update: The app-level desktop update state and primary action.
  * - track: The analytics-tracking function; may be omitted in pure-view tests and default to a no-op.
- * - onUsageDetailVisibleChange: Notifies the outer layout to collapse the draggable top bar when the Token usage detail sub-page's visibility changes.
  */
 export interface SettingsPageViewProps {
   state: AppState;
@@ -290,8 +282,6 @@ export interface SettingsPageViewProps {
   track?: TrackAnalyticsEvent;
   activeTab?: SettingsTabId;
   onActiveTabChange?: (tab: SettingsTabId) => void;
-  showUsageDetail?: boolean;
-  onUsageDetailVisibleChange?: (visible: boolean) => void;
 }
 
 /** Returns whether a nickname input key event should save the current draft. */
@@ -317,9 +307,7 @@ export function SettingsPageView(props: SettingsPageViewProps) {
     update,
     track = noopTrackAnalyticsEvent,
     activeTab: activeTabProp,
-    onActiveTabChange,
-    showUsageDetail: showUsageDetailProp,
-    onUsageDetailVisibleChange
+    onActiveTabChange
   } = props;
   const { t, language } = useTranslation();
   const bootstrap = state.bootstrap;
@@ -338,33 +326,18 @@ export function SettingsPageView(props: SettingsPageViewProps) {
   const [nicknameDraft, setNicknameDraft] = useState("");
   const [accountBusy, setAccountBusy] = useState(false);
   const [accountError, setAccountError] = useState<string | null>(null);
-  const [showUsageDetailState, setShowUsageDetailState] = useState(false);
   const [activeTabState, setActiveTabState] = useState<SettingsTabId>(() => {
     return readInitialSettingsTab(typeof window === "undefined" ? undefined : window.location.hash);
   });
   const activeTab = activeTabProp ?? activeTabState;
-  const showUsageDetail = showUsageDetailProp ?? showUsageDetailState;
 
   function setActiveTab(tab: SettingsTabId) {
-    if (showUsageDetail) {
-      updateShowUsageDetail(false);
-    }
     if (onActiveTabChange) {
       onActiveTabChange(tab);
       return;
     }
     setActiveTabState(tab);
     writeSettingsTabHash(tab);
-  }
-
-  /** Syncs the Token usage detail sub-page's visibility so the AppFrame draggable top bar does not cover the back button. */
-  function updateShowUsageDetail(next: boolean) {
-    if (onUsageDetailVisibleChange) {
-      onUsageDetailVisibleChange(next);
-    }
-    if (showUsageDetailProp === undefined) {
-      setShowUsageDetailState(next);
-    }
   }
 
   const [showApplyMore, setShowApplyMore] = useState(false);
@@ -461,15 +434,14 @@ export function SettingsPageView(props: SettingsPageViewProps) {
   const modelDotClass = modelMode === "platform" ? "bg-action-sky" : "bg-status-success";
   const modelHeaderSpacing = modelMode === "platform" && !showApiConfig ? "" : " mb-4";
   const tokenUsage = bootstrap?.tokenUsage ?? FALLBACK_TOKEN_USAGE;
-  const giftUsedTokens = tokenUsage.usedTokens;
-  // The summary bar tracks Agent 任务 (the task model), not the plan total:
-  // that scene is what blocks the user first. Red / "request more" still use
-  // the original rule — remaining <= 0 or usage >= 80% — on those figures.
+  // The low-balance prompt tracks Agent 任务 (the task model), because that
+  // scene blocks the user first. It keeps the existing remaining <= 0 or
+  // usage >= 80% rule on those figures.
   const agentQuota = tokenUsage.sceneUsages.find((scene) => scene.scene === "agent_chat");
   const giftTotalTokens = agentQuota?.totalTokens ?? tokenUsage.totalTokens;
   const giftRemainingTokens = agentQuota?.remainingTokens ?? tokenUsage.remainingTokens;
-  const giftBarUsedTokens = agentQuota?.usedTokens ?? giftUsedTokens;
-  const { usagePercent, isTokenLow } = resolveGiftTokenUsage(giftBarUsedTokens, giftTotalTokens, giftRemainingTokens);
+  const giftBarUsedTokens = agentQuota?.usedTokens ?? tokenUsage.usedTokens;
+  const { isTokenLow } = resolveGiftTokenUsage(giftBarUsedTokens, giftTotalTokens, giftRemainingTokens);
   const showGiftQuota = !isByokMode;
   const invitationPromotion = bootstrap?.promotions?.invitation;
   const invitationEnabled = invitationPromotion?.enabled === true;
@@ -492,7 +464,6 @@ export function SettingsPageView(props: SettingsPageViewProps) {
   const quotaEligibilityText = quotaEligibilityMessage
     ? t(quotaEligibilityMessage.key, quotaEligibilityMessage.values)
     : null;
-  const customUsedTokens = byokUsage.totalTokens;
   const primaryModelId = state.modelConfig.configured ? modelId || state.modelConfig.model : "";
   const mainModelTestKey = createModelConfigValidationKey(mainModelFormValues);
   const isMainModelTestStale = Boolean(llmValidation.testedKey && llmValidation.testedKey !== mainModelTestKey);
@@ -711,9 +682,8 @@ export function SettingsPageView(props: SettingsPageViewProps) {
       return;
     }
 
-    // Controlled pages already initialize activeTab from the hash in SettingsPage.
-    // Do not call onActiveTabChange here: sidebar handlers also close usage detail,
-    // which would immediately bounce "查看用量详情" back out after open.
+    // Controlled pages already initialize activeTab from the hash in SettingsPage;
+    // only the standalone view needs to synchronize its local tab state here.
     if (activeTabProp === undefined) {
       const tabFromHash = resolveSettingsTabFromHash(window.location.hash);
       if (tabFromHash) {
@@ -1199,20 +1169,6 @@ export function SettingsPageView(props: SettingsPageViewProps) {
     }
   }
 
-  if (showUsageDetail) {
-    return (
-      <UsageDetailView
-        showPlatform={showGiftQuota}
-        platformUsage={tokenUsage}
-        byokUsage={byokUsage}
-        byokUsageStatus={byokUsageStatus}
-        workspaceMode={workspaceMode}
-        seedConfig={state.modelConfig}
-        onBack={() => updateShowUsageDetail(false)}
-      />
-    );
-  }
-
   const confirmDialog = confirm ? resolveAccountConfirmDialog(t) : null;
   return (
     <div
@@ -1380,90 +1336,6 @@ export function SettingsPageView(props: SettingsPageViewProps) {
           aria-labelledby="settings-tab-tokens"
           hidden={activeTab !== "tokens"}
         >
-        <Section icon={<Zap size={16} className="text-text-ink/60" />} title={t("settings.tokens")} sectionId="token-usage">
-          <div className="space-y-4">
-            {showGiftQuota && (
-              <div>
-                <div className="flex justify-between text-xs text-text-ink/65 mb-2">
-                  <span>
-                    {agentQuota
-                      ? t("settings.token.agentQuotaUsed", { count: formatNumber(giftBarUsedTokens) })
-                      : t("settings.token.giftUsed", { count: formatNumber(giftBarUsedTokens) })}
-                  </span>
-                  <span>{t("settings.token.total", { count: formatNumber(giftTotalTokens) })}</span>
-                </div>
-                <div className="h-3 bg-canvas-oat rounded-pill overflow-hidden">
-                  <div
-                    className={`h-full rounded-pill transition-all ${isTokenLow ? "bg-status-error" : "bg-action-sky"}`}
-                    style={{ width: `${usagePercent}%` }}
-                  />
-                </div>
-                <div className="mt-2">
-                  <span className="text-xs text-text-ink/50">{t("settings.token.remaining", { count: formatNumber(giftRemainingTokens) })}</span>
-                </div>
-              </div>
-            )}
-
-            <div className={`grid gap-3 ${showGiftQuota ? "grid-cols-2" : "grid-cols-1"}`}>
-              {showGiftQuota && (
-                <ChannelStat
-                  label={t("settings.token.platformModel")}
-                  value={giftUsedTokens}
-                  hint={t("settings.token.used")}
-                  tone="sky"
-                />
-              )}
-              <ChannelStat
-                label={t("settings.token.customModel")}
-                value={customUsedTokens}
-                hint={t("settings.token.used")}
-                tone="success"
-              />
-            </div>
-
-            {(isTokenLow || quotaEligibilityText) && showGiftQuota && (
-              <div className="flex items-center gap-2.5 p-4 bg-status-error-soft rounded-card border border-status-error/20">
-                <Info size={14} className="text-status-error mt-0.5 shrink-0" />
-                <p className="flex-1 text-xs text-status-error/85 leading-relaxed">
-                  {quotaEligibilityText ?? t("settings.token.lowHint")}
-                </p>
-                {quotaRequestPending ? (
-                  <button
-                    type="button"
-                    disabled
-                    className="shrink-0 px-3 py-1.5 text-xs font-normal text-white bg-status-error rounded-btn hover:opacity-90 transition-opacity cursor-pointer disabled:opacity-55 disabled:cursor-not-allowed"
-                  >
-                    {applyMoreButtonLabel}
-                  </button>
-                ) : canApplyMoreByPromotion && isTokenLow && (!quotaEligibility || quotaEligibility.state === "available") ? (
-                  <button
-                    type="button"
-                    onClick={openApplyMore}
-                    className="shrink-0 px-3 py-1.5 text-xs font-normal text-white bg-status-error rounded-btn hover:opacity-90 transition-opacity cursor-pointer"
-                  >
-                    {applyMoreButtonLabel}
-                  </button>
-                ) : null}
-              </div>
-            )}
-
-            <button
-              type="button"
-              onClick={() => updateShowUsageDetail(true)}
-              className="flex items-center justify-between w-full px-4 py-3 text-sm text-text-ink/75 bg-canvas-oat/40 border-content-panel rounded-card hover:bg-canvas-oat/70 transition-colors cursor-pointer"
-            >
-              <span className="flex items-center gap-2">
-                <Search size={15} className="text-text-ink/55" />
-                {t("settings.token.viewDetail")}
-                <span className="text-xs text-text-ink/45">
-                  {t(showGiftQuota ? "settings.token.breakdown" : "settings.token.breakdownByok")}
-                </span>
-              </span>
-              <ChevronRight size={16} className="text-text-ink/45" />
-            </button>
-          </div>
-        </Section>
-
         {isAccountMode && showGiftQuota && showInvitationBanner ? (
           <div
             className={`mb-6 flex items-center gap-3 px-4 py-3 rounded-card-lg border ${
@@ -1547,6 +1419,49 @@ export function SettingsPageView(props: SettingsPageViewProps) {
             ) : null}
           </div>
         ) : null}
+
+        <div id="token-usage" className="mb-6">
+          <div className="flex items-center justify-between gap-4 mb-3">
+            <div className="flex items-center gap-2">
+              <Zap size={16} className="text-text-ink/60" />
+              <h2 className="text-sm font-semibold text-text-ink">{t("settings.tokens")}</h2>
+            </div>
+            <UsageStatusLabel status={byokUsageStatus} updatedAt={byokUsage.updatedAt} />
+          </div>
+
+          {(isTokenLow || quotaEligibilityText) && showGiftQuota && (
+            <div className="mb-4 flex items-center gap-2.5 p-4 bg-status-error-soft rounded-card border border-status-error/20">
+              <Info size={14} className="text-status-error mt-0.5 shrink-0" />
+              <p className="flex-1 text-xs text-status-error/85 leading-relaxed">
+                {quotaEligibilityText ?? t("settings.token.lowHint")}
+              </p>
+              {quotaRequestPending ? (
+                <button
+                  type="button"
+                  disabled
+                  className="shrink-0 px-3 py-1.5 text-xs font-normal text-white bg-status-error rounded-btn hover:opacity-90 transition-opacity cursor-pointer disabled:opacity-55 disabled:cursor-not-allowed"
+                >
+                  {applyMoreButtonLabel}
+                </button>
+              ) : canApplyMoreByPromotion && isTokenLow && (!quotaEligibility || quotaEligibility.state === "available") ? (
+                <button
+                  type="button"
+                  onClick={openApplyMore}
+                  className="shrink-0 px-3 py-1.5 text-xs font-normal text-white bg-status-error rounded-btn hover:opacity-90 transition-opacity cursor-pointer"
+                >
+                  {applyMoreButtonLabel}
+                </button>
+              ) : null}
+            </div>
+          )}
+
+          <UsageDetails
+            showPlatform={showGiftQuota}
+            platformUsage={tokenUsage}
+            byokUsage={byokUsage}
+            byokUsageStatus={byokUsageStatus}
+          />
+        </div>
         </div>
 
         <div
@@ -1803,70 +1718,28 @@ export function SettingsPageView(props: SettingsPageViewProps) {
 }
 
 /**
- * Channel stat card props.
- *
- * Field meanings:
- * - label: The channel name.
- * - value: The cumulative Token count.
- * - hint: The value description.
- * - tone: The channel color; sky for platform, success for BYOK.
- */
-interface ChannelStatProps {
-  label: string;
-  value: number;
-  hint: string;
-  tone: "sky" | "success";
-}
-
-/**
- * Renders the channel summary card within the Token usage section.
- *
- * @param props The channel stat card props.
- * @returns A single channel's cumulative usage card.
- */
-function ChannelStat(props: ChannelStatProps) {
-  return (
-    <div className="p-3.5 bg-canvas-oat/40 rounded-card border-content-panel">
-      <div className="flex items-center gap-1.5 mb-1.5">
-        <span className={`w-1.5 h-1.5 rounded-full ${props.tone === "sky" ? "bg-action-sky" : "bg-status-success"}`} />
-        <span className="text-xs text-text-ink/60">{props.label}</span>
-      </div>
-      <div className="text-lg font-bold text-text-ink/85">
-        {props.tone === "success" ? formatTokenSummary(props.value) : formatNumber(props.value)}
-        <span className="text-xs font-normal text-text-ink/45 ml-1">Token</span>
-      </div>
-      <div className="text-[11px] text-text-ink/45 mt-0.5">{props.hint}</div>
-    </div>
-  );
-}
-
-/**
- * Token usage detail page props.
+ * Inline Token usage details props.
  *
  * Field meanings:
  * - showPlatform: Whether to show the platform-gifted channel.
  * - platformUsage: Platform quota aggregate and scene details.
  * - byokUsage: The local BYOK API Key Token usage summary.
  * - byokUsageStatus: The local usage loading status.
- * - onBack: The callback to return to the settings page.
  */
-export interface UsageDetailViewProps {
+export interface UsageDetailsProps {
   showPlatform: boolean;
   platformUsage: TokenUsageDto;
   byokUsage: ByokTokenUsageSummary;
   byokUsageStatus: UsageLoadStatus;
-  workspaceMode?: ModelWorkspaceMode;
-  seedConfig?: ModelProviderConfig | null;
-  onBack: () => void;
 }
 
 /**
- * Renders the Token usage detail sub-page.
+ * Renders the complete Token usage breakdown inline.
  *
- * @param props The Token usage detail page props.
- * @returns A detail page split by the platform-gifted and BYOK API Key channels.
+ * @param props The Token usage details props.
+ * @returns Platform-gifted and BYOK API Key usage sections.
  */
-export function UsageDetailView(props: UsageDetailViewProps) {
+export function UsageDetails(props: UsageDetailsProps) {
   const { t } = useTranslation();
   const [selectedUsageModelId, setSelectedUsageModelId] = useState("all");
   // Neither panel invents rows. The platform grants quota per scene and does
@@ -1913,27 +1786,7 @@ export function UsageDetailView(props: UsageDetailViewProps) {
   const describeScenesInByok = !showPlatform;
 
   return (
-    <div className={`${usageStyles.detailPage} settings-page`}>
-      <div className={`app-frame-page-content ${usageStyles.page}`}>
-        <button
-          type="button"
-          onClick={props.onBack}
-          className={usageStyles.backButton}
-        >
-          <ArrowLeft size={16} />
-          {t("settings.back")}
-        </button>
-
-        <div className={usageStyles.titlebar}>
-          <h1 className={usageStyles.title}>
-            <span className={usageStyles.titleMark}>
-              <Zap className={usageStyles.bolt} />
-            </span>
-            {t("settings.token.detail")}
-          </h1>
-          <UsageStatusLabel status={props.byokUsageStatus} updatedAt={props.byokUsage.updatedAt} />
-        </div>
-
+    <div className={usageStyles.detailContent}>
         {showPlatform && (
           <section className={usageStyles.usageSection}>
             <UsageSectionHead
@@ -2046,7 +1899,6 @@ export function UsageDetailView(props: UsageDetailViewProps) {
             </div>
           )}
         </section>
-      </div>
     </div>
   );
 }

--- a/App/frontend/desktop/src/pages/settings-token-usage.module.css
+++ b/App/frontend/desktop/src/pages/settings-token-usage.module.css
@@ -1,12 +1,10 @@
-.detailPage {
+.detailContent {
   --usage-ink: #111d1c;
   --usage-secondary: #3d514c;
   --usage-muted: #7f938d;
   --usage-track: color-mix(in srgb, var(--color-border-stone) 52%, transparent);
   --usage-row-bg: color-mix(in srgb, var(--color-canvas-oat) 40%, transparent);
   --usage-row-hover: color-mix(in srgb, var(--color-canvas-oat) 75%, transparent);
-  height: 100%;
-  overflow-y: auto;
   background: transparent;
   color: var(--usage-ink);
   font-family: var(--font-sans);
@@ -15,89 +13,13 @@
   letter-spacing: 0;
 }
 
-/*
- * Mirrors the settings page wrapper (`app-frame-page-content max-w-2xl mx-auto`)
- * so both pages land on the same content edges. The horizontal padding comes
- * from `app-frame-page-content`, so only the vertical padding is set here.
- */
-.page {
-  box-sizing: border-box;
-  max-width: 672px;
-  margin: 0 auto;
-  padding-top: calc(var(--codex-toolbar-height) + 8px);
-  padding-bottom: 40px;
-}
-
-.backButton {
-  position: relative;
-  z-index: 10000;
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  min-height: 44px;
-  margin: 0 0 6px -12px;
-  padding: 8px 12px;
-  border: 0;
-  border-radius: 999px;
-  background: transparent;
-  color: var(--usage-muted);
-  font-size: var(--codex-text-sm);
-  line-height: var(--codex-leading-sm);
-  cursor: pointer;
-  pointer-events: auto;
-  touch-action: manipulation;
-  transition: color var(--duration-fast) ease;
-  -webkit-app-region: no-drag;
-}
-
-.backButton:hover {
-  color: var(--usage-ink);
-}
-
-/* --- Page header --- */
-
-.titlebar {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 16px;
-  margin-bottom: 24px;
-}
-
-.title {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  margin: 0;
-  font-size: 18px;
-  line-height: 24px;
-  font-weight: 700;
-  letter-spacing: -0.01em;
-}
-
-.titleMark {
-  display: grid;
-  place-items: center;
-  width: 28px;
-  height: 28px;
-  flex: 0 0 auto;
-  border-radius: var(--radius-btn);
-  background: color-mix(in srgb, var(--color-action-sky) 15%, transparent);
-  color: var(--color-action-sky-hover);
-}
-
-.bolt {
-  width: 15px;
-  height: 15px;
-}
-
 .updated,
 .statusError {
   display: inline-flex;
   align-items: center;
   gap: 6px;
   flex: 0 0 auto;
-  color: var(--usage-muted);
+  color: var(--usage-muted, #7f938d);
   font-size: var(--codex-text-xs);
   line-height: var(--codex-leading-xs);
   font-variant-numeric: tabular-nums;
@@ -188,8 +110,7 @@
 }
 
 /*
- * Mirrors the settings sections: the panel keeps the 24px inset of `p-6`, and
- * the cards inside keep the 14px inset of `ChannelStat`'s `p-3.5`.
+ * Mirrors the settings sections with a 24px panel inset.
  */
 .platformQuotaList,
 .byokUsageList {
@@ -547,15 +468,6 @@
 /* --- Responsive --- */
 
 @media (max-width: 640px) {
-  .titlebar {
-    display: block;
-  }
-
-  .titlebar .updated,
-  .titlebar .statusError {
-    margin-top: 8px;
-  }
-
   .sectionHead {
     display: block;
   }

--- a/App/frontend/desktop/src/pages/tests/prototype-modals.test.ts
+++ b/App/frontend/desktop/src/pages/tests/prototype-modals.test.ts
@@ -66,7 +66,7 @@ describe("2026-06-04 prototype modals", () => {
     expect(settingsSource).toContain("TOKEN_EXHAUSTED_APPLY_MORE_EVENT");
     expect(settingsSource).toContain("canApplyMoreByPromotion");
     expect(settingsSource).toContain('id="model-config"');
-    expect(settingsSource).toContain('sectionId="token-usage"');
+    expect(settingsSource).toContain('id="token-usage"');
   });
 
   it("保留旧弹窗偏好读取工具，但 Router 启动时不再全局阻断", () => {

--- a/App/frontend/desktop/src/pages/tests/settings-invitation-banner.test.tsx
+++ b/App/frontend/desktop/src/pages/tests/settings-invitation-banner.test.tsx
@@ -110,6 +110,11 @@ describe("SettingsPage invitation banner", () => {
     expect(container.textContent).not.toContain(
       "好友注册成功后，双方都会获得奖励 Token"
     );
+    const inviteTitle = [...container.querySelectorAll("p")]
+      .find((element) => element.textContent === "邀请好友，享更多额度");
+    const invitationBanner = inviteTitle?.parentElement?.parentElement;
+    const tokenUsageSection = container.querySelector("#token-usage");
+    expect(invitationBanner?.nextElementSibling).toBe(tokenUsageSection);
   });
 });
 

--- a/App/frontend/desktop/src/pages/tests/settings-page-token-usage.interaction.test.tsx
+++ b/App/frontend/desktop/src/pages/tests/settings-page-token-usage.interaction.test.tsx
@@ -7,7 +7,7 @@ import { I18nProvider } from "../../i18n/i18n-provider.js";
 import type { ByokTokenUsageSummary, TokenUsageDto } from "@memmy/local-api-contracts";
 import { appActions } from "../../state/app-actions.js";
 import { appReducer, createInitialAppState } from "../../state/app-reducer.js";
-import { SettingsPageView, UsageDetailView } from "../settings-page.js";
+import { SettingsPageView, UsageDetails } from "../settings-page.js";
 import { mockBootstrap } from "./fixtures/bootstrap.js";
 
 (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
@@ -31,7 +31,7 @@ describe("SettingsPage platform scene quota details", () => {
     document.body.replaceChildren();
   });
 
-  it("shows the aggregate on settings and all three scene totals in usage details", () => {
+  it("shows all three platform scene totals inline without a detail-page click", () => {
     const bootstrap = {
       ...mockBootstrap,
       app: {
@@ -96,14 +96,6 @@ describe("SettingsPage platform scene quota details", () => {
       );
     });
 
-    expect(container.textContent).toContain("Agent 任务额度已用 6.0M Token");
-    expect(container.textContent).toContain("共 5.0M Token");
-
-    const detailsButton = [...container.querySelectorAll("button")]
-      .find((button) => button.textContent?.includes("查看用量详情"));
-    expect(detailsButton).toBeDefined();
-    act(() => detailsButton?.click());
-
     expect(container.textContent).toContain("平台赠送额度");
     expect(container.textContent).toContain("Agent 任务");
     expect(container.textContent).toContain("6M/5MToken");
@@ -111,6 +103,12 @@ describe("SettingsPage platform scene quota details", () => {
     expect(container.textContent).toContain("15M/20MToken");
     expect(container.textContent).toContain("记忆进化");
     expect(container.textContent).toContain("2M/5MToken");
+    expect(container.textContent).toContain("申请更多");
+    expect(container.textContent).not.toContain("查看用量详情");
+    expect(container.textContent).not.toContain("Token 用量详情");
+    const applyMoreButton = [...container.querySelectorAll("button")]
+      .find((button) => button.textContent === "申请更多");
+    expect(applyMoreButton?.className).toContain("bg-status-error rounded-btn");
 
     const sceneHeading = [...container.querySelectorAll("h2")]
       .find((heading) => heading.textContent === "平台赠送额度");
@@ -148,13 +146,11 @@ describe("SettingsPage platform scene quota details", () => {
     act(() => {
       root.render(
         <I18nProvider language="zh-CN">
-          <UsageDetailView
+          <UsageDetails
             showPlatform
             platformUsage={emptyPlatformUsage()}
             byokUsage={byokUsage}
             byokUsageStatus="ready"
-            workspaceMode="account"
-            onBack={vi.fn()}
           />
         </I18nProvider>
       );
@@ -172,13 +168,11 @@ describe("SettingsPage platform scene quota details", () => {
     act(() => {
       root.render(
         <I18nProvider language="zh-CN">
-          <UsageDetailView
+          <UsageDetails
             showPlatform={false}
             platformUsage={emptyPlatformUsage()}
             byokUsage={byokUsage}
             byokUsageStatus="ready"
-            workspaceMode="byok"
-            onBack={vi.fn()}
           />
         </I18nProvider>
       );
@@ -186,6 +180,47 @@ describe("SettingsPage platform scene quota details", () => {
 
     expect(container.textContent).not.toContain("平台赠送额度");
     expect(container.textContent).toContain("自定义 API Key 消耗");
+  });
+
+  it("places the BYOK updated time beside the outer Token usage heading", async () => {
+    const byokUsage: ByokTokenUsageSummary = {
+      inputTokens: 1,
+      outputTokens: 1,
+      totalTokens: 2,
+      cachedInputTokens: 0,
+      cacheCreationInputTokens: 0,
+      updatedAt: "2026-08-11T12:00:00.000Z",
+      byKind: [],
+      byProvider: [],
+      byModel: []
+    };
+
+    await act(async () => {
+      root.render(
+        <I18nProvider language="zh-CN">
+          <SettingsPageView
+            state={createInitialAppState()}
+            dispatch={vi.fn()}
+            byokTokenUsageClient={{ getSummary: vi.fn(async () => byokUsage) }}
+            update={{
+              appVersion: "1.0.4",
+              phase: "idle",
+              preparedUpdatePath: null,
+              downloadProgress: null,
+              feedback: null,
+              requestPrimaryAction: vi.fn(async () => undefined)
+            }}
+          />
+        </I18nProvider>
+      );
+      await Promise.resolve();
+    });
+
+    const tokenUsageHeading = [...container.querySelectorAll("#token-usage h2")]
+      .find((heading) => heading.textContent === "Token 用量");
+    const tokenUsageHeader = tokenUsageHeading?.parentElement?.parentElement;
+    expect(tokenUsageHeader?.textContent).toContain("更新于");
+    expect(tokenUsageHeader?.className).toContain("justify-between");
   });
 });
 

--- a/App/frontend/desktop/src/pages/tests/settings-page.test.tsx
+++ b/App/frontend/desktop/src/pages/tests/settings-page.test.tsx
@@ -286,11 +286,10 @@ describe("SettingsPageView", () => {
     expect(html).toContain("g***@example.com");
     expect(html).not.toContain("grace@example.com");
     expect(html).toContain("注册时间：2026-04-12");
-    expect(html).toContain("Agent 任务额度已用 1.4M Token");
-    expect(html).toContain("共 5.0M Token");
-    expect(html).toContain("平台赠送大模型");
-    expect(html).toContain("自定义 API Key");
-    expect(html).toContain("查看用量详情");
+    expect(html).toContain("平台赠送额度");
+    expect(html).toContain(">1.4M</strong><span>/</span><span>5M</span><em>Token</em>");
+    expect(html).toContain("自定义 API Key 消耗");
+    expect(html).not.toContain("查看用量详情");
     expect(html).toContain("select-control--compact select-control--subtle");
     expect(html).toContain('role="combobox"');
   });
@@ -506,19 +505,19 @@ describe("SettingsPageView", () => {
     expect(html).toContain("中文");
     expect(html).not.toContain("<select");
     expect(html).toContain("已关闭行为数据收集");
-    expect(html).toContain("Agent 任务额度已用 1.4M Token");
+    expect(html).toContain(">1.4M</strong><span>/</span><span>5M</span><em>Token</em>");
     expect(html).not.toContain("已使用 0 Token");
     expect(html).not.toContain("System");
     expect(html).not.toContain("注册于");
   });
 
-  it("Token 用量展示国际邮箱账号参与改进计划后的 300,000 Token 增量", () => {
+  it("Token 用量不再展示计划总额概览", () => {
     const html = normalizeSsrHtml(renderSettingsPageView(createImprovementBonusState()));
 
-    expect(html).toContain("赠送大模型额度已用 0.0M Token");
-    expect(html).toContain("共 30.3M Token");
-    expect(html).toContain("剩余 30.3M Token");
-    expect(html).not.toContain("共 30.0M Token");
+    expect(html).toContain("自定义 API Key 消耗");
+    expect(html).not.toContain("赠送大模型额度已用");
+    expect(html).not.toContain("共 30.3M Token");
+    expect(html).not.toContain("剩余 30.3M Token");
   });
 
   it("注册时间只展示年月日", () => {
@@ -559,9 +558,9 @@ describe("SettingsPageView", () => {
     expect(modelConfigHtml).toContain("Agent 任务模型");
     expect(modelConfigHtml).toContain("Memmy Platform · ASR");
     expect(modelConfigHtml).not.toContain("为语音识别 ASR选择模型 Memmy Platform · 通用文本");
-    expect(html).toContain("平台赠送大模型");
-    expect(html).toContain("自定义 API Key");
-    expect(html).toContain("查看用量详情");
+    expect(html).toContain("平台赠送额度");
+    expect(html).toContain("自定义 API Key 消耗");
+    expect(html).not.toContain("查看用量详情");
     expect(modelConfigHtml).not.toContain("当前模式：");
     expect(modelConfigHtml).not.toContain("切换为自定义 API Key");
     expect(modelConfigHtml).not.toContain("默认任务模型");
@@ -630,7 +629,7 @@ describe("SettingsPageView", () => {
     expect(source).not.toContain('onClick={handleSwitchToCustom}');
   });
 
-  it("Token 用量按原型包含渠道汇总和详情子页结构", () => {
+  it("Token 用量直接展示平台与自定义用量明细", () => {
     const source = readFileSync(settingsPageSourcePath, "utf8");
     const styles = readFileSync(tokenUsageStylesPath, "utf8");
 
@@ -642,16 +641,16 @@ describe("SettingsPageView", () => {
     expect(source).toContain("mb-6 flex items-center gap-3");
     expect(source).toContain("byokTokenUsageClient.getSummary");
     expect(source).toContain("EMPTY_BYOK_TOKEN_USAGE");
-    expect(source).toContain("function ChannelStat");
-    expect(source).toContain("function UsageDetailView");
+    expect(source).not.toContain("function ChannelStat");
+    expect(source).toContain("function UsageDetails");
     expect(source).toContain("function PlatformQuotaRow");
     expect(source).toContain("function ByokUsageRow");
     expect(source).toContain("function UsageSectionHead");
     expect(source).toContain("function formatTokenSummary");
     expect(source).toContain('return abbreviated === "0.0M" ? formatTokens(value) : abbreviated;');
     expect(source).toContain('import usageStyles from "./settings-token-usage.module.css";');
-    expect(source).toContain("usageStyles.detailPage");
-    expect(source).toContain("app-frame-page-content ${usageStyles.page}");
+    expect(source).toContain("usageStyles.detailContent");
+    expect(source).not.toContain("usageStyles.detailPage");
     expect(source).toContain("usageStyles.platformQuotaList");
     expect(source).toContain("usageStyles.byokUsageList");
     expect(source).toContain("usageStyles.usageSection");
@@ -659,11 +658,7 @@ describe("SettingsPageView", () => {
     expect(source).toContain("usageStyles.meter");
     expect(styles).toContain(".platformQuotaList");
     expect(styles).toContain(".byokUsageList");
-    const pageRule = styles.match(/\.page\s*\{[^}]*\}/)?.[0] ?? "";
-    expect(pageRule).toContain("box-sizing: border-box;");
-    expect(styles).toContain(".backButton");
-    const backButtonRule = styles.match(/\.backButton\s*\{[^}]*\}/)?.[0] ?? "";
-    expect(backButtonRule).toContain("cursor: pointer;");
+    expect(styles).not.toContain(".backButton");
     expect(source).toContain("const byokUsageByKind = TOKEN_USAGE_SCENES.map");
     expect(source).toContain("props.byokUsage.byModel.map");
     expect(source).toContain("function ByokModelUsageRow");
@@ -671,8 +666,9 @@ describe("SettingsPageView", () => {
     expect(source).not.toContain("getTaskModelCandidates(workspace, workspaceMode)");
     expect(source).toContain('"settings.token.modelBreakdownPending"');
     expect(source).toContain("usageSceneMeta(props.usage.scene, t)");
-    expect(source).toContain("updateShowUsageDetail(true)");
-    expect(source).toContain('reserveTopBar={!showUsageDetail}');
+    expect(source).not.toContain("updateShowUsageDetail");
+    expect(source).not.toContain("showUsageDetail");
+    expect(source).not.toContain("settings.token.viewDetail");
     expect(source).toContain('t("settings.token.input")');
     expect(source).toContain('t("settings.token.output")');
     expect(source).toContain('t("settings.token.cacheHit")');
@@ -756,8 +752,8 @@ describe("SettingsPageView", () => {
     expect(html).toContain("生图模型");
     expect(html).toContain("未配置");
     expect(html).toContain("Token 用量");
-    expect(html).toContain("查看用量详情");
-    expect(html).toContain("查看自定义 API Key 消耗");
+    expect(html).toContain("自定义 API Key 消耗");
+    expect(html).not.toContain("查看用量详情");
     expect(html).not.toContain("分别查看平台赠送额度和自定义 API Key 消耗");
     expect(html).not.toContain("切换回平台 Token");
     expect(html).not.toContain("当前模式：");


### PR DESCRIPTION
## Summary
- render the existing Token usage details directly in Settings without requiring a detail-page click
- move the invitation banner above Token usage and keep updated-at / apply-more controls in the outer view
- remove the obsolete overview cards and detail navigation while preserving platform/BYOK usage logic and filters

## Verification
- `npm.cmd run test -w @memmy/frontend-desktop` (141 files, 1407 tests passed)
- `npm.cmd run typecheck -w @memmy/frontend-desktop`
- `npm.cmd run build -w @memmy/frontend-desktop`
- `git diff --check`
- Manual Intl Electron check: Token usage details render inline and the app remains responsive

## UI consistency
- Secondary usage headings retain the exact styling from the previous detail page
- Documentation files are intentionally excluded from this PR