### PR TITLE
fix: recover startup from legacy model config

### DIFF
--- a/App/backend/local-api-contracts/src/index.ts
+++ b/App/backend/local-api-contracts/src/index.ts
@@ -214,9 +214,13 @@ export const ByokTokenUsageSummarySchema = z.object({
 });
 export type ByokTokenUsageSummary = z.infer<typeof ByokTokenUsageSummarySchema>;
 
+export const AgentGatewayStartupIssueSchema = z.enum(["model_config_invalid"]);
+export type AgentGatewayStartupIssue = z.infer<typeof AgentGatewayStartupIssueSchema>;
+
 export const AgentGatewayRuntimeConfigSchema = z.object({
     baseUrl: z.string().url(),
-    bootstrapSecret: z.string().min(1).optional()
+    bootstrapSecret: z.string().min(1).optional(),
+    startupIssue: AgentGatewayStartupIssueSchema.optional()
 });
 export type AgentGatewayRuntimeConfig = z.infer<typeof AgentGatewayRuntimeConfigSchema>;
 

--- a/App/frontend/desktop/src/pages/home-page.tsx
+++ b/App/frontend/desktop/src/pages/home-page.tsx
@@ -1,5 +1,6 @@
 /** Home page module. */
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type ChangeEvent, type ClipboardEvent, type CSSProperties, type DragEvent, type KeyboardEvent, type PointerEvent as ReactPointerEvent, type SetStateAction, type UIEvent } from "react";
+import type { AgentGatewayStartupIssue } from "@memmy/local-api-contracts";
 import { hydrateAgentThreadInBackground, refreshAgentTaskList, useAgentRuntimeBridge, type AgentTaskStateCoordinator } from "../app/agent-runtime-bridge.js";
 import { useApiClients } from "../app/providers.js";
 import { FOCUSED_AGENT_CHAT_STORAGE_KEY, clearFocusedAgentTarget, isAccountTokenQuotaExhausted, normalizeAgentChatId, readLaunchAgentChatId, removeLaunchAgentChatIdFromUrl } from "../app/routes.js";
