### PR TITLE
fix: make BYOK setup saves retryable

### DIFF
--- a/App/frontend/desktop/src/pages/api-key-optional-page.tsx
+++ b/App/frontend/desktop/src/pages/api-key-optional-page.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { ChevronLeft, Image as ImageIcon, Mic } from "lucide-react";
 import { useAnalytics } from "../analytics/use-analytics.js";
 import { persistLoginModeSelection } from "../app/login-mode.js";
@@ -50,6 +50,11 @@ import {
   type ImageProtocol
 } from "./model-config.js";
 
+interface SavedEndpointIdentity {
+  endpointId: string;
+  credentialSignature: string;
+}
+
 export function ApiKeyOptionalPage() {
   const { state, dispatch } = useAppState();
   const { clients } = useApiClients();
@@ -81,9 +86,43 @@ export function ApiKeyOptionalPage() {
   const isImageGenUsable = canSaveModelConfig(imageGenFormValues, imageGenValidation);
   const imageGenTestKey = createModelConfigValidationKey(imageGenFormValues);
   const isImageGenTestStale = Boolean(imageGenValidation.testedKey && imageGenValidation.testedKey !== imageGenTestKey);
+  const imageGenEndpointProtocol = imageGenProtocol === "qwen"
+    ? "dashscope-multimodal-generation"
+    : "openai-images";
+  const asrCredentialSignature = endpointCredentialSignature(
+    "qwen",
+    "dashscope-input-audio-chat",
+    asrEndpoint,
+    asrApiKey,
+    asrApiKeyMasked
+  );
+  const imageGenCredentialSignature = endpointCredentialSignature(
+    imageGenProtocol,
+    imageGenEndpointProtocol,
+    imageGenEndpoint,
+    imageGenApiKey,
+    imageGenApiKeyMasked
+  );
+  const saveSignature = JSON.stringify({
+    asr: isAsrUsable ? asrTestKey : null,
+    imageGeneration: isImageGenUsable ? imageGenTestKey : null
+  });
+  const savedCatalogSignatureRef = useRef<string | null>(null);
+  const initialWorkspace = createModelWorkspace(state.modelConfig);
+  const initialAsrEndpointId = assignedCatalogEndpointId(initialWorkspace, "byok", "asr");
+  const initialImageEndpointId = assignedCatalogEndpointId(initialWorkspace, "byok", "image_generation");
+  const savedEndpointIdentitiesRef = useRef<Partial<Record<"asr" | "imageGeneration", SavedEndpointIdentity>>>({
+    ...(initialAsrEndpointId
+      ? { asr: { endpointId: initialAsrEndpointId, credentialSignature: asrCredentialSignature } }
+      : {}),
+    ...(initialImageEndpointId
+      ? { imageGeneration: { endpointId: initialImageEndpointId, credentialSignature: imageGenCredentialSignature } }
+      : {})
+  });
   const [optionalModelMissingWarning, setOptionalModelMissingWarning] = useState<OptionalModelMissingWarningKind | null>(null);
   const [modePersistencePending, setModePersistencePending] = useState(false);
   const [nextValidationError, setNextValidationError] = useState<"noInput" | "testRequired" | null>(null);
+  const [saveError, setSaveError] = useState<string | null>(null);
 
   function changeImageGenProtocol(nextProtocol: string) {
     const next = (IMAGE_PROTOCOL_OPTIONS.find((option) => option.value === nextProtocol)?.value ?? "openai") as ImageProtocol;
@@ -134,45 +173,65 @@ export function ApiKeyOptionalPage() {
       return;
     }
 
+    setSaveError(null);
     try {
       setModePersistencePending(true);
-      const latest = await clients.config.getModelConfig();
-      let workspace = createModelWorkspace(latest);
-      if (isAsrUsable) {
-        const assignedAsrEndpointId = assignedCatalogEndpointId(workspace, "byok", "asr");
-        const asr = upsertByokPreset(workspace, {
-          provider: "qwen",
-          ...(asrApiKeyMasked && assignedAsrEndpointId ? { endpointId: assignedAsrEndpointId } : {}),
-          endpoint: asrEndpoint,
-          protocol: "dashscope-input-audio-chat",
-          ...(asrApiKey.trim() ? { apiKey: asrApiKey.trim() } : {}),
-          ...(asrApiKeyMasked ? { apiKeyMasked: asrApiKeyMasked } : {}),
-          model: asrModel || ASR_MODEL_ID,
-          capabilities: ["asr"]
-        });
-        workspace = assignCatalogPreset(asr.workspace, "byok", "asr", asr.presetId);
+      if (savedCatalogSignatureRef.current !== saveSignature) {
+        const latest = await clients.config.getModelConfig();
+        let workspace = createModelWorkspace(latest);
+        if (isAsrUsable) {
+          const savedAsrIdentity = savedEndpointIdentitiesRef.current.asr;
+          const asrEndpointId = savedAsrIdentity?.credentialSignature === asrCredentialSignature
+            ? savedAsrIdentity.endpointId
+            : undefined;
+          const asr = upsertByokPreset(workspace, {
+            provider: "qwen",
+            ...(asrEndpointId ? { endpointId: asrEndpointId } : {}),
+            endpoint: asrEndpoint,
+            protocol: "dashscope-input-audio-chat",
+            ...(asrApiKey.trim() ? { apiKey: asrApiKey.trim() } : {}),
+            ...(asrApiKeyMasked ? { apiKeyMasked: asrApiKeyMasked } : {}),
+            model: asrModel || ASR_MODEL_ID,
+            capabilities: ["asr"]
+          });
+          workspace = assignCatalogPreset(asr.workspace, "byok", "asr", asr.presetId);
+        }
+        if (isImageGenUsable) {
+          const savedImageIdentity = savedEndpointIdentitiesRef.current.imageGeneration;
+          const imageEndpointId = savedImageIdentity?.credentialSignature === imageGenCredentialSignature
+            ? savedImageIdentity.endpointId
+            : undefined;
+          const image = upsertByokPreset(workspace, {
+            provider: imageGenProtocol,
+            ...(imageEndpointId ? { endpointId: imageEndpointId } : {}),
+            endpoint: imageGenEndpoint,
+            protocol: imageGenEndpointProtocol,
+            ...(imageGenApiKey.trim() ? { apiKey: imageGenApiKey.trim() } : {}),
+            ...(imageGenApiKeyMasked ? { apiKeyMasked: imageGenApiKeyMasked } : {}),
+            model: imageGenModel,
+            capabilities: ["image_generation"]
+          });
+          workspace = assignCatalogPreset(image.workspace, "byok", "image_generation", image.presetId);
+        }
+        const savedConfig = await clients.config.saveModelCatalog(modelConfigInput(workspace));
+        if (!savedConfig.catalog?.modelAssignments.byok.agent.candidates.length) {
+          throw new Error("persisted BYOK Agent assignment is empty");
+        }
+        dispatch(appActions.modelConfigUpdated(savedConfig));
+        const savedWorkspace = createModelWorkspace(savedConfig);
+        const savedAsrEndpointId = assignedCatalogEndpointId(savedWorkspace, "byok", "asr");
+        const savedImageEndpointId = assignedCatalogEndpointId(savedWorkspace, "byok", "image_generation");
+        savedEndpointIdentitiesRef.current = {
+          ...savedEndpointIdentitiesRef.current,
+          ...(isAsrUsable && savedAsrEndpointId
+            ? { asr: { endpointId: savedAsrEndpointId, credentialSignature: asrCredentialSignature } }
+            : {}),
+          ...(isImageGenUsable && savedImageEndpointId
+            ? { imageGeneration: { endpointId: savedImageEndpointId, credentialSignature: imageGenCredentialSignature } }
+            : {})
+        };
+        savedCatalogSignatureRef.current = saveSignature;
       }
-      if (isImageGenUsable) {
-        const assignedImageEndpointId = assignedCatalogEndpointId(workspace, "byok", "image_generation");
-        const image = upsertByokPreset(workspace, {
-          provider: imageGenProtocol,
-          ...(imageGenApiKeyMasked && assignedImageEndpointId ? { endpointId: assignedImageEndpointId } : {}),
-          endpoint: imageGenEndpoint,
-          protocol: imageGenProtocol === "qwen"
-            ? "dashscope-multimodal-generation"
-            : "openai-images",
-          ...(imageGenApiKey.trim() ? { apiKey: imageGenApiKey.trim() } : {}),
-          ...(imageGenApiKeyMasked ? { apiKeyMasked: imageGenApiKeyMasked } : {}),
-          model: imageGenModel,
-          capabilities: ["image_generation"]
-        });
-        workspace = assignCatalogPreset(image.workspace, "byok", "image_generation", image.presetId);
-      }
-      const savedConfig = await clients.config.saveModelCatalog(modelConfigInput(workspace));
-      if (!savedConfig.catalog?.modelAssignments.byok.agent.candidates.length) {
-        throw new Error("persisted BYOK Agent assignment is empty");
-      }
-      dispatch(appActions.modelConfigUpdated(savedConfig));
       const byokCompletion = resolveByokModelCompletion({
         onboarding: state.bootstrap?.onboarding ?? buildByokOnboardingGuidePatch()
       });
@@ -186,6 +245,7 @@ export function ApiKeyOptionalPage() {
       track({ name: "byok_completed", params: { user_mode: "byok" }, consentTier: "basic" });
     } catch (error) {
       console.error("save byok optional model config failed", error);
+      setSaveError(optionalStepSaveErrorText(error, t));
     } finally {
       setModePersistencePending(false);
     }
@@ -196,6 +256,7 @@ export function ApiKeyOptionalPage() {
       return;
     }
 
+    setSaveError(null);
     setNextValidationError(null);
 
     const nextWarning = resolveOptionalModelMissingWarning({
@@ -215,6 +276,7 @@ export function ApiKeyOptionalPage() {
       return;
     }
 
+    setSaveError(null);
     setNextValidationError(null);
 
     const asrHasInput = Boolean(asrApiKey.trim());
@@ -358,6 +420,14 @@ export function ApiKeyOptionalPage() {
           </div>
         )}
 
+        {saveError ? (
+          <div className="agent-model-error-notice mb-3" role="alert">
+            <div className="agent-model-error-notice__header">
+              <p className="agent-model-error-notice__title">{saveError}</p>
+            </div>
+          </div>
+        ) : null}
+
         <div className="flex gap-3">
           <button
             type="button"
@@ -381,4 +451,32 @@ export function ApiKeyOptionalPage() {
       {optionalModelMissingWarning && <OptionalModelMissingWarningModal kind={optionalModelMissingWarning} onClose={closeOptionalModelMissingWarning} />}
     </div>
   );
+}
+
+function endpointCredentialSignature(
+  provider: string,
+  protocol: string,
+  endpoint: string,
+  apiKey: string,
+  apiKeyMasked: string
+): string {
+  const normalizedApiKey = apiKey.trim();
+  return JSON.stringify({
+    provider: provider.trim().toLowerCase(),
+    protocol,
+    endpoint: endpoint.trim().replace(/\/+$/, ""),
+    credential: normalizedApiKey ? `raw:${normalizedApiKey}` : `masked:${apiKeyMasked.trim()}`
+  });
+}
+
+function optionalStepSaveErrorText(
+  error: unknown,
+  t: ReturnType<typeof useTranslation>["t"]
+): string {
+  const code = error && typeof error === "object" && "code" in error ? error.code : null;
+  if (code === "model_config_changed") return t("settings.model.configChanged");
+  if (code === "config_write_busy") return t("settings.modelWorkspace.saveBusy");
+  return error instanceof Error && error.message
+    ? error.message
+    : t("settings.modelWorkspace.saveFailed");
 }

--- a/App/frontend/desktop/src/pages/api-key-page.tsx
+++ b/App/frontend/desktop/src/pages/api-key-page.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { Brain, ChevronLeft, Search } from "lucide-react";
 import { useAnalytics } from "../analytics/use-analytics.js";
 import { persistLoginModeSelection } from "../app/login-mode.js";
@@ -52,6 +52,11 @@ interface ProviderOption {
   labelKey: MessageKey;
   endpoint: string;
   defaultModelId: string;
+}
+
+interface SavedEndpointIdentity {
+  endpointId: string;
+  credentialSignature: string;
 }
 
 const providerOptions: ProviderOption[] = [
@@ -112,10 +117,39 @@ export function ApiKeyPage() {
   const [embeddingValidation, setEmbeddingValidation] = useState<ModelConfigValidationState>(initialModelForm.embValidation);
   const canSave = canSaveModelConfig(modelFormValues, llmValidation)
     && canSaveOptionalModelConfig(true, embeddingFormValues, embeddingValidation);
+  const [savePending, setSavePending] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
   const testedKey = createModelConfigValidationKey(modelFormValues);
   const isTestStale = Boolean(llmValidation.testedKey && llmValidation.testedKey !== testedKey);
   const embeddingTestKey = createModelConfigValidationKey(embeddingFormValues);
   const isEmbeddingTestStale = Boolean(embeddingValidation.testedKey && embeddingValidation.testedKey !== embeddingTestKey);
+  const agentCredentialSignature = endpointCredentialSignature(
+    provider,
+    chatProtocol(provider),
+    endpoint,
+    apiKey,
+    apiKeyMasked
+  );
+  const embeddingCredentialSignature = endpointCredentialSignature(
+    "openai",
+    "openai-embeddings",
+    embeddingConfig.endpoint,
+    embeddingConfig.apiKey,
+    embeddingConfig.apiKeyMasked
+  );
+  const saveSignature = `${testedKey}\n${embeddingTestKey}`;
+  const savedCatalogSignatureRef = useRef<string | null>(null);
+  const initialWorkspace = createModelWorkspace(state.modelConfig);
+  const initialAgentEndpointId = assignedCatalogEndpointId(initialWorkspace, "byok", "agent");
+  const initialEmbeddingEndpointId = assignedCatalogEndpointId(initialWorkspace, "byok", "embedding");
+  const savedEndpointIdentitiesRef = useRef<Partial<Record<"agent" | "embedding", SavedEndpointIdentity>>>({
+    ...(initialAgentEndpointId
+      ? { agent: { endpointId: initialAgentEndpointId, credentialSignature: agentCredentialSignature } }
+      : {}),
+    ...(initialEmbeddingEndpointId
+      ? { embedding: { endpointId: initialEmbeddingEndpointId, credentialSignature: embeddingCredentialSignature } }
+      : {})
+  });
 
   function changeProvider(nextProvider: string) {
     const next = providerOptions.find((option) => option.value === nextProvider) ?? defaultProvider;
@@ -152,46 +186,71 @@ export function ApiKeyPage() {
   }
 
   async function saveConfig() {
-    if (!canSave || !clients?.config) {
+    if (!canSave || !clients?.config || savePending) {
       return;
     }
+    setSaveError(null);
+    setSavePending(true);
     try {
-      const latest = await clients.config.getModelConfig();
-      let workspace = createModelWorkspace(latest);
-      const assignedAgentEndpointId = assignedCatalogEndpointId(workspace, "byok", "agent");
-      const agent = upsertByokPreset(workspace, {
-        provider,
-        ...(apiKeyMasked && assignedAgentEndpointId ? { endpointId: assignedAgentEndpointId } : {}),
-        endpoint,
-        protocol: chatProtocol(provider),
-        ...(apiKey.trim() ? { apiKey: apiKey.trim() } : {}),
-        ...(apiKeyMasked ? { apiKeyMasked } : {}),
-        model,
-        capabilities: ["agent"]
-      });
-      workspace = assignCatalogPreset(agent.workspace, "byok", "agent", agent.presetId);
-      const assignedEmbeddingEndpointId = assignedCatalogEndpointId(workspace, "byok", "embedding");
-      const embedding = upsertByokPreset(workspace, {
-        provider: "openai",
-        ...(embeddingConfig.apiKeyMasked && assignedEmbeddingEndpointId ? { endpointId: assignedEmbeddingEndpointId } : {}),
-        endpoint: embeddingConfig.endpoint,
-        protocol: "openai-embeddings",
-        ...(embeddingConfig.apiKey.trim() ? { apiKey: embeddingConfig.apiKey.trim() } : {}),
-        ...(embeddingConfig.apiKeyMasked ? { apiKeyMasked: embeddingConfig.apiKeyMasked } : {}),
-        model: embeddingConfig.model,
-        capabilities: ["embedding"]
-      });
-      workspace = assignCatalogPreset(embedding.workspace, "byok", "embedding", embedding.presetId);
-      const saved = await clients.config.saveModelCatalog(modelConfigInput(workspace));
-      if (!saved.catalog?.modelAssignments.byok.agent.candidates.length) {
-        throw new Error("persisted BYOK Agent assignment is empty");
+      if (savedCatalogSignatureRef.current !== saveSignature) {
+        const latest = await clients.config.getModelConfig();
+        let workspace = createModelWorkspace(latest);
+        const savedAgentIdentity = savedEndpointIdentitiesRef.current.agent;
+        const agentEndpointId = savedAgentIdentity?.credentialSignature === agentCredentialSignature
+          ? savedAgentIdentity.endpointId
+          : undefined;
+        const agent = upsertByokPreset(workspace, {
+          provider,
+          ...(agentEndpointId ? { endpointId: agentEndpointId } : {}),
+          endpoint,
+          protocol: chatProtocol(provider),
+          ...(apiKey.trim() ? { apiKey: apiKey.trim() } : {}),
+          ...(apiKeyMasked ? { apiKeyMasked } : {}),
+          model,
+          capabilities: ["agent"]
+        });
+        workspace = assignCatalogPreset(agent.workspace, "byok", "agent", agent.presetId);
+        const savedEmbeddingIdentity = savedEndpointIdentitiesRef.current.embedding;
+        const embeddingEndpointId = savedEmbeddingIdentity?.credentialSignature === embeddingCredentialSignature
+          ? savedEmbeddingIdentity.endpointId
+          : undefined;
+        const embedding = upsertByokPreset(workspace, {
+          provider: "openai",
+          ...(embeddingEndpointId ? { endpointId: embeddingEndpointId } : {}),
+          endpoint: embeddingConfig.endpoint,
+          protocol: "openai-embeddings",
+          ...(embeddingConfig.apiKey.trim() ? { apiKey: embeddingConfig.apiKey.trim() } : {}),
+          ...(embeddingConfig.apiKeyMasked ? { apiKeyMasked: embeddingConfig.apiKeyMasked } : {}),
+          model: embeddingConfig.model,
+          capabilities: ["embedding"]
+        });
+        workspace = assignCatalogPreset(embedding.workspace, "byok", "embedding", embedding.presetId);
+        const saved = await clients.config.saveModelCatalog(modelConfigInput(workspace));
+        if (!saved.catalog?.modelAssignments.byok.agent.candidates.length) {
+          throw new Error("persisted BYOK Agent assignment is empty");
+        }
+        track({ name: "model_config_saved", params: { page_path: "/api-key" }, consentTier: "basic" });
+        dispatch(appActions.modelConfigUpdated(saved));
+        const savedWorkspace = createModelWorkspace(saved);
+        const savedAgentEndpointId = assignedCatalogEndpointId(savedWorkspace, "byok", "agent");
+        const savedEmbeddingEndpointId = assignedCatalogEndpointId(savedWorkspace, "byok", "embedding");
+        savedEndpointIdentitiesRef.current = {
+          ...(savedAgentEndpointId
+            ? { agent: { endpointId: savedAgentEndpointId, credentialSignature: agentCredentialSignature } }
+            : {}),
+          ...(savedEmbeddingEndpointId
+            ? { embedding: { endpointId: savedEmbeddingEndpointId, credentialSignature: embeddingCredentialSignature } }
+            : {})
+        };
+        savedCatalogSignatureRef.current = saveSignature;
       }
-      track({ name: "model_config_saved", params: { page_path: "/api-key" }, consentTier: "basic" });
-      dispatch(appActions.modelConfigUpdated(saved));
       await persistLoginModeSelection({ configClient: clients.config, dispatch, userMode: "byok" });
       dispatch(appActions.navigate("/api-key-models"));
     } catch (error) {
-      console.warn("save byok model config failed", error);
+      console.error("save byok model config failed", error);
+      setSaveError(firstStepSaveErrorText(error, t));
+    } finally {
+      setSavePending(false);
     }
   }
 
@@ -308,15 +367,44 @@ export function ApiKeyPage() {
 
         <button
           type="button"
-          disabled={!canSave}
-          onClick={saveConfig}
+          disabled={!canSave || !clients?.config || savePending}
+          onClick={() => void saveConfig()}
           className={`w-full ${API_KEY_PRIMARY_BTN_CLASS}`}
         >
           {t("apiKey.next")}
         </button>
+        {saveError ? <p className="mt-3 text-[12px] text-left leading-relaxed text-red-500" role="alert">{saveError}</p> : null}
       </div>
     </div>
   );
+}
+
+function endpointCredentialSignature(
+  provider: string,
+  protocol: string,
+  endpoint: string,
+  apiKey: string,
+  apiKeyMasked: string
+): string {
+  const normalizedApiKey = apiKey.trim();
+  return JSON.stringify({
+    provider: provider.trim().toLowerCase(),
+    protocol,
+    endpoint: endpoint.trim().replace(/\/+$/, ""),
+    credential: normalizedApiKey ? `raw:${normalizedApiKey}` : `masked:${apiKeyMasked.trim()}`
+  });
+}
+
+function firstStepSaveErrorText(
+  error: unknown,
+  t: ReturnType<typeof useTranslation>["t"]
+): string {
+  const code = error && typeof error === "object" && "code" in error ? error.code : null;
+  if (code === "model_config_changed") return t("settings.model.configChanged");
+  if (code === "config_write_busy") return t("settings.modelWorkspace.saveBusy");
+  return error instanceof Error && error.message
+    ? error.message
+    : t("settings.modelWorkspace.saveFailed");
 }
 
 function chatProtocol(provider: string) {

--- a/App/frontend/desktop/src/pages/tests/api-key-optional-page-source.test.ts
+++ b/App/frontend/desktop/src/pages/tests/api-key-optional-page-source.test.ts
@@ -23,4 +23,25 @@ describe("ApiKeyOptionalPage catalog source", () => {
     expect(source).not.toContain("maxTokens");
     expect(source).not.toContain("dailyTokenLimit");
   });
+
+  it("保存失败时展示可重试的持久化错误", () => {
+    const source = readFileSync(sourcePath, "utf8");
+
+    expect(source).toContain("const [saveError, setSaveError] = useState<string | null>(null)");
+    expect(source).toContain("setSaveError(null)");
+    expect(source).toContain("setSaveError(optionalStepSaveErrorText(error, t))");
+    expect(source).toContain("optionalStepSaveErrorText");
+    expect(source).toContain("const savedCatalogSignatureRef = useRef<string | null>(null)");
+    expect(source).toContain("savedCatalogSignatureRef.current !== saveSignature");
+    expect(source).toContain("savedCatalogSignatureRef.current = saveSignature");
+    expect(source).toContain("const savedEndpointIdentitiesRef = useRef");
+    expect(source).toContain("savedAsrIdentity?.credentialSignature === asrCredentialSignature");
+    expect(source).toContain("savedImageIdentity?.credentialSignature === imageGenCredentialSignature");
+    expect(source).toContain("endpointCredentialSignature(");
+    expect(source).toContain("provider: provider.trim().toLowerCase()");
+    expect(source).toContain('endpoint: endpoint.trim().replace(/\\/+$/, "")');
+    expect(source).toContain("credential: normalizedApiKey");
+    expect(source).toContain('role="alert"');
+    expect(source).toContain("disabled={modePersistencePending}");
+  });
 });

--- a/App/frontend/desktop/src/pages/tests/api-key-page-source.test.ts
+++ b/App/frontend/desktop/src/pages/tests/api-key-page-source.test.ts
@@ -66,6 +66,23 @@ describe("ApiKeyPage source", () => {
     expect(stateIndex).toBeGreaterThan(saveIndex);
     expect(persistIndex).toBeGreaterThan(stateIndex);
     expect(navigateIndex).toBeGreaterThan(persistIndex);
+    expect(source).toContain("const [savePending, setSavePending] = useState(false)");
+    expect(source).toContain("const [saveError, setSaveError] = useState<string | null>(null)");
+    expect(source).toContain("if (!canSave || !clients?.config || savePending)");
+    expect(source).toContain("disabled={!canSave || !clients?.config || savePending}");
+    expect(source).toContain("setSaveError(firstStepSaveErrorText(error, t))");
+    expect(source).toContain("const savedCatalogSignatureRef = useRef<string | null>(null)");
+    expect(source).toContain("savedCatalogSignatureRef.current !== saveSignature");
+    expect(source).toContain("savedCatalogSignatureRef.current = saveSignature");
+    expect(source).toContain("const savedEndpointIdentitiesRef = useRef");
+    expect(source).toContain("savedAgentIdentity?.credentialSignature === agentCredentialSignature");
+    expect(source).toContain("savedEmbeddingIdentity?.credentialSignature === embeddingCredentialSignature");
+    expect(source).toContain("endpointCredentialSignature(");
+    expect(source).toContain("provider: provider.trim().toLowerCase()");
+    expect(source).toContain('endpoint: endpoint.trim().replace(/\\/+$/, "")');
+    expect(source).toContain("credential: normalizedApiKey");
+    expect(source).toContain('role="alert"');
+    expect(source).toContain("} finally {");
   });
 
   it("重新进入 BYOK 第一步时从已保存模型配置 hydrate 主模型与 Embedding", () => {

--- a/App/frontend/desktop/src/pages/tests/byok-setup-save-feedback.interaction.test.tsx
+++ b/App/frontend/desktop/src/pages/tests/byok-setup-save-feedback.interaction.test.tsx
@@ -1,0 +1,550 @@
+// @vitest-environment happy-dom
+
+import type { ModelConfigInput, ModelConfigView } from "@memmy/local-api-contracts";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AppClients } from "../../api/client-types.js";
+import type { ModelProviderConfig } from "../../api/config-client.js";
+import { appActions } from "../../state/app-actions.js";
+import { createInitialAppState, type AppState } from "../../state/app-reducer.js";
+import {
+  assignedCatalogEndpointId,
+  assignCatalogPreset,
+  createModelWorkspace,
+  maskApiKey,
+  modelConfigInput,
+  upsertByokPreset
+} from "../../state/model-workspace.js";
+import { ApiKeyOptionalPage } from "../api-key-optional-page.js";
+import { ApiKeyPage } from "../api-key-page.js";
+import { ModelPage } from "../model-page.js";
+
+const mocks = vi.hoisted(() => ({
+  clients: null as AppClients | null,
+  state: null as AppState | null,
+  dispatch: vi.fn(),
+  track: vi.fn()
+}));
+
+vi.mock("../../app/providers.js", () => ({
+  useApiClients: () => ({ clients: mocks.clients, setClients: vi.fn() })
+}));
+
+vi.mock("../../state/app-state.js", () => ({
+  useAppState: () => ({ state: mocks.state, dispatch: mocks.dispatch })
+}));
+
+vi.mock("../../analytics/use-analytics.js", () => ({
+  useAnalytics: () => ({ track: mocks.track, ready: true })
+}));
+
+vi.mock("../../i18n/use-translation.js", () => ({
+  useTranslation: () => ({ t: (key: string) => key, language: "zh-CN" })
+}));
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe("BYOK setup save feedback", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    mocks.state = { ...createInitialAppState(), modelConfig: savedModelConfig() };
+    container = document.createElement("div");
+    document.body.append(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    document.body.replaceChildren();
+    mocks.clients = null;
+    mocks.state = null;
+    vi.restoreAllMocks();
+  });
+
+  it("advances from the first step after persistence succeeds", async () => {
+    mocks.clients = createClients(vi.fn(async () => savedModelConfig()));
+    await render(<ApiKeyPage />);
+
+    await click(button("apiKey.next"));
+
+    expect(mocks.dispatch).toHaveBeenCalledWith(appActions.navigate("/api-key-models"));
+    expect(container.querySelector('[role="alert"]')).toBeNull();
+  });
+
+  it("shows a first-step conflict, stays put, and allows a successful retry", async () => {
+    const firstSave = deferred<ModelProviderConfig>();
+    const saveModelCatalog = vi.fn()
+      .mockReturnValueOnce(firstSave.promise)
+      .mockResolvedValueOnce(savedModelConfig());
+    mocks.clients = createClients(saveModelCatalog);
+    await render(<ApiKeyPage />);
+    const nextButton = button("apiKey.next");
+
+    await click(nextButton);
+    expect(nextButton.disabled).toBe(true);
+
+    await reject(firstSave, Object.assign(new Error("stale revision"), { code: "model_config_changed" }));
+
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain("settings.model.configChanged");
+    expect(nextButton.disabled).toBe(false);
+    expect(mocks.dispatch).not.toHaveBeenCalledWith(appActions.navigate("/api-key-models"));
+
+    await click(nextButton);
+    expect(mocks.dispatch).toHaveBeenCalledWith(appActions.navigate("/api-key-models"));
+  });
+
+  it("does not save the first-step catalog again when mode persistence is retried", async () => {
+    const saveModelCatalog = vi.fn(async () => savedModelConfig());
+    const updateSettings = vi.fn(async (settings: unknown) => settings)
+      .mockRejectedValueOnce(new Error("settings offline"));
+    mocks.clients = createClients(saveModelCatalog, { updateSettings });
+    await render(<ApiKeyPage />);
+    const nextButton = button("apiKey.next");
+
+    await click(nextButton);
+
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain("settings offline");
+    expect(saveModelCatalog).toHaveBeenCalledTimes(1);
+    expect(mocks.dispatch).not.toHaveBeenCalledWith(appActions.navigate("/api-key-models"));
+
+    await click(nextButton);
+
+    expect(saveModelCatalog).toHaveBeenCalledTimes(1);
+    expect(mocks.dispatch).toHaveBeenCalledWith(appActions.navigate("/api-key-models"));
+  });
+
+  it("reuses first-step endpoint identities when only the model changes after partial success", async () => {
+    const server = createCatalogServer();
+    const updateSettings = vi.fn(async (settings: unknown) => settings)
+      .mockRejectedValueOnce(new Error("settings offline"));
+    mocks.state = { ...createInitialAppState(), modelConfig: savedModelConfig(server.catalog()) };
+    mocks.clients = createClients(server.saveModelCatalog, {
+      getModelConfig: server.getModelConfig,
+      updateSettings
+    });
+    await render(<ApiKeyPage />);
+    const nextButton = button("apiKey.next");
+
+    await click(nextButton);
+    const firstCatalog = server.catalog();
+    const firstAgentEndpointId = assignedCatalogEndpointId(createModelWorkspace(firstCatalog), "byok", "agent");
+    expect(endpointCount(firstCatalog)).toBe(2);
+    expect(mocks.dispatch).not.toHaveBeenCalledWith(appActions.navigate("/api-key-models"));
+
+    await changeField("apiKey.model", "gpt-4.1");
+    await click(button("apiKey.test"));
+    await vi.waitFor(() => expect(nextButton.disabled).toBe(false));
+    await click(nextButton);
+
+    const retriedCatalog = server.catalog();
+    expect(server.saveModelCatalog).toHaveBeenCalledTimes(2);
+    expect(endpointCount(retriedCatalog)).toBe(2);
+    expect(assignedCatalogEndpointId(createModelWorkspace(retriedCatalog), "byok", "agent"))
+      .toBe(firstAgentEndpointId);
+    expect(mocks.dispatch).toHaveBeenCalledWith(appActions.navigate("/api-key-models"));
+  });
+
+  it("invalidates only the changed first-step credential identity", async () => {
+    const server = createCatalogServer();
+    const updateSettings = vi.fn(async (settings: unknown) => settings)
+      .mockRejectedValueOnce(new Error("settings offline"));
+    mocks.state = { ...createInitialAppState(), modelConfig: savedModelConfig(server.catalog()) };
+    mocks.clients = createClients(server.saveModelCatalog, {
+      getModelConfig: server.getModelConfig,
+      updateSettings
+    });
+    await render(<ApiKeyPage />);
+    const nextButton = button("apiKey.next");
+
+    await click(nextButton);
+    const firstCatalog = server.catalog();
+    const firstAgentEndpointId = assignedCatalogEndpointId(createModelWorkspace(firstCatalog), "byok", "agent");
+
+    await changeField("apiKey.key", "sk-primary-changed");
+    await click(button("apiKey.test"));
+    await vi.waitFor(() => expect(nextButton.disabled).toBe(false));
+    await click(nextButton);
+
+    const retriedCatalog = server.catalog();
+    expect(endpointCount(retriedCatalog)).toBe(3);
+    expect(assignedCatalogEndpointId(createModelWorkspace(retriedCatalog), "byok", "agent"))
+      .not.toBe(firstAgentEndpointId);
+  });
+
+  it("shows a busy error after Skip, stays put, and allows a successful retry", async () => {
+    const firstSave = deferred<ModelProviderConfig>();
+    const saveModelCatalog = vi.fn()
+      .mockReturnValueOnce(firstSave.promise)
+      .mockResolvedValueOnce(savedModelConfig());
+    mocks.clients = createClients(saveModelCatalog);
+    await render(<ApiKeyOptionalPage />);
+    const skipButton = button("apiKey.optionalPage.skip");
+    const nextButton = button("apiKey.next");
+
+    await click(skipButton);
+    expect(skipButton.disabled).toBe(true);
+    expect(nextButton.disabled).toBe(true);
+
+    await reject(firstSave, Object.assign(new Error("busy"), { code: "config_write_busy" }));
+
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain("settings.modelWorkspace.saveBusy");
+    expect(skipButton.disabled).toBe(false);
+    expect(nextButton.disabled).toBe(false);
+    expect(mocks.dispatch).not.toHaveBeenCalledWith(appActions.navigate("/onboarding"));
+
+    await click(skipButton);
+    expect(mocks.dispatch).toHaveBeenCalledWith(appActions.navigate("/onboarding"));
+  });
+
+  it("shows a raw save error after Next, stays put, and allows a successful retry", async () => {
+    const firstSave = deferred<ModelProviderConfig>();
+    const saveModelCatalog = vi.fn()
+      .mockReturnValueOnce(firstSave.promise)
+      .mockResolvedValueOnce(savedModelConfig());
+    mocks.clients = createClients(saveModelCatalog);
+    await render(<ApiKeyOptionalPage />);
+    const skipButton = button("apiKey.optionalPage.skip");
+    const nextButton = button("apiKey.next");
+
+    await click(nextButton);
+    await reject(firstSave, new Error("catalog offline"));
+
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain("catalog offline");
+    expect(skipButton.disabled).toBe(false);
+    expect(nextButton.disabled).toBe(false);
+    expect(mocks.dispatch).not.toHaveBeenCalledWith(appActions.navigate("/onboarding"));
+
+    await click(nextButton);
+    expect(mocks.dispatch).toHaveBeenCalledWith(appActions.navigate("/onboarding"));
+  });
+
+  it("does not save the optional catalog again when onboarding persistence is retried", async () => {
+    const saveModelCatalog = vi.fn(async () => savedModelConfig());
+    const updateOnboarding = vi.fn(async (onboarding: unknown) => onboarding)
+      .mockRejectedValueOnce(new Error("onboarding offline"));
+    mocks.clients = createClients(saveModelCatalog, { updateOnboarding });
+    await render(<ApiKeyOptionalPage />);
+    const nextButton = button("apiKey.next");
+
+    await click(nextButton);
+
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain("onboarding offline");
+    expect(saveModelCatalog).toHaveBeenCalledTimes(1);
+    expect(mocks.dispatch).not.toHaveBeenCalledWith(appActions.navigate("/onboarding"));
+
+    await click(nextButton);
+
+    expect(saveModelCatalog).toHaveBeenCalledTimes(1);
+    expect(mocks.dispatch).toHaveBeenCalledWith(appActions.navigate("/onboarding"));
+  });
+
+  it("reuses optional endpoint identities when only the image model changes after partial success", async () => {
+    const server = createCatalogServer(configuredCatalog(false));
+    const updateOnboarding = vi.fn(async (onboarding: unknown) => onboarding)
+      .mockRejectedValueOnce(new Error("onboarding offline"));
+    mocks.state = { ...createInitialAppState(), modelConfig: savedModelConfig(server.catalog()) };
+    mocks.clients = createClients(server.saveModelCatalog, {
+      getModelConfig: server.getModelConfig,
+      updateOnboarding
+    });
+    await render(<ApiKeyOptionalPage />);
+    const nextButton = button("apiKey.next");
+
+    await click(nextButton);
+    const firstCatalog = server.catalog();
+    const firstImageEndpointId = assignedCatalogEndpointId(createModelWorkspace(firstCatalog), "byok", "image_generation");
+    expect(endpointCount(firstCatalog)).toBe(4);
+    expect(mocks.dispatch).not.toHaveBeenCalledWith(appActions.navigate("/onboarding"));
+
+    await changeField("apiKey.imageGenModel", "gpt-image-2");
+    await click(button("apiKey.test", 1));
+    await vi.waitFor(() => expect(nextButton.disabled).toBe(false));
+    await click(nextButton);
+
+    const retriedCatalog = server.catalog();
+    expect(server.saveModelCatalog).toHaveBeenCalledTimes(2);
+    expect(endpointCount(retriedCatalog)).toBe(4);
+    expect(assignedCatalogEndpointId(createModelWorkspace(retriedCatalog), "byok", "image_generation"))
+      .toBe(firstImageEndpointId);
+    expect(mocks.dispatch).toHaveBeenCalledWith(appActions.navigate("/onboarding"));
+  });
+
+  it("keeps the middle step pending and retryable when its catalog save fails", async () => {
+    const firstSave = deferred<ModelProviderConfig>();
+    const saveModelCatalog = vi.fn()
+      .mockReturnValueOnce(firstSave.promise)
+      .mockResolvedValueOnce(savedModelConfig());
+    mocks.clients = createClients(saveModelCatalog);
+    await render(<ModelPage />);
+    const nextButton = button("apiKey.next");
+
+    await click(nextButton);
+    expect(nextButton.disabled).toBe(true);
+
+    await reject(firstSave, new Error("middle step offline"));
+
+    expect(container.textContent).toContain("middle step offline");
+    expect(nextButton.disabled).toBe(false);
+    expect(mocks.dispatch).not.toHaveBeenCalledWith(appActions.navigate("/api-key-optional"));
+
+    await click(nextButton);
+    expect(mocks.dispatch).toHaveBeenCalledWith(appActions.navigate("/api-key-optional"));
+  });
+
+  async function render(page: React.ReactNode) {
+    await act(async () => root.render(page));
+  }
+
+  async function click(target: HTMLButtonElement) {
+    await act(async () => target.click());
+  }
+
+  function button(label: string, index = 0): HTMLButtonElement {
+    const target = [...container.querySelectorAll("button")]
+      .filter((candidate) => candidate.textContent === label)[index];
+    if (!(target instanceof HTMLButtonElement)) {
+      throw new Error(`button not found: ${label}`);
+    }
+    return target;
+  }
+
+  async function changeField(labelText: string, value: string) {
+    const label = [...container.querySelectorAll("label")]
+      .find((candidate) => candidate.textContent === labelText);
+    const input = label?.parentElement?.querySelector("input");
+    if (!(input instanceof HTMLInputElement)) {
+      throw new Error(`input not found: ${labelText}`);
+    }
+    await act(async () => {
+      Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")!.set!.call(input, value);
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+  }
+});
+
+function createClients(
+  saveModelCatalog: ReturnType<typeof vi.fn>,
+  overrides: {
+    getModelConfig?: ReturnType<typeof vi.fn>;
+    testModelConfig?: ReturnType<typeof vi.fn>;
+    updateSettings?: ReturnType<typeof vi.fn>;
+    updateOnboarding?: ReturnType<typeof vi.fn>;
+  } = {}
+): AppClients {
+  return {
+    config: {
+      getModelConfig: vi.fn(async () => mocks.state!.modelConfig),
+      saveModelCatalog,
+      testModelConfig: vi.fn(async () => ({
+        ok: true,
+        message: "ok",
+        checkedAt: "2026-08-19T00:00:00.000Z"
+      })),
+      updateSettings: vi.fn(async (settings) => settings),
+      updateOnboarding: vi.fn(async (onboarding) => onboarding),
+      ...overrides
+    }
+  } as unknown as AppClients;
+}
+
+function savedModelConfig(catalog = configuredCatalog()): ModelProviderConfig {
+  return {
+    provider: "openai",
+    endpoint: "https://api.openai.com/v1",
+    model: "gpt-4o",
+    apiKey: "sk-primary",
+    apiKeyMasked: "",
+    configured: true,
+    embedding: {
+      mode: "custom",
+      endpoint: "https://api.openai.com/v1",
+      model: "text-embedding-3-small",
+      apiKey: "sk-embedding",
+      apiKeyMasked: "",
+      configured: true
+    },
+    asr: {
+      provider: "qwen",
+      endpoint: "https://dashscope.aliyuncs.com/compatible-mode/v1",
+      model: "qwen3-asr-flash",
+      apiKey: "sk-asr",
+      apiKeyMasked: "",
+      configured: true
+    },
+    imageGen: {
+      provider: "openai",
+      endpoint: "https://api.openai.com/v1",
+      model: "gpt-image-1",
+      apiKey: "sk-image",
+      apiKeyMasked: "",
+      configured: true
+    },
+    catalog
+  };
+}
+
+function configuredCatalog(includeOptional = true): ModelConfigView {
+  const empty = emptyCatalog();
+  let workspace = createModelWorkspace(empty);
+  const agent = upsertByokPreset(workspace, {
+    provider: "openai",
+    endpoint: "https://api.openai.com/v1",
+    protocol: "openai-chat-completions",
+    apiKey: "sk-primary",
+    model: "gpt-4o",
+    capabilities: ["agent"]
+  });
+  workspace = assignCatalogPreset(agent.workspace, "byok", "agent", agent.presetId);
+  const embedding = upsertByokPreset(workspace, {
+    provider: "openai",
+    endpoint: "https://api.openai.com/v1",
+    protocol: "openai-embeddings",
+    apiKey: "sk-embedding",
+    model: "text-embedding-3-small",
+    capabilities: ["embedding"]
+  });
+  workspace = assignCatalogPreset(embedding.workspace, "byok", "embedding", embedding.presetId);
+  if (!includeOptional) {
+    return catalogFromInput(modelConfigInput(workspace), empty, 1);
+  }
+  const asr = upsertByokPreset(workspace, {
+    provider: "qwen",
+    endpoint: "https://dashscope.aliyuncs.com/compatible-mode/v1",
+    protocol: "dashscope-input-audio-chat",
+    apiKey: "sk-asr",
+    model: "qwen3-asr-flash",
+    capabilities: ["asr"]
+  });
+  workspace = assignCatalogPreset(asr.workspace, "byok", "asr", asr.presetId);
+  const image = upsertByokPreset(workspace, {
+    provider: "openai",
+    endpoint: "https://api.openai.com/v1",
+    protocol: "openai-images",
+    apiKey: "sk-image",
+    model: "gpt-image-1",
+    capabilities: ["image_generation"]
+  });
+  workspace = assignCatalogPreset(image.workspace, "byok", "image_generation", image.presetId);
+  return catalogFromInput(modelConfigInput(workspace), empty, 1);
+}
+
+function endpointCount(catalog: ModelConfigView): number {
+  return catalog.providers.reduce((total, provider) => total + provider.endpoints.length, 0);
+}
+
+function emptyCatalog(): ModelConfigView {
+  const assignment = {
+    agent: { candidates: [], default: null },
+    memorySummary: null,
+    memoryEvolution: null,
+    embedding: null,
+    asr: null,
+    imageGeneration: null
+  };
+  return {
+    configRevision: "revision-0",
+    providers: [],
+    modelAssignments: {
+      byok: structuredClone(assignment),
+      account: structuredClone(assignment)
+    },
+    effectiveCandidates: { byok: [], account: [] },
+    configured: false,
+    updatedAt: "2026-08-19T00:00:00.000Z"
+  };
+}
+
+function createCatalogServer(initialCatalog = emptyCatalog()) {
+  let catalog = structuredClone(initialCatalog);
+  let revision = 0;
+  return {
+    getModelConfig: vi.fn(async () => savedModelConfig(catalog)),
+    saveModelCatalog: vi.fn(async (input: ModelConfigInput | ModelConfigView) => {
+      const writable = "configured" in input
+        ? modelConfigInput(createModelWorkspace(input))
+        : input;
+      catalog = catalogFromInput(writable, catalog, ++revision);
+      return savedModelConfig(catalog);
+    }),
+    catalog: () => structuredClone(catalog)
+  };
+}
+
+function catalogFromInput(input: ModelConfigInput, previous: ModelConfigView, revision: number): ModelConfigView {
+  const providers: ModelConfigView["providers"] = input.providers.map((provider) => {
+    const previousProvider = previous.providers.find((candidate) => candidate.provider === provider.provider);
+    const endpoints = provider.endpoints.map((endpoint) => {
+      const previousEndpoint = previousProvider?.endpoints.find((candidate) => candidate.endpointId === endpoint.endpointId);
+      const rawApiKey = endpoint.apiKey?.trim() ?? "";
+      const apiKeyMasked = rawApiKey ? maskApiKey(rawApiKey) : previousEndpoint?.apiKeyMasked ?? "";
+      return {
+        endpointId: endpoint.endpointId,
+        apiBase: endpoint.apiBase,
+        protocol: endpoint.protocol,
+        hasApiKey: Boolean(rawApiKey || apiKeyMasked),
+        apiKeyMasked,
+        apiKey: ""
+      };
+    });
+    const models = provider.models.map((model) => {
+      const endpoint = endpoints.find((candidate) => candidate.endpointId === model.endpointId)!;
+      return {
+        ...model,
+        provider: provider.provider,
+        protocol: endpoint.protocol,
+        available: true
+      };
+    });
+    const apiKeyMasked = provider.apiKey
+      ? maskApiKey(provider.apiKey)
+      : previousProvider?.apiKeyMasked ?? "";
+    return {
+      provider: provider.provider,
+      configured: endpoints.some((endpoint) => endpoint.hasApiKey),
+      hasApiKey: Boolean(apiKeyMasked) || endpoints.some((endpoint) => endpoint.hasApiKey),
+      apiKeyMasked,
+      apiKey: "",
+      endpoints,
+      accountManaged: false,
+      editable: true,
+      models
+    };
+  });
+  const models = providers.flatMap((provider) => provider.models);
+  const byokIds = new Set(input.modelAssignments.byok.agent.candidates);
+  const accountIds = new Set(input.modelAssignments.account.agent.candidates);
+  return {
+    configRevision: `revision-${revision}`,
+    providers,
+    modelAssignments: structuredClone(input.modelAssignments),
+    effectiveCandidates: {
+      byok: models.filter((model) => byokIds.has(model.presetId)),
+      account: models.filter((model) => accountIds.has(model.presetId))
+    },
+    configured: byokIds.size > 0 || accountIds.size > 0,
+    updatedAt: "2026-08-19T00:00:00.000Z"
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((next, fail) => {
+    resolve = next;
+    reject = fail;
+  });
+  return { promise, resolve, reject };
+}
+
+async function reject<T>(pending: ReturnType<typeof deferred<T>>, error: unknown) {
+  await act(async () => {
+    pending.reject(error);
+    await Promise.resolve();
+  });
+}

--- a/App/frontend/desktop/src/pages/tests/model-page-source.test.ts
+++ b/App/frontend/desktop/src/pages/tests/model-page-source.test.ts
@@ -63,6 +63,10 @@ describe("ModelPage source", () => {
     expect(pageSource).not.toContain("function simulateTest");
     expect(pageSource).not.toContain("window.setTimeout");
     expect(pageSource).toContain("modelPageSaveErrorText(error, t)");
+    expect(pageSource).toContain("const [savePending, setSavePending] = useState(false)");
+    expect(pageSource).toContain("disabled={!canContinue || savePending}");
+    expect(pageSource).toContain("const [saveFeedback, setSaveFeedback]");
+    expect(pageSource).toContain("{saveFeedback.text}");
     expect(pageSource).not.toContain('t("login.error.modePersistenceFailed")');
     expect(pageSource).not.toContain("MessageToast");
     expect(pageSource).toContain('text-red-500">{saveFeedback.text}</p>');


### PR DESCRIPTION
## Summary
- surface save failures on the first and optional BYOK setup steps instead of leaving Next/Skip apparently unresponsive
- disable setup actions while persistence is pending and keep failed saves retryable without navigating away
- preserve endpoint identity across partial-success retries so model-only changes do not duplicate endpoints, while credential changes correctly invalidate the cached identity
- add interaction coverage for all three setup steps, including retry, pending, and endpoint-idempotency paths

## Verification
- PASS: focused BYOK setup suite (4 files, 20 tests)
- PASS: frontend TypeScript typecheck
- PASS: frontend production build
- PASS: manual custom-API setup check, including simulated first-save failure and successful retry; temporary simulation removed afterward
- PASS: Intl renderer, Memory, Gateway health, authenticated WebUI bootstrap, and authenticated Local API bootstrap all returned HTTP 200
- BASELINE: full frontend suite reports 1481 passed / 7 failed; the seven existing layout/CSS failures are in files unchanged from upstream/v1.0.9