### PR TITLE
fix: resolve Windows ACL tools from System32

### DIFF
--- a/Migrations/src/runtime-config-writer.ts
+++ b/Migrations/src/runtime-config-writer.ts
@@ -171,14 +171,38 @@ function currentUserSid(source: string): string {
   return match[1]!;
 }
 
+type WindowsAclExecutable = "whoami.exe" | "icacls.exe";
+
+function windowsSystemExecutable(executable: WindowsAclExecutable): string {
+  const systemDirectories = [
+    process.env.SystemRoot && path.isAbsolute(process.env.SystemRoot)
+      ? path.join(process.env.SystemRoot, "System32")
+      : null,
+    process.env.WINDIR && path.isAbsolute(process.env.WINDIR)
+      ? path.join(process.env.WINDIR, "System32")
+      : null,
+    process.env.ComSpec && path.isAbsolute(process.env.ComSpec)
+      ? path.dirname(process.env.ComSpec)
+      : null,
+  ];
+  for (const directory of new Set(systemDirectories)) {
+    if (!directory) continue;
+    const candidate = path.join(directory, executable);
+    if (fsSync.existsSync(candidate)) return candidate;
+  }
+  throw new Error(`Unable to find Windows system executable: ${executable}`);
+}
+
 async function restrictWindowsAcl(filePath: string): Promise<void> {
   if (process.platform !== "win32") return;
-  const { stdout } = await execFileAsync("whoami", ["/user", "/fo", "csv", "/nh"], {
-    windowsHide: true,
-  });
+  const { stdout } = await execFileAsync(
+    windowsSystemExecutable("whoami.exe"),
+    ["/user", "/fo", "csv", "/nh"],
+    { windowsHide: true },
+  );
   const sid = currentUserSid(stdout);
   await execFileAsync(
-    "icacls",
+    windowsSystemExecutable("icacls.exe"),
     [filePath, "/inheritance:r", "/grant:r", `*${sid}:(F)`, "*S-1-5-18:(F)"],
     { windowsHide: true },
   );
@@ -186,13 +210,14 @@ async function restrictWindowsAcl(filePath: string): Promise<void> {
 
 function restrictWindowsAclSync(filePath: string): void {
   if (process.platform !== "win32") return;
-  const stdout = execFileSync("whoami", ["/user", "/fo", "csv", "/nh"], {
-    encoding: "utf8",
-    windowsHide: true,
-  });
+  const stdout = execFileSync(
+    windowsSystemExecutable("whoami.exe"),
+    ["/user", "/fo", "csv", "/nh"],
+    { encoding: "utf8", windowsHide: true },
+  );
   const sid = currentUserSid(stdout);
   execFileSync(
-    "icacls",
+    windowsSystemExecutable("icacls.exe"),
     [filePath, "/inheritance:r", "/grant:r", `*${sid}:(F)`, "*S-1-5-18:(F)"],
     { stdio: "ignore", windowsHide: true },
   );

--- a/Migrations/tests/runtime-config-writer.test.ts
+++ b/Migrations/tests/runtime-config-writer.test.ts
@@ -102,4 +102,45 @@ describe("runtime config writer", () => {
     expect(acl).not.toContain("(I)");
     expect(acl.match(/\(F\)/g)).toHaveLength(2);
   });
+
+  it.runIf(process.platform === "win32")(
+    "uses verified Windows system ACL tools instead of PATH shadows",
+    async () => {
+      const configPath = await configFixture({});
+      const windowsDirectory = process.env.SystemRoot ?? process.env.WINDIR;
+      if (!windowsDirectory) throw new Error("Windows directory is unavailable");
+      const whereExecutable = path.join(windowsDirectory, "System32", "where.exe");
+      const shadowRoot = path.join(path.dirname(configPath), "shadow-windows-root");
+      const shadowSystemDirectory = path.join(shadowRoot, "System32");
+      await fs.mkdir(shadowSystemDirectory, { recursive: true });
+      await Promise.all([
+        fs.copyFile(whereExecutable, path.join(shadowSystemDirectory, "whoami.exe")),
+        fs.copyFile(whereExecutable, path.join(shadowSystemDirectory, "icacls.exe")),
+      ]);
+      const originalCurrentDirectory = process.cwd();
+      const originalPath = process.env.PATH;
+      const originalSystemRoot = process.env.SystemRoot;
+      const originalWindowsDirectory = process.env.WINDIR;
+      process.chdir(path.dirname(configPath));
+      process.env.SystemRoot = path.basename(shadowRoot);
+      process.env.WINDIR = path.basename(shadowRoot);
+      process.env.PATH = `${shadowSystemDirectory};${originalPath ?? ""}`;
+      try {
+        await expect(mutateRuntimeConfig(configPath, (config) => {
+          config.asyncWrite = true;
+        })).resolves.toMatchObject({ changed: true });
+        expect(mutateRuntimeConfigSync(configPath, (config) => {
+          config.syncWrite = true;
+        })).toMatchObject({ changed: true });
+      } finally {
+        process.chdir(originalCurrentDirectory);
+        if (originalSystemRoot === undefined) delete process.env.SystemRoot;
+        else process.env.SystemRoot = originalSystemRoot;
+        if (originalWindowsDirectory === undefined) delete process.env.WINDIR;
+        else process.env.WINDIR = originalWindowsDirectory;
+        if (originalPath === undefined) delete process.env.PATH;
+        else process.env.PATH = originalPath;
+      }
+    },
+  );
 });


### PR DESCRIPTION
## Summary

- resolve `whoami.exe` and `icacls.exe` from verified absolute Windows system directories instead of `PATH`
- accept `%SystemRoot%`, `%WINDIR%`, and `%ComSpec%` fallbacks only when absolute and the executable exists
- cover async and sync runtime-config writes against both `PATH` shadowing and relative Windows environment variables
- keep the non-Windows chmod/fsync behavior unchanged; no existing UI copy is modified

## Root cause

The v1.0.9 runtime-model-catalog repair rewrites `config.yaml` and hardens its ACL. On Windows, a `PATH` that puts Git `usr/bin` first can resolve bare `whoami` to the GNU utility instead of the Windows system tool. With a config path containing spaces, that prevents ACL hardening from completing and can block the repair before application startup.

## Verification

- `npm test -w @memmy/migrations` — 12 files / 116 tests passed
- `npm run typecheck -w @memmy/migrations`
- `git diff --check upstream/v1.0.9...HEAD`
- Windows real-machine reproduction in a Program-Files-style path containing spaces:
  - official v1.0.8 reproduced `providers current contract does not accept legacy field 'apiBase'`
  - current v1.0.9 completed `v1.0.9/0001-repair-runtime-model-catalog` with `changed: 1` and reached `boot:ready`
  - Git `C:\Program Files\Git\usr\bin` was first in `PATH`
  - runtime config ACL was protected with only the current user and SYSTEM retaining Full Control
  - Local API, model config, Memory, Agent health, and Agent bootstrap all returned HTTP 200
- manual Windows validation passed for both the abnormal legacy configuration and the restored normal API/model configuration