### PR TITLE
fix(packaging): validate Windows packaged ASAR output

### DIFF
--- a/scripts/internal/shared/verify-packaged-asar.mjs
+++ b/scripts/internal/shared/verify-packaged-asar.mjs
@@ -7,7 +7,7 @@ if (!/^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/.test(expected)) {
   throw new Error("Expected packaged version must use semantic version syntax");
 }
 
-const entries = listPackage(asarPath).map((entry) => entry.replace(/^\/+/, ""));
+const entries = listPackage(asarPath).map((entry) => entry.replaceAll("\\", "/").replace(/^\/+/, ""));
 if (entries.some((entry) => /(^|\/)\.env(?:$|\.)/u.test(entry))) {
   throw new Error("Packaged ASAR contains a forbidden environment file");
 }
@@ -16,9 +16,7 @@ const requiredFiles = [
   "dist/main/desktop-edition.json",
   "package.json",
   "dist/runtime/memory/package.json",
-  "dist/runtime/memory/package-lock.json",
   "dist/runtime/memmy-agent/package.json",
-  "dist/runtime/memmy-agent/package-lock.json",
   "dist/runtime/memmy-agent/node_modules/@memmy/local-api-contracts/dist/index.js",
 ];
 const entrySet = new Set(entries);
@@ -33,6 +31,9 @@ for (const [file, lock] of [
   ["dist/runtime/memmy-agent/package.json", false],
   ["dist/runtime/memmy-agent/package-lock.json", true],
 ]) {
+  // electron-builder excludes npm lockfiles by default. The staged-runtime
+  // version guard validates them before packaging; re-check any that are kept.
+  if (lock && !entrySet.has(file)) continue;
   const json = readAsarJson(asarPath, file);
   if (json.version !== expected) {
     throw new Error(`Packaged version does not match the requested version: ${file}`);
@@ -46,7 +47,8 @@ console.log(`Verified packaged ASAR boundary and version ${expected}`);
 
 function readAsarJson(path, file) {
   try {
-    return JSON.parse(extractFile(path, file).toString("utf8"));
+    const archiveFile = process.platform === "win32" ? file.replaceAll("/", "\\") : file;
+    return JSON.parse(extractFile(path, archiveFile).toString("utf8"));
   } catch {
     throw new Error(`Packaged runtime JSON is invalid: ${file}`);
   }

--- a/tests/packaged-runtime-config.test.mjs
+++ b/tests/packaged-runtime-config.test.mjs
@@ -159,6 +159,14 @@ describe("packaged desktop runtime configuration", () => {
     });
     expect(good.status, good.stderr).toBe(0);
 
+    const noLocksAsar = await createAsarFixture(root, "without-locks", "1.0.8", false, false);
+    const withoutLocks = spawnSync(
+      process.execPath,
+      [verifier, "--asar", noLocksAsar, "--expected", "1.0.8"],
+      { encoding: "utf8" },
+    );
+    expect(withoutLocks.status, withoutLocks.stderr).toBe(0);
+
     const staleAsar = await createAsarFixture(root, "stale", "1.0.7");
     const stale = spawnSync(process.execPath, [verifier, "--asar", staleAsar, "--expected", "1.0.8"], {
       encoding: "utf8",
@@ -175,7 +183,7 @@ describe("packaged desktop runtime configuration", () => {
   });
 });
 
-async function createAsarFixture(root, name, version, includeEnv = false) {
+async function createAsarFixture(root, name, version, includeEnv = false, includeLocks = true) {
   const source = join(root, `${name}-source`);
   const asar = join(root, `${name}.asar`);
   const manifest = { version };
@@ -186,7 +194,7 @@ async function createAsarFixture(root, name, version, includeEnv = false) {
   });
   for (const component of ["memory", "memmy-agent"]) {
     writeFixtureJson(join(source, `dist/runtime/${component}/package.json`), manifest);
-    writeFixtureJson(join(source, `dist/runtime/${component}/package-lock.json`), lock);
+    if (includeLocks) writeFixtureJson(join(source, `dist/runtime/${component}/package-lock.json`), lock);
   }
   const contracts = join(
     source,


### PR DESCRIPTION
## Summary
- normalize `@electron/asar` entry separators before checking required packaged files on Windows
- use Windows-native separators when extracting JSON from `app.asar`
- allow npm lockfiles that electron-builder excludes by default to be absent, while still validating their version when present
- add a regression fixture for the real no-lockfile ASAR layout

## Verification
- `npm run test:packaging-guards` (15 passed)
- `npm run version:check`
- real Windows PROD signed dual build completed for INTL and CN v1.0.8
- both installers passed NSIS integrity, Windows loader, Authenticode, timestamp, and packaged ASAR checks