### PR TITLE
feat(settings): refine token usage layout

### DIFF
--- a/App/frontend/desktop/src/pages/settings-page.tsx
+++ b/App/frontend/desktop/src/pages/settings-page.tsx
@@ -1336,90 +1336,6 @@ export function SettingsPageView(props: SettingsPageViewProps) {
           aria-labelledby="settings-tab-tokens"
           hidden={activeTab !== "tokens"}
         >
-        {isAccountMode && showGiftQuota && showInvitationBanner ? (
-          <div
-            className={`mb-6 flex items-center gap-3 px-4 py-3 rounded-card-lg border ${
-              inviteDailyLimitReached
-                ? "bg-text-ink/[0.05] border-border-stone/50"
-                : "bg-action-sky/6 border-action-sky/15"
-            }`}
-          >
-            <span
-              className={`w-8 h-8 shrink-0 rounded-full flex items-center justify-center ${
-                inviteDailyLimitReached ? "bg-text-ink/10 text-text-ink/40" : "bg-action-sky/12 text-action-sky"
-              }`}
-            >
-              <Gift size={15} strokeWidth={2.1} aria-hidden="true" />
-            </span>
-            <div className="min-w-0 flex-1">
-              <p className="text-sm text-text-ink/80 leading-5">{t("settings.token.invite.title")}</p>
-              <p
-                className={`mt-0.5 text-xs leading-4 ${
-                  inviteDailyLimitReached ? "text-text-ink/50" : "text-text-ink/45"
-                }`}
-              >
-                {invitationLoadStatus === "error"
-                  ? t("settings.token.invite.loadFailed")
-                  : invitationLoadStatus === "loading" || invitationLoadStatus === "idle"
-                    ? t("settings.token.invite.loading")
-                    : inviteDailyLimitReached
-                      ? t("settings.token.invite.dailyLimit")
-                      : invitationRewardBody}
-              </p>
-            </div>
-            {displayInviteCode ? (
-              <div className="shrink-0 flex items-center gap-2">
-              <code
-                className={`px-2.5 py-1.5 text-xs font-semibold tracking-wide bg-background-paper rounded-input border ${
-                  inviteDailyLimitReached
-                    ? "text-text-ink/35 border-border-stone/50"
-                    : "text-text-ink border-action-sky/20"
-                }`}
-              >
-                {displayInviteCode}
-              </code>
-              <button
-                type="button"
-                className={`inline-flex items-center gap-1 px-2.5 py-1.5 text-xs rounded-btn border transition-colors cursor-pointer ${
-                  inviteDailyLimitReached
-                    ? "text-text-ink/35 border-border-stone/50 hover:bg-text-ink/[0.03]"
-                    : "text-action-sky border-action-sky/30 hover:bg-action-sky/8"
-                }`}
-                onClick={() => {
-                  void (async () => {
-                    try {
-                      if (typeof navigator === "undefined" || typeof navigator.clipboard?.writeText !== "function") {
-                        throw new Error("Clipboard API is unavailable");
-                      }
-                      await copyInvitationCode({
-                        invitationCode: displayInviteCode,
-                        clipboard: navigator.clipboard,
-                        track
-                      });
-                      setInviteCopied(true);
-                      window.setTimeout(() => setInviteCopied(false), 2000);
-                    } catch (error) {
-                      console.warn("copy invite code failed", error);
-                    }
-                  })();
-                }}
-              >
-                <Copy size={12} strokeWidth={2.2} />
-                {inviteCopied ? t("settings.token.invite.copied") : t("settings.token.invite.copy")}
-              </button>
-              </div>
-            ) : invitationLoadStatus === "error" ? (
-              <button
-                type="button"
-                className="shrink-0 px-2.5 py-1.5 text-xs rounded-btn border text-action-sky border-action-sky/30 hover:bg-action-sky/8 cursor-pointer"
-                onClick={() => setInvitationReloadVersion((current) => current + 1)}
-              >
-                {t("settings.token.invite.retry")}
-              </button>
-            ) : null}
-          </div>
-        ) : null}
-
         <div id="token-usage" className="mb-6">
           <div className="flex items-center justify-between gap-4 mb-3">
             <div className="flex items-center gap-2">
@@ -1462,6 +1378,90 @@ export function SettingsPageView(props: SettingsPageViewProps) {
             byokUsageStatus={byokUsageStatus}
           />
         </div>
+
+        {isAccountMode && showGiftQuota && showInvitationBanner ? (
+          <div
+            className={`${usageStyles.invitationCard} border ${
+              inviteDailyLimitReached
+                ? "bg-text-ink/[0.05] border-border-stone/50"
+                : "bg-action-sky/6 border-action-sky/15"
+            }`}
+          >
+            <span
+              className={`w-8 h-8 shrink-0 rounded-full flex items-center justify-center ${
+                inviteDailyLimitReached ? "bg-text-ink/10 text-text-ink/40" : "bg-action-sky/12 text-action-sky"
+              }`}
+            >
+              <Gift size={15} strokeWidth={2.1} aria-hidden="true" />
+            </span>
+            <div className="min-w-0">
+              <p className="text-sm text-text-ink/80 leading-5">{t("settings.token.invite.title")}</p>
+              <p
+                className={`mt-0.5 text-xs leading-4 ${
+                  inviteDailyLimitReached ? "text-text-ink/50" : "text-text-ink/45"
+                }`}
+              >
+                {invitationLoadStatus === "error"
+                  ? t("settings.token.invite.loadFailed")
+                  : invitationLoadStatus === "loading" || invitationLoadStatus === "idle"
+                    ? t("settings.token.invite.loading")
+                    : inviteDailyLimitReached
+                      ? t("settings.token.invite.dailyLimit")
+                      : invitationRewardBody}
+              </p>
+            </div>
+            {displayInviteCode ? (
+              <div className={usageStyles.invitationActions}>
+                <code
+                  className={`px-2.5 py-1.5 text-xs font-semibold tracking-wide bg-background-paper rounded-input border ${
+                    inviteDailyLimitReached
+                      ? "text-text-ink/35 border-border-stone/50"
+                      : "text-text-ink border-action-sky/20"
+                  }`}
+                >
+                  {displayInviteCode}
+                </code>
+                <button
+                  type="button"
+                  className={`inline-flex items-center gap-1 px-2.5 py-1.5 text-xs rounded-btn border transition-colors cursor-pointer ${
+                    inviteDailyLimitReached
+                      ? "text-text-ink/35 border-border-stone/50 hover:bg-text-ink/[0.03]"
+                      : "text-action-sky border-action-sky/30 hover:bg-action-sky/8"
+                  }`}
+                  onClick={() => {
+                    void (async () => {
+                      try {
+                        if (typeof navigator === "undefined" || typeof navigator.clipboard?.writeText !== "function") {
+                          throw new Error("Clipboard API is unavailable");
+                        }
+                        await copyInvitationCode({
+                          invitationCode: displayInviteCode,
+                          clipboard: navigator.clipboard,
+                          track
+                        });
+                        setInviteCopied(true);
+                        window.setTimeout(() => setInviteCopied(false), 2000);
+                      } catch (error) {
+                        console.warn("copy invite code failed", error);
+                      }
+                    })();
+                  }}
+                >
+                  <Copy size={12} strokeWidth={2.2} />
+                  {inviteCopied ? t("settings.token.invite.copied") : t("settings.token.invite.copy")}
+                </button>
+              </div>
+            ) : invitationLoadStatus === "error" ? (
+              <button
+                type="button"
+                className="shrink-0 px-2.5 py-1.5 text-xs rounded-btn border text-action-sky border-action-sky/30 hover:bg-action-sky/8 cursor-pointer"
+                onClick={() => setInvitationReloadVersion((current) => current + 1)}
+              >
+                {t("settings.token.invite.retry")}
+              </button>
+            ) : null}
+          </div>
+        ) : null}
         </div>
 
         <div

--- a/App/frontend/desktop/src/pages/settings-token-usage.module.css
+++ b/App/frontend/desktop/src/pages/settings-token-usage.module.css
@@ -13,6 +13,22 @@
   letter-spacing: 0;
 }
 
+.invitationCard {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 16px;
+  border-radius: var(--radius-card-lg);
+}
+
+.invitationActions {
+  display: flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 8px;
+}
+
 .updated,
 .statusError {
   display: inline-flex;
@@ -468,6 +484,20 @@
 /* --- Responsive --- */
 
 @media (max-width: 640px) {
+  .invitationCard {
+    grid-template-columns: auto minmax(0, 1fr);
+  }
+
+  .invitationActions,
+  .invitationCard > button {
+    grid-column: 2;
+    justify-self: start;
+  }
+
+  .invitationActions {
+    flex-wrap: wrap;
+  }
+
   .sectionHead {
     display: block;
   }

--- a/App/frontend/desktop/src/pages/tests/settings-invitation-banner.test.tsx
+++ b/App/frontend/desktop/src/pages/tests/settings-invitation-banner.test.tsx
@@ -115,7 +115,7 @@ describe("SettingsPage invitation banner", () => {
       .find((element) => element.textContent === "邀请好友，享更多额度");
     const invitationBanner = inviteTitle?.parentElement?.parentElement;
     const tokenUsageSection = container.querySelector("#token-usage");
-    expect(invitationBanner?.nextElementSibling).toBe(tokenUsageSection);
+    expect(tokenUsageSection?.nextElementSibling).toBe(invitationBanner);
   });
 });
 

--- a/App/frontend/desktop/src/pages/tests/settings-page.test.tsx
+++ b/App/frontend/desktop/src/pages/tests/settings-page.test.tsx
@@ -638,7 +638,12 @@ describe("SettingsPageView", () => {
     expect(source).toContain("requestAccountInvitation(accountClient, accountKey)");
     expect(source).not.toContain("resolveDisplayInviteCode");
     expect(source).toContain('t("settings.token.invite.title")');
-    expect(source).toContain("mb-6 flex items-center gap-3");
+    expect(source).toContain("usageStyles.invitationCard");
+    expect(styles).toContain(".invitationCard");
+    const compactStyles = styles.slice(styles.indexOf("@media (max-width: 640px)"));
+    expect(compactStyles).toContain("grid-template-columns: auto minmax(0, 1fr)");
+    expect(compactStyles).toContain("grid-column: 2");
+    expect(compactStyles).toContain("flex-wrap: wrap");
     expect(source).toContain("byokTokenUsageClient.getSummary");
     expect(source).toContain("EMPTY_BYOK_TOKEN_USAGE");
     expect(source).not.toContain("function ChannelStat");


### PR DESCRIPTION
## Summary
- place Token usage before the invitation card so usage details remain the primary content
- move the invitation card below all platform and BYOK usage sections
- add a responsive grid so invitation actions wrap cleanly below 640px
- preserve invitation loading, retry, copy, and analytics behavior

## Verification
- `npm exec -w @memmy/frontend-desktop vitest run src/pages/tests/settings-invitation-banner.test.tsx src/pages/tests/settings-page-token-usage.interaction.test.tsx src/pages/tests/settings-page.test.tsx` (3 files, 64 tests passed)
- `npm run build -w @memmy/frontend-desktop`
- `git diff --check upstream/v1.0.9...HEAD`
- Manual Electron check: Token usage renders first and the invitation card appears below the complete usage breakdown

## Scope
- only the settings Token usage component, its existing CSS module, and focused tests are changed