### PR TITLE
chore(release): prepare Memmy v1.0.7

### DIFF
--- a/.github/release-notes/v1.0.7.md
+++ b/.github/release-notes/v1.0.7.md
@@ -1,0 +1,19 @@
+# Memmy v1.0.7
+
+## Highlights
+
+- Added persistent goals for longer Agent tasks. Memmy can keep the active objective, progress, and continuation context across turns instead of treating every message as a separate task.
+- Added per-session model selection and a unified model workspace for account models and BYOK providers, with provider-aware connection checks and clearer configuration status.
+- Added DeepSeek Harness as an Agent source, including local history discovery and Memmy Skill installation for sharing Memory on demand.
+
+## Agent and desktop improvements
+
+- Improved cross-Agent task continuity across desktop, IM channels, and the terminal interface, including queued messages and more consistent session projection.
+- Added provider and model logos, clearer model-selection controls, and safer handling when a configured model or endpoint is unavailable.
+- Improved terminal startup, restart, and gateway behavior so configuration migrations and session recovery complete before the interactive interface connects.
+
+## Memory and reliability improvements
+
+- Added versioned migrations for model configuration and goal state so existing installations can move to the new runtime structure without losing supported settings.
+- Improved Memory task routing, retrieval query handling, episode processing, and related error reporting for more reliable capture and recall.
+- Strengthened session admission, cancellation, transcript synchronization, and tool-result handling to reduce duplicated, misplaced, or incomplete conversation state.

--- a/App/backend/src/project-version.ts
+++ b/App/backend/src/project-version.ts
@@ -1,2 +1,2 @@
 /** Generated from the root package.json by scripts/sync-project-version.mjs. */
-export const MEMMY_VERSION = "1.0.5";
+export const MEMMY_VERSION = "1.0.7";

--- a/App/memmy-agent/package-lock.json
+++ b/App/memmy-agent/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "memmy-agent",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "memmy-agent",
-      "version": "1.0.6",
+      "version": "1.0.7",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.100.1",
         "@aws-sdk/client-bedrock-runtime": "^3.1061.0",

--- a/App/memmy-agent/package.json
+++ b/App/memmy-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memmy-agent",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "TypeScript refactor of memmy's agent runtime.",
   "type": "module",
   "main": "./dist/index.js",

--- a/App/shell/desktop/package.json
+++ b/App/shell/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memmy/desktop",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "private": true,
   "type": "module",
   "description": "Memmy desktop client.",

--- a/Memory/package.json
+++ b/Memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memmy/memory",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "private": true,
   "type": "module",
   "main": "./dist/src/index.js",

--- a/Memory/src/cli/npm/package.json
+++ b/Memory/src/cli/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memtensor/memmy-memory-cli",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Memmy Memory CLI for local agent memory.",
   "type": "module",
   "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "memmy-agent",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "memmy-agent",
-      "version": "1.0.6",
+      "version": "1.0.7",
       "workspaces": [
         "Migrations",
         "Memory",
@@ -87,7 +87,7 @@
     },
     "App/shell/desktop": {
       "name": "@memmy/desktop",
-      "version": "1.0.6",
+      "version": "1.0.7",
       "dependencies": {
         "@memmy/backend": "0.0.0",
         "@memmy/desktop-interface": "0.0.0",
@@ -224,7 +224,7 @@
     },
     "Memory": {
       "name": "@memmy/memory",
-      "version": "1.0.6",
+      "version": "1.0.7",
       "dependencies": {
         "@huggingface/transformers": "^3.8.0",
         "@memmy/local-api-contracts": "0.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memmy-agent",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "private": true,
   "type": "module",
   "description": "Local-first agent memory substrate with desktop and CLI surfaces.",


### PR DESCRIPTION
## 目标

修复 v1.0.7 发版 Action 在版本元数据校验阶段失败的问题，并提供一份经过代码证据核对的 v1.0.7 Release Notes。

## 变更

- 将根包、Memory、Memory CLI、Agent、Desktop、生成版本常量及 lockfile 统一到 `1.0.7`
- 新增 `.github/release-notes/v1.0.7.md`，作为人工审核过的 Draft Release 文案输入
- 不修改发版工作流逻辑，不创建 tag，不创建 Release，不发布安装包

## 验证

- `npm run version:check`：通过
- `npm run test:release-workflow`：18/18 通过
- `git diff --check`：通过

## 合并后

合并后由发版人手动重新运行 `GitHub Draft Release v2` 的 smoke/full dry-run；通过后再创建 Draft Release。仍需人工检查并点击 Publish。