### PR TITLE
fix: repair Goal controls and active steering

### DIFF
--- a/App/frontend/desktop/src/pages/agent-goal-bar.tsx
+++ b/App/frontend/desktop/src/pages/agent-goal-bar.tsx
@@ -117,6 +117,12 @@ export function AgentGoalBar(props: AgentGoalBarProps) {
     });
   };
 
+  const submitControl = (request: AgentGoalControlRequest) => {
+    setForm(null);
+    setValidationError(null);
+    props.onControl(request);
+  };
+
   const submitForm = () => {
     if (!form) return;
     const objective = form.value.trim();
@@ -124,7 +130,7 @@ export function AgentGoalBar(props: AgentGoalBarProps) {
       setValidationError(t("home.goal.objectiveInvalid"));
       return;
     }
-    props.onControl({
+    submitControl({
       chatId: form.chatId,
       goalId: form.goalId,
       action: "edit",

--- a/App/frontend/desktop/src/pages/home-page.tsx
+++ b/App/frontend/desktop/src/pages/home-page.tsx
@@ -11,6 +11,7 @@ import {
   type MemmyAgentProject,
   type MemmyAgentSessionSummary,
   type MemmyAgentSlashCommand,
+  type AgentTurnSource,
   type MemmyAgentUiLanguage,
   type MemmyAgentWebSocketConnection,
   type UploadAgentMediaInput,
@@ -178,6 +179,11 @@ const TRANSLATABLE_AGENT_ERROR_KEYS = new Set<MessageKey>([
 ]);
 export const AGENT_ATTACHMENT_ACCEPT = agentAttachmentAccept();
 export const AGENT_MEDIA_ACCEPT = AGENT_ATTACHMENT_ACCEPT;
+
+export function isSteerableCurrentTurn(source: AgentTurnSource | null, isGoalActive: boolean): boolean {
+  if (!source) return isGoalActive;
+  return source.kind === "gui" && source.channel === "websocket";
+}
 export const AGENT_RESTART_STATE_STORAGE_KEY = "memmy-agent-restart-state";
 
 export interface ComposerSubmitButtonProps {
@@ -883,6 +889,8 @@ export function HomePage() {
   const currentQueuedMessages = state.agent.currentChatId
     ? state.agent.queuedMessagesByChatId[state.agent.currentChatId] ?? []
     : [];
+  const currentGoal = state.agent.goalState?.goal_id ? state.agent.goalState : null;
+  const isCurrentGoalActive = currentGoal?.status === "active";
   const currentActiveTurnId = state.agent.currentChatId
     ? state.agent.activeTurnIdByChatId[state.agent.currentChatId] ?? null
     : null;
@@ -895,8 +903,7 @@ export function HomePage() {
     && state.agent.recoveringGeneration === null
     && state.agent.runStartedAtByChatId[state.agent.currentChatId]
     && currentActiveTurnId
-    && currentActiveTurnSource?.kind === "gui"
-    && currentActiveTurnSource.channel === "websocket"
+    && isSteerableCurrentTurn(currentActiveTurnSource, Boolean(isCurrentGoalActive))
     && !currentQueuedMessages.some((item) => item.status === "steering")
   );
   const hasActiveConversation = hasActiveAgentConversation(state.agent.currentChatId, state.agent.messages.length);
@@ -924,8 +931,6 @@ export function HomePage() {
       state.agent.optimisticSendingByChatId[state.agent.currentChatId]
     )
   );
-  const currentGoal = state.agent.goalState?.goal_id ? state.agent.goalState : null;
-  const isCurrentGoalActive = currentGoal?.status === "active";
   const goalMutationPending = state.agent.currentChatId
     ? state.agent.goalMutationPendingByChatId[state.agent.currentChatId] ?? null
     : null;
@@ -1764,8 +1769,7 @@ export function HomePage() {
       || !connection
       || generation === null
       || !turnId
-      || source?.kind !== "gui"
-      || source.channel !== "websocket"
+      || !isSteerableCurrentTurn(source, Boolean(isCurrentGoalActive))
       || item?.source.kind !== "gui"
       || item.queueSurface !== "chat_composer"
       || item.content.trimStart().startsWith("/")

--- a/App/frontend/desktop/src/pages/tests/agent-goal-bar.test.tsx
+++ b/App/frontend/desktop/src/pages/tests/agent-goal-bar.test.tsx
@@ -291,6 +291,7 @@ describe("AgentGoalBar", () => {
       action: "edit",
       objective: "Updated objective"
     });
+    expect(container.querySelector(".agent-goal-bar__form")).toBeNull();
   });
 
   it("binds a form to the chat and Goal identity that opened it and discards stale drafts", () => {

--- a/App/frontend/desktop/src/pages/tests/home-page.test.tsx
+++ b/App/frontend/desktop/src/pages/tests/home-page.test.tsx
@@ -31,6 +31,7 @@ import {
   isAgentConversationAtBottom,
   isComposingKeyboardEvent,
   isSingleLineComposerInput,
+  isSteerableCurrentTurn,
   parseStoredAgentRestartState,
   parseComposerCommandDraft,
   readFocusedAgentChatId,
@@ -66,6 +67,14 @@ function mockCallOrder(fn: { mock: { invocationCallOrder: readonly number[] } },
 }
 
 describe("HomePage", () => {
+  it("allows Goal steering when source metadata is missing without opening TUI or IM turns", () => {
+    expect(isSteerableCurrentTurn(null, true)).toBe(true);
+    expect(isSteerableCurrentTurn(null, false)).toBe(false);
+    expect(isSteerableCurrentTurn({ kind: "gui", channel: "websocket" }, false)).toBe(true);
+    expect(isSteerableCurrentTurn({ kind: "tui", channel: "websocket" }, true)).toBe(false);
+    expect(isSteerableCurrentTurn({ kind: "im", channel: "slack" }, true)).toBe(false);
+  });
+
   it("renders the first-phase agent input controls", () => {
     const html = renderToString(
       <AppProviders>

--- a/App/memmy-agent/src/core/agent-runtime/goal-runtime.ts
+++ b/App/memmy-agent/src/core/agent-runtime/goal-runtime.ts
@@ -938,7 +938,14 @@ export class GoalRuntime {
       }
       const entry = inbox[index]!;
       if (entry.turnId !== null) return { value: { outcome: "reserved" as const } };
-      const source = parseTurnSource(entry.metadata.turn_source);
+      const persistedSource = parseTurnSource(entry.metadata.turn_source);
+      const source = persistedSource ?? (
+        entry.channel === "websocket"
+        && entry.metadata.webui === true
+        && entry.metadata.webui_queue_surface === requiredQueueSurface
+          ? { kind: "gui" as const, channel: "websocket" }
+          : null
+      );
       if (
         source?.kind !== "gui"
         || source.channel !== "websocket"
@@ -968,12 +975,24 @@ export class GoalRuntime {
           senderId: entry.senderId,
           content: entry.content,
           media: [...entry.media],
-          metadata: structuredClone(entry.metadata),
+          metadata: {
+            ...structuredClone(entry.metadata),
+            turn_source: source,
+          },
           timestamp: entry.receivedAt,
           sessionKey,
           turnSource: source,
         },
       };
+      const goalRoute = readGoalRoute(session.metadata);
+      if (
+        goalRoute
+        && !goalRoute.source
+        && goalRoute.channel === entry.channel
+        && goalRoute.chatId === entry.chatId
+      ) {
+        session.metadata[GOAL_ROUTE_KEY] = { ...goalRoute, source };
+      }
       session.metadata[GOAL_TURN_INBOX_KEY] = inbox.filter(
         (_, itemIndex) => itemIndex !== index,
       );
@@ -1059,7 +1078,11 @@ export class GoalRuntime {
   }
 
   async enqueueUserMessage(sessionKey: string, message: InboundMessage): Promise<GoalTurnInboxEntry> {
-    const metadata = sanitizeGoalInboxMetadata(message.channel, message.metadata ?? {});
+    const source = message.turnSource ?? parseTurnSource(message.metadata?.turn_source);
+    const metadata = sanitizeGoalInboxMetadata(message.channel, {
+      ...(message.metadata ?? {}),
+      ...(source ? { turn_source: source } : {}),
+    });
     const id = typeof metadata.client_request_id === "string" ? metadata.client_request_id : randomUUID();
     return this.mutate(sessionKey, (session) => {
       const inbox = parseInbox(session.metadata[GOAL_TURN_INBOX_KEY]);

--- a/App/memmy-agent/src/core/agent-runtime/loop.ts
+++ b/App/memmy-agent/src/core/agent-runtime/loop.ts
@@ -1986,13 +1986,20 @@ export class AgentLoop {
         return { outcome: "already_dequeued" as const, revision };
       }
       const slots = this.turnSlots.get(sessionKey) ?? [];
-      const activeSlot = slots.find((slot) => (
-        slot.turnId === expectedTurnId
-        && slot.state === "running"
-        && slot.acceptingSteer
-        && sharedTurnSource(slot.root)?.kind === "gui"
-        && sharedTurnSource(slot.root)?.channel === "websocket"
-      ));
+      const activeGoal = this.goalRuntime.get(sessionKey);
+      const activeGoalRoute = this.goalRuntime.route(sessionKey);
+      const activeSlot = slots.find((slot) => {
+        const source = sharedTurnSource(slot.root);
+        const ownsGuiTurn = source?.kind === "gui" && source.channel === "websocket";
+        const ownsLegacyGuiGoalTurn = !source
+          && activeGoal?.status === "active"
+          && activeGoalRoute?.channel === slot.root.channel
+          && activeGoalRoute.chatId === slot.root.chatId;
+        return slot.turnId === expectedTurnId
+          && slot.state === "running"
+          && slot.acceptingSteer
+          && (ownsGuiTurn || ownsLegacyGuiGoalTurn);
+      });
       if (!activeSlot) return { outcome: "not_steerable" as const, revision };
 
       const queuedSlot = slots.find((slot) => (
@@ -3705,7 +3712,11 @@ export class AgentLoop {
       ctx.msg.channel,
       ctx.msg.chatId,
       ctx.msg.metadata?.message_id ?? ctx.msg.metadata?.messageId ?? null,
-      { ...(ctx.msg.metadata ?? {}), ...turnMetadata(ctx.turnId) },
+      {
+        ...(ctx.msg.metadata ?? {}),
+        ...(sharedTurnSource(ctx.msg) ? { turn_source: sharedTurnSource(ctx.msg)! } : {}),
+        ...turnMetadata(ctx.turnId),
+      },
       ctx.sessionKey,
       sessionWorkspace,
       ctx.tools,

--- a/App/memmy-agent/tests/core/agent-runtime/goal-runtime.test.ts
+++ b/App/memmy-agent/tests/core/agent-runtime/goal-runtime.test.ts
@@ -646,11 +646,15 @@ describe("GoalRuntime control and inbox arbitration", () => {
         webui_queue_surface: "chat_composer",
         webui: true,
         queued_at: "2026-08-10T12:00:00.000Z",
-        turn_source: { kind: "gui", channel: "websocket" },
       },
       sessionKeyOverride: SESSION_KEY,
       turnSource: { kind: "gui", channel: "websocket" },
     }));
+
+    expect(runtime.inbox(SESSION_KEY)[0]?.metadata.turn_source).toEqual({
+      kind: "gui",
+      channel: "websocket",
+    });
 
     await expect(runtime.beginQueueSteerTransfer(
       SESSION_KEY,
@@ -687,6 +691,45 @@ describe("GoalRuntime control and inbox arbitration", () => {
     });
     await runtime.completeQueueSteerTransfer(SESSION_KEY, clientRequestId);
     expect(runtime.queueSteerTransfers(SESSION_KEY)).toEqual([]);
+  });
+
+  it("recovers a legacy WebUI Goal inbox source while transferring it", async () => {
+    const { runtime } = createRuntime();
+    await createGoal(runtime);
+    const clientRequestId = "23232323-2323-4232-8232-232323232323";
+    await runtime.enqueueUserMessage(SESSION_KEY, new InboundMessage({
+      channel: "websocket",
+      chatId: ROUTE.chatId,
+      senderId: "user",
+      content: "legacy GUI adjustment",
+      metadata: {
+        client_request_id: clientRequestId,
+        webui_request_digest: "legacy-goal-steer-digest",
+        webui_queue_surface: "chat_composer",
+        webui: true,
+        queued_at: "2026-08-10T12:00:00.000Z",
+      },
+      sessionKeyOverride: SESSION_KEY,
+    }));
+
+    await expect(runtime.beginQueueSteerTransfer(
+      SESSION_KEY,
+      clientRequestId,
+      "turn-active",
+      "chat_composer",
+      ROUTE,
+    )).resolves.toMatchObject({
+      outcome: "transferred",
+      transfer: {
+        descriptor: {
+          source: { kind: "gui", channel: "websocket" },
+        },
+      },
+    });
+    expect(runtime.route(SESSION_KEY)).toEqual({
+      ...ROUTE,
+      source: { kind: "gui", channel: "websocket" },
+    });
   });
 
   it("rejects missing WebUI dedupe fields and drops unsupported metadata", () => {

--- a/App/memmy-agent/tests/core/agent-runtime/loop-runner-integration.test.ts
+++ b/App/memmy-agent/tests/core/agent-runtime/loop-runner-integration.test.ts
@@ -109,6 +109,24 @@ describe("AgentLoop direct processing", () => {
     });
   });
 
+  it("passes the structured Turn source into tool request metadata", async () => {
+    const agent = loop(provider(["ok"]));
+    const source = { kind: "gui", channel: "websocket" } as const;
+    const contextSpy = vi.spyOn(agent, "setToolContext");
+
+    await agent.processMessage(new InboundMessage({
+      channel: "websocket",
+      chatId: "goal-source",
+      content: "create a Goal",
+      turnSource: source,
+    }));
+
+    expect(contextSpy.mock.calls.some((call) => (
+      call[3]?.turn_source?.kind === source.kind
+      && call[3]?.turn_source?.channel === source.channel
+    ))).toBe(true);
+  });
+
   it("keeps a projected CLI Session on its canonical workspace across the whole turn", async () => {
     const root = workspace();
     process.env.MEMMY_AGENT_DATA_DIR = path.join(root, "data");

--- a/App/memmy-agent/tests/core/agent-runtime/loop-turn-admission.test.ts
+++ b/App/memmy-agent/tests/core/agent-runtime/loop-turn-admission.test.ts
@@ -951,6 +951,152 @@ describe("AgentLoop Turn admission", () => {
     await running;
   });
 
+  it("steers a GUI Goal inbox item into a legacy continuation without source metadata", async () => {
+    const loop = makeLoop();
+    const sessionKey = "websocket:legacy-goal-steer";
+    const chatId = "legacy-goal-steer";
+    const clientRequestId = "78787878-7878-4878-8878-787878787878";
+    loop.sessions.getOrCreate(sessionKey);
+    const goal = await loop.goalRuntime.create({
+      sessionKey,
+      objective: "Finish the legacy Goal",
+      route: { channel: "websocket", chatId },
+      turnId: "goal-create-turn",
+    });
+    loop.goalRuntime.releaseTurn(sessionKey, "goal-create-turn");
+    let releaseActive!: () => void;
+    const activeGate = new Promise<void>((resolve) => {
+      releaseActive = resolve;
+    });
+    loop.processMessageInternal = vi.fn(async (message: InboundMessage, _key, options: any) => {
+      if (message.internal?.kind === "goal_continuation") {
+        options.slot.acceptingSteer = true;
+        await activeGate;
+      }
+      options.slot.stopReason = "completed";
+      return null;
+    }) as any;
+
+    const running = loop.run();
+    const activeTurnId = "legacy-goal-active-turn";
+    expect(loop.goalRuntime.reserveWork(sessionKey, activeTurnId, "continuation")).toBe(true);
+    await loop.bus.publishInbound(new InboundMessage({
+      channel: "websocket",
+      chatId,
+      content: "Continue the Goal",
+      metadata: { turn_id: activeTurnId },
+      internal: {
+        kind: "goal_continuation",
+        goalId: goal.goalId,
+        goalUpdatedAt: goal.updatedAt,
+      },
+      sessionKeyOverride: sessionKey,
+    }));
+    await waitUntil(() => (loop.turnSlots.get(sessionKey) as any[])?.[0]?.acceptingSteer === true);
+    await loop.bus.publishInbound(new InboundMessage({
+      channel: "websocket",
+      chatId,
+      content: "put it on the desktop",
+      metadata: {
+        client_request_id: clientRequestId,
+        webui_request_digest: "legacy-goal-steer-digest",
+        webui_queue_surface: "chat_composer",
+        webui: true,
+      },
+      sessionKeyOverride: sessionKey,
+      turnSource: { kind: "gui", channel: "websocket" },
+    }));
+    await waitUntil(() => loop.goalRuntime.inbox(sessionKey).length === 1);
+
+    await expect(loop.steerQueuedWebuiMessage(
+      sessionKey,
+      clientRequestId,
+      activeTurnId,
+    )).resolves.toMatchObject({
+      outcome: "steered",
+      turnId: activeTurnId,
+    });
+    expect(loop.goalRuntime.route(sessionKey)).toEqual({
+      channel: "websocket",
+      chatId,
+      source: { kind: "gui", channel: "websocket" },
+    });
+
+    releaseActive();
+    await waitUntil(() => !loop.isSessionBusy(sessionKey));
+    loop.stop();
+    await running;
+  });
+
+  it("does not treat a source-less WebSocket turn outside the Goal route as steerable", async () => {
+    const loop = makeLoop();
+    const sessionKey = "websocket:legacy-goal-route-mismatch";
+    const goalChatId = "goal-route";
+    const otherChatId = "other-route";
+    const clientRequestId = "89898989-8989-4898-8898-898989898989";
+    loop.sessions.getOrCreate(sessionKey);
+    const goal = await loop.goalRuntime.create({
+      sessionKey,
+      objective: "Keep steering on the Goal route",
+      route: { channel: "websocket", chatId: goalChatId },
+      turnId: "goal-route-create-turn",
+    });
+    loop.goalRuntime.releaseTurn(sessionKey, "goal-route-create-turn");
+    let releaseActive!: () => void;
+    const activeGate = new Promise<void>((resolve) => {
+      releaseActive = resolve;
+    });
+    loop.processMessageInternal = vi.fn(async (_message: InboundMessage, _key, options: any) => {
+      options.slot.acceptingSteer = true;
+      await activeGate;
+      options.slot.stopReason = "completed";
+      return null;
+    }) as any;
+
+    const running = loop.run();
+    const activeTurnId = "legacy-goal-route-mismatch-turn";
+    expect(loop.goalRuntime.reserveWork(sessionKey, activeTurnId, "continuation")).toBe(true);
+    await loop.bus.publishInbound(new InboundMessage({
+      channel: "websocket",
+      chatId: otherChatId,
+      content: "A different source-less WebSocket turn",
+      metadata: { turn_id: activeTurnId },
+      internal: {
+        kind: "goal_continuation",
+        goalId: goal.goalId,
+        goalUpdatedAt: goal.updatedAt,
+      },
+      sessionKeyOverride: sessionKey,
+    }));
+    await waitUntil(() => (loop.turnSlots.get(sessionKey) as any[])?.[0]?.acceptingSteer === true);
+    await loop.goalRuntime.enqueueUserMessage(sessionKey, new InboundMessage({
+      channel: "websocket",
+      chatId: otherChatId,
+      content: "Do not steer this into the Goal",
+      metadata: {
+        client_request_id: clientRequestId,
+        webui_request_digest: "legacy-goal-route-mismatch-digest",
+        webui_queue_surface: "chat_composer",
+        webui: true,
+      },
+      sessionKeyOverride: sessionKey,
+      turnSource: { kind: "gui", channel: "websocket" },
+    }));
+
+    await expect(loop.steerQueuedWebuiMessage(
+      sessionKey,
+      clientRequestId,
+      activeTurnId,
+    )).resolves.toMatchObject({ outcome: "not_steerable" });
+    await expect(loop.removeQueuedWebuiMessage(sessionKey, clientRequestId))
+      .resolves.toMatchObject({ outcome: "removed" });
+
+    releaseActive();
+    await waitUntil(() => !loop.isSessionBusy(sessionKey));
+    loop.stop();
+    await running;
+  });
+
   it("leaves stale, cross-surface, and slash queue items untouched", async () => {
     const loop = makeLoop();
     const sessionKey = "websocket:queue-steer-reject";


### PR DESCRIPTION
## Summary
- close the Goal edit form immediately after a successful control submission
- preserve GUI turn-source metadata and recover legacy Goal WebUI source metadata
- allow active Goal chat-composer adjustments to steer the running turn without admitting TUI, IM, slash, non-Goal source-less, or cross-route turns
- keep upstream's removal of GUI Goal budget controls

## Verification
- frontend focused tests: 2 files, 114 tests passed
- Goal runtime and turn admission: 2 files, 51 tests passed
- focused Agent steering regressions, including matching and cross-route legacy cases, passed
- frontend typecheck passed
- memmy-agent typecheck passed
- git diff --check passed

## Baseline note
- `extracts document media before building prompt and keeps image media for multimodal content` times out at its existing 5-second limit on both this branch and an untouched `upstream/v1.0.7` worktree.