@@ -1527,7 +1528,10 @@ export function HomePage() {
     : state.agent.recoveryKind === "reconnect"
       ? "reconnecting"
       : state.agent.connectionStatus;
-  const statusText = agentStatusText(displayConnectionStatus, state.agent.modelName, t);
+  const statusText = agentStatusText(displayConnectionStatus, state.agent.modelName, t, {
+    startupIssue: clients?.runtimeConfig.agentGateway?.startupIssue,
+    hasConnected: state.agent.hasConnectedSinceStartup
+  });
   const operationErrorNotice = state.agent.operationErrorNotice;
   const visibleOperationError = operationErrorNotice
     && (operationErrorNotice.scopeKey
@@ -2794,7 +2798,7 @@ export function HomePage() {
               {displayConnectionStatus !== "connected" && (
                 <div className="text-center">
                   <span className="inline-flex text-[11px] px-3 py-1 rounded-tag bg-background-paper text-text-ink/55 border border-border-stone/30">
-                    {agentStatusText(displayConnectionStatus, state.agent.modelName, t)}
+                    {statusText}
                   </span>
                 </div>
               )}
@@ -3457,12 +3461,19 @@ const AGENT_OPERATION_ERROR_MESSAGE_KEYS: Record<string, MessageKey> = {
   attachment_read_failed: "home.media.error.sendReadFailed"
 };
 
-export function agentStatusText(status: string, modelName: string | null, t: HomeTranslate): string | null {
+export function agentStatusText(
+  status: string,
+  modelName: string | null,
+  t: HomeTranslate,
+  context: { startupIssue?: AgentGatewayStartupIssue; hasConnected?: boolean } = {}
+): string | null {
   if (status === "connected") {
     return null;
   }
   if (status === "error") {
-    return t("home.agent.failed");
+    return t(context.startupIssue === "model_config_invalid" && !context.hasConnected
+      ? "home.modelSelector.unavailable"
+      : "home.agent.failed");
   }
   if (status === "reconnecting") {
     return t("home.agent.reconnecting");

--- a/App/frontend/desktop/src/pages/tests/home-page.test.tsx
+++ b/App/frontend/desktop/src/pages/tests/home-page.test.tsx
@@ -213,6 +213,13 @@ describe("HomePage", () => {
     expect(agentStatusText("connecting", null, (key) => key)).toBe("home.agent.connecting");
     expect(agentStatusText("reconnecting", null, (key) => key)).toBe("home.agent.reconnecting");
     expect(agentStatusText("error", null, (key) => key)).toBe("home.agent.failed");
+    expect(agentStatusText("error", null, (key) => key, {
+      startupIssue: "model_config_invalid"
+    })).toBe("home.modelSelector.unavailable");
+    expect(agentStatusText("error", null, (key) => key, {
+      startupIssue: "model_config_invalid",
+      hasConnected: true
+    })).toBe("home.agent.failed");
   });
 
   it("shows the specific queue steer failure messages", () => {

--- a/App/frontend/desktop/src/state/agent-chat-slice.ts
+++ b/App/frontend/desktop/src/state/agent-chat-slice.ts
@@ -174,6 +174,7 @@ export interface AgentState {
   operationErrorNotice: AgentOperationError | null;
   operationErrorsBySurface: Record<AgentOperationSurface, AgentOperationError | null>;
   connectionGeneration: number;
+  hasConnectedSinceStartup: boolean;
   recoveringGeneration: number | null;
   recoveringChatId: string | null;
   recoveringChatSelectionEpoch: number | null;
@@ -338,6 +339,7 @@ export const initialAgentState: AgentState = {
   operationErrorNotice: null,
   operationErrorsBySurface: { chat: null, sidebar: null },
   connectionGeneration: 0,
+  hasConnectedSinceStartup: false,
   recoveringGeneration: null,
   recoveringChatId: null,
   recoveringChatSelectionEpoch: null,
@@ -2519,7 +2521,8 @@ function reduceWsEvent(state: AgentState, event: MemmyAgentWsEvent): AgentState 
           ...base,
           connectionStatus: "connected",
           connectionError: null,
-          connectionGeneration: readyGeneration
+          connectionGeneration: readyGeneration,
+          hasConnectedSinceStartup: true
         });
       }
       const pendingCanonicalHydrateByChatId = { ...base.pendingCanonicalHydrateByChatId };
@@ -2534,6 +2537,7 @@ function reduceWsEvent(state: AgentState, event: MemmyAgentWsEvent): AgentState 
         connectionStatus: "connected",
         connectionError: null,
         connectionGeneration: readyGeneration,
+        hasConnectedSinceStartup: true,
         recoveringGeneration: readyGeneration,
         recoveringChatId: base.currentChatId,
         recoveringChatSelectionEpoch: base.currentChatId ? base.chatSelectionEpoch : null,

--- a/App/frontend/desktop/src/state/tests/agent-chat-slice.test.ts
+++ b/App/frontend/desktop/src/state/tests/agent-chat-slice.test.ts
@@ -4966,6 +4966,19 @@ describe("agent chat slice", () => {
     expect(state.currentChatId).toBe("chat-1");
   });
 
+  it("remembers a successful connection after the Agent bridge is disposed", () => {
+    let state = agentReducer(initialAgentState, {
+      type: "agent/wsEvent",
+      event: { event: "ready", chat_id: "chat-1", connection_generation: 1 }
+    });
+    expect(state.hasConnectedSinceStartup).toBe(true);
+
+    state = agentReducer(state, { type: "agent/connectionDisposed" });
+
+    expect(state.connectionGeneration).toBe(0);
+    expect(state.hasConnectedSinceStartup).toBe(true);
+  });
+
   it("does not treat attached as an application-ready connection", () => {
     const state = agentReducer({ ...initialAgentState, connectionStatus: "connecting" }, {
       type: "agent/wsEvent",

--- a/App/shell/desktop/src/main/main.ts
+++ b/App/shell/desktop/src/main/main.ts
@@ -774,12 +774,16 @@ async function startLocalApi(services: ManagedRuntimeServices | null): Promise<D
     memoryBaseUrl: memoryControl.baseUrl,
     runtimeConfigPath: process.env.MEMMY_HOME ? join(process.env.MEMMY_HOME, "runtime.json") : undefined
   });
-  const agentGateway = services?.agentGateway ?? await resolveAgentGatewayRuntimeConfig();
+  const agentGateway: NonNullable<DesktopRuntimeConfig["agentGateway"]> =
+    services?.agentGateway ?? await resolveAgentGatewayRuntimeConfig();
   const agentGatewayConfig: NonNullable<DesktopRuntimeConfig["agentGateway"]> = {
     baseUrl: agentGateway.baseUrl
   };
   if (agentGateway.bootstrapSecret) {
     agentGatewayConfig.bootstrapSecret = agentGateway.bootstrapSecret;
+  }
+  if (agentGateway.startupIssue) {
+    agentGatewayConfig.startupIssue = agentGateway.startupIssue;
   }
 
   return {

--- a/App/shell/desktop/src/main/runtime-services.ts
+++ b/App/shell/desktop/src/main/runtime-services.ts
@@ -1,4 +1,5 @@
 import { mutateRuntimeConfig } from "@memmy/migrations";
+import type { AgentGatewayStartupIssue } from "@memmy/local-api-contracts";
 import { execFileSync, spawn, type ChildProcess } from "node:child_process";
 import { randomBytes, randomUUID } from "node:crypto";
 import { existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
@@ -34,6 +35,7 @@ export interface ManagedRuntimeServices {
     bootstrapSecret: string;
     configPath: string;
     workspace: string;
+    startupIssue?: AgentGatewayStartupIssue;
   };
   restartMemory(): Promise<void>;
   close(): Promise<void>;
@@ -200,7 +202,7 @@ export async function startManagedRuntimeServices(
       .catch((error) => {
         console.warn(`Memory service unavailable during desktop startup: ${errorMessage(error)}`);
       });
-    await gatewaySupervisor.ensureStarted();
+    const agentGatewayStartupIssue = await startAgentGatewayWithRecovery(gatewaySupervisor);
 
     return {
       memory: {
@@ -213,7 +215,8 @@ export async function startManagedRuntimeServices(
         baseUrl: runtimeConfig.agentGatewayBaseUrl,
         bootstrapSecret: runtimeConfig.agentGatewayBootstrapSecret,
         configPath: runtimeConfig.configPath,
-        workspace: runtimeConfig.agentWorkspace
+        workspace: runtimeConfig.agentWorkspace,
+        ...(agentGatewayStartupIssue ? { startupIssue: agentGatewayStartupIssue } : {})
       },
       async restartMemory() {
         if (closing) {
@@ -829,6 +832,26 @@ export interface AgentGatewaySupervisorDependencies {
   clearTimer?: typeof clearTimeout;
 }
 
+export async function startAgentGatewayWithRecovery(
+  supervisor: Pick<AgentGatewaySupervisor, "ensureStarted" | "startRecovery">
+): Promise<AgentGatewayStartupIssue | null> {
+  try {
+    await supervisor.ensureStarted();
+    return null;
+  } catch (error) {
+    console.warn(`Agent gateway unavailable during desktop startup: ${errorMessage(error)}`);
+    supervisor.startRecovery();
+    return classifyAgentGatewayStartupIssue(error);
+  }
+}
+
+function classifyAgentGatewayStartupIssue(error: unknown): AgentGatewayStartupIssue | null {
+  const message = errorMessage(error);
+  return /failed to load config[\s\S]*\b(providers|modelPresets|modelAssignments|agents\.defaults)\b/i.test(message)
+    ? "model_config_invalid"
+    : null;
+}
+
 export class AgentGatewaySupervisor {
   ownership: "external" | "owned" | null = null;
   ownedChild: ManagedChild | null = null;
@@ -875,6 +898,11 @@ export class AgentGatewaySupervisor {
       this.startPromise = null;
     });
     return this.startPromise;
+  }
+
+  startRecovery(): void {
+    if (this.stopping || this.hasReachedReady) return;
+    this.scheduleReplacement();
   }
 
   async close(): Promise<void> {
@@ -1068,6 +1096,9 @@ export class AgentGatewaySupervisor {
     }
     try {
       await this.spawnOwnedGateway(false);
+      if (!this.hasReachedReady) {
+        this.scheduleReplacement();
+      }
     } catch {
       this.scheduleReplacement();
     }

--- a/App/shell/desktop/tests/packaged-runtime-boundary.test.ts
+++ b/App/shell/desktop/tests/packaged-runtime-boundary.test.ts
@@ -476,8 +476,11 @@ describe("desktop packaged runtime boundaries", () => {
     const contractsSource = readFileSync(localApiContractsPath, "utf8");
 
     expect(contractsSource).toContain("bootstrapSecret: z.string().min(1).optional()");
+    expect(contractsSource).toContain("startupIssue: AgentGatewayStartupIssueSchema.optional()");
     expect(mainSource).toContain("if (agentGateway.bootstrapSecret) {");
     expect(mainSource).toContain("agentGatewayConfig.bootstrapSecret = agentGateway.bootstrapSecret;");
+    expect(mainSource).toContain("if (agentGateway.startupIssue) {");
+    expect(mainSource).toContain("agentGatewayConfig.startupIssue = agentGateway.startupIssue;");
     expect(mainSource).not.toContain("bootstrapSecret: agentGateway.bootstrapSecret");
   });
 

--- a/App/shell/desktop/tests/runtime-services.test.ts
+++ b/App/shell/desktop/tests/runtime-services.test.ts
@@ -20,6 +20,7 @@ import {
   runPackagedMigrationCommand,
   restartExternalMemoryService,
   spawnNodeService,
+  startAgentGatewayWithRecovery,
   startPackagedBrowserPreparation,
   stopManagedChild,
   syncBundledAgentSkills,
@@ -837,6 +838,89 @@ describe("AgentGatewaySupervisor", () => {
     expect(harness.spawn).toHaveBeenCalledTimes(1);
     expect(harness.supervisor.hasReachedReady).toBe(false);
     expect(harness.supervisor.restartTimer).toBeNull();
+  });
+
+  it("keeps retrying after an explicitly recoverable initial startup failure", async () => {
+    vi.useFakeTimers();
+    const waitForHttpService = vi.fn()
+      .mockRejectedValueOnce(new Error("invalid runtime config"))
+      .mockRejectedValueOnce(new Error("runtime config is still invalid"))
+      .mockResolvedValueOnce(undefined);
+    const harness = createSupervisorHarness({
+      waitForHttpService,
+      stopManagedChild: vi.fn(async (child: ManagedChild) => {
+        emitChildClose(child, 1);
+      })
+    });
+
+    await expect(harness.supervisor.ensureStarted()).rejects.toThrow("invalid runtime config");
+    harness.supervisor.startRecovery();
+    await vi.advanceTimersByTimeAsync(249);
+    expect(harness.spawn).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(harness.spawn).toHaveBeenCalledTimes(2);
+    expect(harness.supervisor.hasReachedReady).toBe(false);
+    await vi.advanceTimersByTimeAsync(999);
+    expect(harness.spawn).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(harness.spawn).toHaveBeenCalledTimes(3);
+    expect(harness.supervisor.hasReachedReady).toBe(true);
+    expect(harness.supervisor.restartTimer).toBeNull();
+  });
+
+  it("cancels pending initial recovery during shutdown", async () => {
+    vi.useFakeTimers();
+    const harness = createSupervisorHarness({
+      waitForHttpService: vi.fn(async () => {
+        throw new Error("invalid runtime config");
+      }),
+      stopManagedChild: vi.fn(async (child: ManagedChild) => {
+        emitChildClose(child, 1);
+      })
+    });
+
+    await expect(harness.supervisor.ensureStarted()).rejects.toThrow("invalid runtime config");
+    harness.supervisor.startRecovery();
+    await harness.supervisor.close();
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(harness.spawn).toHaveBeenCalledTimes(1);
+    expect(harness.supervisor.restartTimer).toBeNull();
+  });
+
+  it("contains the initial Agent failure and enables background recovery", async () => {
+    const failure = new Error("invalid runtime config");
+    const supervisor = {
+      ensureStarted: vi.fn(async () => {
+        throw failure;
+      }),
+      startRecovery: vi.fn()
+    };
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    await expect(startAgentGatewayWithRecovery(supervisor)).resolves.toBeNull();
+
+    expect(supervisor.startRecovery).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith(
+      "Agent gateway unavailable during desktop startup: invalid runtime config"
+    );
+  });
+
+  it("classifies a rejected model config without exposing the startup error", async () => {
+    const supervisor = {
+      ensureStarted: vi.fn(async () => {
+        throw new Error(
+          "agent-gateway exited before it became ready (code 1). stderr: memmy: Failed to load config from C:/Memmy/config.yaml: providers current contract does not accept legacy field 'apiBase'"
+        );
+      }),
+      startRecovery: vi.fn()
+    };
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    await expect(startAgentGatewayWithRecovery(supervisor)).resolves.toBe("model_config_invalid");
+    expect(supervisor.startRecovery).toHaveBeenCalledTimes(1);
   });
 
   it("restarts an owned gateway with bounded escalating delays and ignores old child callbacks", async () => {

--- a/Migrations/src/migrations/v1.0.7/0001-normalize-runtime-model-catalog.ts
+++ b/Migrations/src/migrations/v1.0.7/0001-normalize-runtime-model-catalog.ts
@@ -212,7 +212,10 @@ function authValueEquals(left: unknown, right: unknown): boolean {
   return stableJson(left ?? null) === stableJson(right ?? null);
 }
 
-function normalizeProviderCatalog(config: JsonObject): ProviderCatalogNormalization {
+function normalizeProviderCatalog(
+  config: JsonObject,
+  migrationId: string,
+): ProviderCatalogNormalization {
   const providers = objectAt(config, "providers") ?? {};
   const normalizedProviders: JsonObject = {};
   const defaultEndpoints: Record<string, string> = {};
@@ -228,7 +231,7 @@ function normalizeProviderCatalog(config: JsonObject): ProviderCatalogNormalizat
       throw new MigrationError(
         "migration_config_invalid",
         `Provider ${legacyId} must be an object`,
-        { migrationId: MIGRATION_ID, scope: "runtime-config" },
+        { migrationId, scope: "runtime-config" },
       );
     }
     const providerId = canonicalProviderId(legacyId);
@@ -247,7 +250,7 @@ function normalizeProviderCatalog(config: JsonObject): ProviderCatalogNormalizat
         throw new MigrationError(
           "migration_config_invalid",
           `Endpoint ${legacyId}/${endpointId} must be an object`,
-          { migrationId: MIGRATION_ID, scope: "runtime-config" },
+          { migrationId, scope: "runtime-config" },
         );
       }
       const endpoint = structuredClone(rawEndpoint);
@@ -257,7 +260,7 @@ function normalizeProviderCatalog(config: JsonObject): ProviderCatalogNormalizat
         throw new MigrationError(
           "migration_config_invalid",
           `Endpoint ${legacyId}/${endpointId} is missing apiBase`,
-          { migrationId: MIGRATION_ID, scope: "runtime-config" },
+          { migrationId, scope: "runtime-config" },
         );
       }
       endpoint.apiBase = normalizeApiBase(apiBase);
@@ -599,7 +602,11 @@ function rewritePresetReference(
   }
 }
 
-function normalizePresets(config: JsonObject, normalization: ProviderCatalogNormalization): void {
+function normalizePresets(
+  config: JsonObject,
+  normalization: ProviderCatalogNormalization,
+  migrationId: string,
+): void {
   const { defaultEndpoints, endpointReferences } = normalization;
   const presets = objectAt(config, "modelPresets") ?? {};
   const providers = objectAt(config, "providers") ?? {};
@@ -638,7 +645,7 @@ function normalizePresets(config: JsonObject, normalization: ProviderCatalogNorm
         throw new MigrationError(
           "migration_config_invalid",
           "Legacy account model preset is missing an owner account ID",
-          { migrationId: MIGRATION_ID, scope: "runtime-config" },
+          { migrationId, scope: "runtime-config" },
         );
       }
       const replacements: Partial<Record<CatalogCapability, string>> = {};
@@ -968,7 +975,7 @@ function hasCurrentAccountCatalog(config: RuntimeConfigDocument): boolean {
   return Boolean(endpoint && endpoint.protocol === "memmy-account" && isHttpUrl(endpoint.apiBase));
 }
 
-function normalizeRuntimeCatalog(config: RuntimeConfigDocument): void {
+function normalizeRuntimeCatalog(config: RuntimeConfigDocument, migrationId: string): void {
   flattenLegacyMemoryModelConfig(config);
   liftLegacyRoots(config);
   const legacy = captureLegacyConnections(config);
@@ -988,8 +995,8 @@ function normalizeRuntimeCatalog(config: RuntimeConfigDocument): void {
   );
 
   removeInvalidByokAccountPresets(config);
-  const normalization = normalizeProviderCatalog(config);
-  normalizePresets(config, normalization);
+  const normalization = normalizeProviderCatalog(config, migrationId);
+  normalizePresets(config, normalization, migrationId);
   ensureAccountCatalog(config);
   mergeLegacyByokCatalog(config, legacy);
   removeLegacyRuntimeModelFields(config);
@@ -1007,35 +1014,40 @@ function normalizeRuntimeCatalog(config: RuntimeConfigDocument): void {
   config.app = app;
 }
 
-function wrapError(error: unknown): never {
+function wrapError(error: unknown, migrationId: string): never {
   if (error instanceof MigrationError) {
-    if (error.migrationId !== null) throw error;
+    if (error.migrationId === migrationId) throw error;
     throw new MigrationError(error.code, error.message, {
-      migrationId: MIGRATION_ID,
+      migrationId,
       scope: "runtime-config",
       cause: error.cause,
     });
   }
   throw new MigrationError("migration_config_invalid", "Unable to normalize runtime model catalog", {
-    migrationId: MIGRATION_ID,
+    migrationId,
     scope: "runtime-config",
     cause: error,
   });
 }
 
-async function migrate(context: AgentWorkspaceMigrationContext): Promise<MigrationResult> {
+export async function runRuntimeModelCatalogMigration(
+  context: AgentWorkspaceMigrationContext,
+  migrationId: string,
+): Promise<MigrationResult> {
   try {
-    const mutator = (config: RuntimeConfigDocument): void => normalizeRuntimeCatalog(config);
+    const mutator = (config: RuntimeConfigDocument): void => normalizeRuntimeCatalog(config, migrationId);
     const options = { createIfMissing: false as const };
     const result = context.runtimeConfigLock
       ? await mutateRuntimeConfigLockHeld(context.runtimeConfigLock, mutator, options)
       : await mutateRuntimeConfig(context.runtimeConfigFile, mutator, options);
-    if (!result.sourceExists) return { scanned: 0, changed: 0, ignored: 1 };
+    if (!result.sourceExists) {
+      return { scanned: 0, changed: 0, ignored: 0, deferred: true };
+    }
     return result.changed
       ? { scanned: 1, changed: 1, ignored: 0 }
       : { scanned: 1, changed: 0, ignored: 1 };
   } catch (error) {
-    wrapError(error);
+    wrapError(error, migrationId);
   }
 }
 
@@ -1044,11 +1056,11 @@ export const normalizeRuntimeModelCatalogV107: MigrationDefinition = {
   introducedIn: "1.0.7",
   scope: "runtime-config",
   description: "Normalize legacy model settings into the runtime model catalog",
-  up: migrate,
+  up: (context) => runRuntimeModelCatalogMigration(context, MIGRATION_ID),
 };
 
 export function normalizeRuntimeModelCatalogForTest(
   context: AgentWorkspaceMigrationContext,
 ): Promise<MigrationResult> {
-  return migrate(context);
+  return runRuntimeModelCatalogMigration(context, MIGRATION_ID);
 }

--- a/Migrations/src/migrations/v1.0.9/0001-repair-runtime-model-catalog.ts
+++ b/Migrations/src/migrations/v1.0.9/0001-repair-runtime-model-catalog.ts
@@ -1,0 +1,12 @@
+import { runRuntimeModelCatalogMigration } from "../v1.0.7/0001-normalize-runtime-model-catalog.js";
+import type { MigrationDefinition } from "../../types.js";
+
+const MIGRATION_ID = "v1.0.9/0001-repair-runtime-model-catalog";
+
+export const repairRuntimeModelCatalogV109: MigrationDefinition = {
+  id: MIGRATION_ID,
+  introducedIn: "1.0.9",
+  scope: "runtime-config",
+  description: "Repair runtime model catalogs skipped by the original migration",
+  up: (context) => runRuntimeModelCatalogMigration(context, MIGRATION_ID),
+};

--- a/Migrations/src/registry.ts
+++ b/Migrations/src/registry.ts
@@ -3,6 +3,7 @@ import { normalizeRuntimeModelCatalogV107 } from "./migrations/v1.0.7/0001-norma
 import { importLegacyAppStateModelConfigV107 } from "./migrations/v1.0.7/0002-import-legacy-app-state-model-config.js";
 import { normalizeGoalStateV107 } from "./migrations/v1.0.7/0003-normalize-goal-state.js";
 import { addGoalDagBoundaryV107 } from "./migrations/v1.0.7/0004-add-goal-dag-boundary.js";
+import { repairRuntimeModelCatalogV109 } from "./migrations/v1.0.9/0001-repair-runtime-model-catalog.js";
 import { MigrationError, type MigrationDefinition } from "./types.js";
 
 const STABLE_SEMVER_PATTERN =
@@ -22,6 +23,7 @@ export const migrations: readonly MigrationDefinition[] = [
   importLegacyAppStateModelConfigV107,
   normalizeGoalStateV107,
   addGoalDagBoundaryV107,
+  repairRuntimeModelCatalogV109,
 ];
 
 function definitionError(message: string, migrationId: string | null = null): never {

--- a/Migrations/tests/0001-normalize-runtime-model-catalog.test.ts
+++ b/Migrations/tests/0001-normalize-runtime-model-catalog.test.ts
@@ -282,7 +282,7 @@ describe("v1.0.7/0001-normalize-runtime-model-catalog", () => {
     expect(config.modelPresets.stable.futurePreset.keep).toBe(true);
   });
 
-  it("ignores a missing config without creating it", async () => {
+  it("defers a missing config without creating it", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "memmy-model-catalog-missing-"));
     roots.push(root);
     const configPath = path.join(root, "config.yaml");
@@ -296,7 +296,8 @@ describe("v1.0.7/0001-normalize-runtime-model-catalog", () => {
     await expect(normalizeRuntimeModelCatalogForTest(context)).resolves.toEqual({
       scanned: 0,
       changed: 0,
-      ignored: 1,
+      ignored: 0,
+      deferred: true,
     });
     await expect(fs.stat(configPath)).rejects.toMatchObject({ code: "ENOENT" });
   });

--- a/Migrations/tests/0001-repair-runtime-model-catalog.test.ts
+++ b/Migrations/tests/0001-repair-runtime-model-catalog.test.ts
@@ -1,0 +1,132 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import YAML from "yaml";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { normalizeRuntimeModelCatalogV107 } from "../src/migrations/v1.0.7/0001-normalize-runtime-model-catalog.js";
+import { repairRuntimeModelCatalogV109 } from "../src/migrations/v1.0.9/0001-repair-runtime-model-catalog.js";
+import { runMigrationsForTest } from "../src/runner.js";
+import type { MigrationLogger, RunMigrationsOptions } from "../src/types.js";
+
+const roots: string[] = [];
+
+function logger(): MigrationLogger {
+  return { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+}
+
+async function workspace(): Promise<string> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "memmy-model-catalog-repair-"));
+  roots.push(root);
+  return fs.realpath(root);
+}
+
+function options(root: string, configPath: string): RunMigrationsOptions {
+  return {
+    targets: {
+      agentWorkspace: root,
+      runtimeConfigFile: configPath,
+      sessionDagDir: path.join(root, "session-dag"),
+    },
+    logger: logger(),
+  };
+}
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true })));
+});
+
+describe("v1.0.9/0001-repair-runtime-model-catalog", () => {
+  it("attributes repair failures to the v1.0.9 migration", async () => {
+    const root = await workspace();
+    const configPath = path.join(root, "config.yaml");
+    await fs.writeFile(configPath, YAML.stringify({
+      memmyMemory: { activeProfile: "broken" },
+    }), "utf8");
+
+    await expect(repairRuntimeModelCatalogV109.up({
+      profileWorkspace: root,
+      sessionsDir: path.join(root, "sessions"),
+      runtimeConfigFile: configPath,
+      sessionDagDir: path.join(root, "session-dag"),
+      logger: logger(),
+    })).rejects.toMatchObject({
+      code: "migration_config_invalid",
+      migrationId: repairRuntimeModelCatalogV109.id,
+      scope: "runtime-config",
+    });
+  });
+
+  it("leaves the original migration pending until a config file appears", async () => {
+    const root = await workspace();
+    const configPath = path.join(root, "config.yaml");
+
+    const deferred = await runMigrationsForTest(options(root, configPath), {
+      definitions: [normalizeRuntimeModelCatalogV107],
+    });
+    expect(deferred).toMatchObject({
+      applied: [],
+      skipped: [],
+      deferred: [normalizeRuntimeModelCatalogV107.id],
+    });
+
+    await fs.writeFile(configPath, YAML.stringify({
+      providers: {
+        openai: { apiBase: "https://api.example.test/v1", apiKey: "sk-legacy" },
+      },
+      agents: { defaults: { model: "openai/gpt-4.1" } },
+    }), "utf8");
+
+    const applied = await runMigrationsForTest(options(root, configPath), {
+      definitions: [normalizeRuntimeModelCatalogV107],
+    });
+    expect(applied.applied.map((item) => item.id)).toEqual([normalizeRuntimeModelCatalogV107.id]);
+    const config = YAML.parse(await fs.readFile(configPath, "utf8"));
+    expect(config.providers.openai).not.toHaveProperty("apiBase");
+    expect(config.providers.openai.endpoints.chat).toMatchObject({
+      apiBase: "https://api.example.test/v1",
+      protocol: "openai-chat-completions",
+    });
+  });
+
+  it("repairs a legacy field reintroduced after the v1.0.7 marker was written", async () => {
+    const root = await workspace();
+    const configPath = path.join(root, "config.yaml");
+    await fs.writeFile(configPath, YAML.stringify({
+      providers: {
+        openai: { apiBase: "https://api.example.test/v1", apiKey: "sk-legacy" },
+      },
+      agents: { defaults: { model: "openai/gpt-4.1" } },
+    }), "utf8");
+
+    await runMigrationsForTest(options(root, configPath), {
+      definitions: [normalizeRuntimeModelCatalogV107],
+    });
+    const current = YAML.parse(await fs.readFile(configPath, "utf8"));
+    current.providers.openai.apiBase = "https://api.changed.test/v1/";
+    current.providers.openai.apiType = "responses";
+    await fs.writeFile(configPath, YAML.stringify(current), "utf8");
+
+    const repaired = await runMigrationsForTest(options(root, configPath), {
+      definitions: [normalizeRuntimeModelCatalogV107, repairRuntimeModelCatalogV109],
+    });
+    expect(repaired.skipped).toEqual([normalizeRuntimeModelCatalogV107.id]);
+    expect(repaired.applied.map((item) => item.id)).toEqual([repairRuntimeModelCatalogV109.id]);
+
+    const config = YAML.parse(await fs.readFile(configPath, "utf8"));
+    expect(config.providers.openai).not.toHaveProperty("apiBase");
+    expect(config.providers.openai).not.toHaveProperty("apiType");
+    expect(Object.values(config.providers.openai.endpoints)).toContainEqual(expect.objectContaining({
+      apiBase: "https://api.changed.test/v1",
+      protocol: "openai-responses",
+    }));
+
+    const repeated = await runMigrationsForTest(options(root, configPath), {
+      definitions: [normalizeRuntimeModelCatalogV107, repairRuntimeModelCatalogV109],
+    });
+    expect(repeated.applied).toEqual([]);
+    expect(repeated.skipped).toEqual([
+      normalizeRuntimeModelCatalogV107.id,
+      repairRuntimeModelCatalogV109.id,
+    ]);
+  });
+});

--- a/Migrations/tests/runner.test.ts
+++ b/Migrations/tests/runner.test.ts
@@ -110,9 +110,10 @@ describe("migration runner", () => {
       "v1.0.7/0001-normalize-runtime-model-catalog",
       "v1.0.7/0003-normalize-goal-state",
       "v1.0.7/0004-add-goal-dag-boundary",
+      "v1.0.9/0001-repair-runtime-model-catalog",
     ]);
     expect(first.deferred).toEqual(["v1.0.7/0002-import-legacy-app-state-model-config"]);
-    expect(first.results).toEqual({ scanned: 3, changed: 2, ignored: 1 });
+    expect(first.results).toEqual({ scanned: 4, changed: 2, ignored: 2 });
     expect(second).toEqual({
       applied: [],
       skipped: [
@@ -120,6 +121,7 @@ describe("migration runner", () => {
         "v1.0.7/0001-normalize-runtime-model-catalog",
         "v1.0.7/0003-normalize-goal-state",
         "v1.0.7/0004-add-goal-dag-boundary",
+        "v1.0.9/0001-repair-runtime-model-catalog",
       ],
       deferred: ["v1.0.7/0002-import-legacy-app-state-model-config"],
       results: { scanned: 0, changed: 0, ignored: 0 },
@@ -159,6 +161,15 @@ describe("migration runner", () => {
         target: {
           type: "session-dag",
           key: expect.stringMatching(/^[a-f0-9]{64}$/),
+        },
+      },
+      {
+        id: "v1.0.9/0001-repair-runtime-model-catalog",
+        introducedIn: "1.0.9",
+        appliedAt: expect.stringMatching(/Z$/),
+        target: {
+          type: "runtime-config",
+          key: runtimeConfigTargetKey(configPath),
         },
       },
     ]);


### PR DESCRIPTION
## Summary

- defer the original v1.0.7 runtime model catalog migration when `config.yaml` is absent, so it can still run once user config exists
- add the v1.0.9 repair migration to normalize legacy provider-level `apiBase` and protocol fields
- keep the desktop app available when the owned Agent Gateway fails its initial start, and retry recovery in the background
- classify invalid model configuration as the existing model-unavailable state without changing existing copy such as `home.agent.failed`

## Verification

- `npm test -w @memmy/migrations` — 115/115 passed
- local API contracts — 8/8 passed
- focused desktop frontend tests — 280/280 passed
- typecheck passed for migrations, local API contracts, desktop frontend, and desktop shell
- `git diff --check upstream/v1.0.9...HEAD` passed
- final code review: APPROVE, no Critical/Important/Minor findings

Manual Windows upgrade validation used an isolated official v1.0.8 user state containing legacy provider-level `apiBase`. The old runtime reproduced the startup config rejection; this change applied the v1.0.9 repair, reached `boot:ready`, and returned HTTP 200 for Memory, Agent, Local API, and Agent-via-Local-API without requiring the app to exit.

Known unrelated baseline failures in the desktop test selection remain:

- macOS packaging script path assertion in `packaged-runtime-boundary.test.ts`
- Windows process termination description assertion (`code 1` vs `signal SIGKILL`) in `runtime-services.test.ts`

Temporary planning/spec documents are intentionally excluded from this PR.