### PR TITLE
fix(release): validate compare target explicitly

### DIFF
--- a/.github/workflows/github-draft-release-v2.yml
+++ b/.github/workflows/github-draft-release-v2.yml
@@ -307,6 +307,14 @@ jobs:
             echo "::error title=Release compare metadata failed::Could not validate ${base_sha}...${TARGET_SHA} against GitHub. Manual recovery: confirm both commits are reachable in the repository, then retry." >&2
             exit 1
           fi
+          # GitHub Compare metadata has no top-level head_commit field. Validate
+          # the remote target through the exact commit endpoint instead.
+          if ! gh api --method GET \
+            "repos/${GITHUB_REPOSITORY}/commits/${TARGET_SHA}" \
+            > release-assets/TARGET_COMMIT_METADATA.json; then
+            echo "::error title=Release target metadata failed::Could not validate target commit ${TARGET_SHA} against GitHub. Manual recovery: confirm the merged main commit is reachable in the repository, then retry." >&2
+            exit 1
+          fi
 
           node scripts/build-release-compare.mjs \
             --base "$base_sha" \
@@ -316,7 +324,7 @@ jobs:
 
           api_base="$(jq -r '.base_commit.sha // empty' release-assets/COMPARE_METADATA.json)"
           api_merge_base="$(jq -r '.merge_base_commit.sha // empty' release-assets/COMPARE_METADATA.json)"
-          api_head="$(jq -r '.head_commit.sha // empty' release-assets/COMPARE_METADATA.json)"
+          api_target="$(jq -r '.sha // empty' release-assets/TARGET_COMMIT_METADATA.json)"
           api_status="$(jq -r '.status // empty' release-assets/COMPARE_METADATA.json)"
           api_ahead="$(jq -r '.ahead_by // -1' release-assets/COMPARE_METADATA.json)"
           api_behind="$(jq -r '.behind_by // -1' release-assets/COMPARE_METADATA.json)"
@@ -325,7 +333,7 @@ jobs:
           local_files="$(jq -r '.files | length' release-assets/COMPARE.json)"
           local_head="$(jq -r '.head_commit.sha // empty' release-assets/COMPARE.json)"
 
-          if [[ "$api_base" != "$base_sha" || "$api_merge_base" != "$base_sha" || "$api_head" != "$TARGET_SHA" || "$local_head" != "$TARGET_SHA" ]]; then
+          if [[ "$api_base" != "$base_sha" || "$api_merge_base" != "$base_sha" || "$api_target" != "$TARGET_SHA" || "$local_head" != "$TARGET_SHA" ]]; then
             echo "::error title=Release comparison identity mismatch::GitHub and the trusted checkout do not agree on the base, merge base, or target. Manual recovery: refresh the target checkout and retry without changing the tag." >&2
             exit 1
           fi
@@ -853,6 +861,7 @@ jobs:
             release-assets/RELEASE_NOTES_SOURCE.json
             release-assets/QUALITY_REPORT.json
             release-assets/COMPARE_METADATA.json
+            release-assets/TARGET_COMMIT_METADATA.json
             release-assets/COMPARE.json
             release-assets/PULL_REQUESTS.json
             release-assets/RELEASE_EVIDENCE.json

--- a/tests/release-workflow.test.ts
+++ b/tests/release-workflow.test.ts
@@ -359,6 +359,34 @@ describe("GitHub Draft Release v2 workflow", () => {
     expect(download).toContain("SHA256SUMS.txt");
   });
 
+  it("does not expect a nonexistent head_commit in GitHub Compare metadata", () => {
+    const realCompareMetadataShape = {
+      base_commit: { sha: "base-sha" },
+      merge_base_commit: { sha: "base-sha" },
+      status: "ahead",
+      ahead_by: 2,
+      behind_by: 0,
+      total_commits: 2,
+      commits: [{ sha: "first-commit" }],
+      files: [],
+    };
+    expect(realCompareMetadataShape).not.toHaveProperty("head_commit");
+
+    const snapshot = draftScript("Build complete release change snapshot");
+    expect(snapshot).not.toContain("api_head=");
+    expect(snapshot).not.toContain(
+      "'.head_commit.sha // empty' release-assets/COMPARE_METADATA.json",
+    );
+    expect(snapshot).toContain('"repos/${GITHUB_REPOSITORY}/commits/${TARGET_SHA}"');
+    expect(snapshot).toContain("TARGET_COMMIT_METADATA.json");
+    expect(snapshot).toContain("Release target metadata failed");
+    expect(snapshot).toContain("api_target");
+    expect(snapshot).toContain('"$api_target" != "$TARGET_SHA"');
+    expect(snapshot).toContain(
+      "'.head_commit.sha // empty' release-assets/COMPARE.json",
+    );
+  });
+
   it("records independently auditable commits, PRs, files, versions, and assets", () => {
     for (const stepName of [
       "Build complete release change snapshot",
@@ -432,6 +460,7 @@ describe("GitHub Draft Release v2 workflow", () => {
     expect(JSON.stringify(uploadAudit)).toContain("RELEASE_NOTES_SOURCE.json");
     expect(JSON.stringify(uploadAudit)).toContain("QUALITY_REPORT.json");
     expect(JSON.stringify(uploadAudit)).toContain("COMPARE_METADATA.json");
+    expect(JSON.stringify(uploadAudit)).toContain("TARGET_COMMIT_METADATA.json");
     expect(JSON.stringify(uploadAudit)).toContain("COMPARE.json");
     expect(JSON.stringify(uploadAudit)).toContain("PULL_REQUESTS.json");
     expect(draftScript("Create draft release and upload every asset")).toContain(


### PR DESCRIPTION
## Problem

The merged v1.0.7 release Action ([run 32009739539](https://github.com/MemTensor/memmy-agent/actions/runs/32009739539)) failed in `Build complete release change snapshot`. GitHub Compare REST responses do not contain a top-level `head_commit`, so reading `.head_commit.sha` always returned empty and triggered a false identity mismatch.

## Fix

- Keep GitHub Compare validation for the exact base SHA, merge-base, status, ahead/behind counts, and total commit count.
- Validate the remote target SHA through `GET /repos/{owner}/{repo}/commits/{TARGET_SHA}`.
- Keep the local complete snapshot `head_commit.sha` validation against the trusted checkout.
- Upload `TARGET_COMMIT_METADATA.json` with the release audit artifact.
- Add a regression test that models the real Compare response shape without `head_commit` and prevents the invalid read from returning.

## Verification

- Regression test observed failing before the workflow change.
- Release workflow tests: **20/20 passed**.
- Actual v1.0.6 → failed v1.0.7 target comparison: **431 commits / 496 files**, all base/merge-base/remote-target/local-target/count checks passed.
- Project Harness Full gate: **12/12 passed** on `13bf60f3d97a16a5f9fd76e578d36b5564fa1660` against `main@5fd094b1b8a04151d506cdbfc68b4b52b0cb42df`.

## Recovery after merge

Do not rerun the old failed event. After this PR is merged, manually dispatch `GitHub Draft Release v2` from `main` with:

- `version`: `1.0.7`
- `preflight_level`: `full`
- `create_draft`: `true`
- `target_sha`: leave empty

There is currently no `v1.0.7` Tag or Release. This PR does not create, move, or publish either one. A different MemTensor maintainer must independently review and approve this T3 change.