### PR TITLE
fix(updater): support legacy Windows in-app upgrades

### DIFF
--- a/App/backend/src/infrastructure/app-state-store/repositories/account-session-repo.ts
+++ b/App/backend/src/infrastructure/app-state-store/repositories/account-session-repo.ts
@@ -364,19 +364,41 @@ function buildPersistedRawProfile(
 ): Record<string, unknown> {
   const result = stripCloudCredential(rawProfile);
   delete result[LOCAL_AUTH_CHANNEL_FIELD];
-  const persistedChannel = authChannel ?? resolveExplicitAccountAuthChannel(previous);
+  const persistedChannel = authChannel ?? resolveAccountAuthChannel(previous);
   if (persistedChannel) result[LOCAL_AUTH_CHANNEL_FIELD] = persistedChannel;
   return result;
 }
 
 function resolveAccountAuthChannel(row: AccountSessionRow | null): AccountChannel | null {
-  return resolveExplicitAccountAuthChannel(row);
+  return resolveExplicitAccountAuthChannel(row) ?? resolveLegacyAccountAuthChannel(row);
 }
 
 function resolveExplicitAccountAuthChannel(row: AccountSessionRow | null): AccountChannel | null {
   if (!row?.raw_profile_json) return null;
   const value = parseRawProfile(row.raw_profile_json)?.[LOCAL_AUTH_CHANNEL_FIELD];
   return value === "email" || value === "phone" ? value : null;
+}
+
+/**
+ * Infers the login channel for sessions written before `_memmyAuthChannel` existed.
+ *
+ * Only a single bound contact is trusted: an account containing both email and phone remains
+ * ambiguous and must still be rejected when a package requires a specific login channel.
+ *
+ * @param row the persisted account row.
+ * @returns the unambiguous legacy channel, or null when it cannot be inferred safely.
+ */
+function resolveLegacyAccountAuthChannel(row: AccountSessionRow | null): AccountChannel | null {
+  if (!row) return null;
+  const rawProfile = row.raw_profile_json ? parseRawProfile(row.raw_profile_json) : null;
+  const hasEmail = Boolean(row.email?.trim() || readRawProfileString(rawProfile?.email));
+  const hasPhone = Boolean(
+    row.phone?.trim()
+    || readRawProfileString(rawProfile?.phoneNumber)
+    || readRawProfileString(rawProfile?.phone)
+  );
+  if (hasEmail === hasPhone) return null;
+  return hasEmail ? "email" : "phone";
 }
 
 /**

--- a/App/backend/src/infrastructure/app-state-store/tests/account-session-repo.test.ts
+++ b/App/backend/src/infrastructure/app-state-store/tests/account-session-repo.test.ts
@@ -269,6 +269,47 @@ describe("account session repository", () => {
     expect(fabricatedAccount).toBeUndefined();
   });
 
+  it("infers a legacy login channel only from one unambiguous bound contact", () => {
+    tempDir = mkdtempSync(join(tmpdir(), "memmy-account-session-"));
+    const store = createAppStateStore({ databasePath: join(tempDir, "app.sqlite") });
+    const createProfile = (input: { userId: string; email: string | null; phoneNumber: string | null }) => ({
+      ...input,
+      nickname: input.userId,
+      avatarUrl: null,
+      planType: "free",
+      hasFinishedGuide: false,
+      region: null,
+      registeredAt: "2026-06-02T10:00:00.000Z",
+      rawProfile: {
+        id: input.userId,
+        ...(input.email ? { email: input.email } : {}),
+        ...(input.phoneNumber ? { phoneNumber: input.phoneNumber } : {})
+      }
+    });
+
+    store.repositories.accountSession.upsert({
+      profile: createProfile({ userId: "legacy-email", email: "legacy@example.com", phoneNumber: null }),
+      uuid: "legacy-email",
+      cloudUuid: "legacy.email.credential"
+    });
+    expect(store.repositories.accountSession.getAuthChannel()).toBe("email");
+
+    store.repositories.accountSession.upsert({
+      profile: createProfile({ userId: "legacy-phone", email: null, phoneNumber: "13800138000" }),
+      uuid: "legacy-phone",
+      cloudUuid: "legacy.phone.credential"
+    });
+    expect(store.repositories.accountSession.getAuthChannel()).toBe("phone");
+
+    store.repositories.accountSession.upsert({
+      profile: createProfile({ userId: "legacy-ambiguous", email: "both@example.com", phoneNumber: "13800138000" }),
+      uuid: "legacy-ambiguous",
+      cloudUuid: "legacy.ambiguous.credential"
+    });
+    expect(store.repositories.accountSession.getAuthChannel()).toBeNull();
+    store.close();
+  });
+
   it("uses the persisted login channel instead of inferring from bound contact fields", () => {
     tempDir = mkdtempSync(join(tmpdir(), "memmy-account-session-"));
     const store = createAppStateStore({ databasePath: join(tempDir, "app.sqlite") });

--- a/App/backend/src/services/tests/runtime-config-sync-service.test.ts
+++ b/App/backend/src/services/tests/runtime-config-sync-service.test.ts
@@ -79,6 +79,31 @@ describe("syncRuntimeConfigWithAppState", () => {
     expect(context.store.db.prepare("SELECT uuid FROM cloud_accounts WHERE uuid = ?").get("cloud-token-a")).toBeUndefined();
   });
 
+  it("keeps an unmarked legacy email session when the INTL package starts", async () => {
+    const context = createContext();
+    context.store.repositories.accountSession.upsert({
+      profile: {
+        userId: "owner-a", email: "a@example.test", phoneNumber: null, nickname: "a", avatarUrl: null,
+        planType: "free", hasFinishedGuide: false, region: null, registeredAt: "2026-06-02T10:00:00.000Z",
+        rawProfile: { id: "owner-a", email: "a@example.test", userName: "a" }
+      },
+      uuid: "account-a",
+      cloudUuid: "cloud-token-a"
+    });
+    context.writeConfig(currentAccountCatalog());
+
+    await expect(syncRuntimeConfigWithAppState({
+      ...context,
+      accountChannel: "email"
+    })).resolves.toMatchObject({
+      source: "runtime_config", mode: "account", hydratedAppState: true, wroteConfig: false
+    });
+    expect(context.store.repositories.accountSession.get()).toMatchObject({
+      authenticated: true,
+      profile: { userId: "owner-a" }
+    });
+  });
+
   it("clears an email session before CN startup hydrates the shared account projection", async () => {
     const context = createContext();
     context.store.repositories.accountSession.upsert({

--- a/App/shell/desktop/build/MemmyWindowsUpgradeCleanup.ps1
+++ b/App/shell/desktop/build/MemmyWindowsUpgradeCleanup.ps1
@@ -1,0 +1,6 @@
+param(
+  [Parameter(Mandatory = $true)][string]$WorkDir
+)
+
+Start-Sleep -Seconds 3
+Remove-Item -LiteralPath $WorkDir -Recurse -Force -ErrorAction SilentlyContinue

--- a/App/shell/desktop/build/MemmyWindowsUpgradeRelay.ps1
+++ b/App/shell/desktop/build/MemmyWindowsUpgradeRelay.ps1
@@ -1,0 +1,242 @@
+param(
+  [Parameter(Mandatory = $true)][string]$InstallerPath,
+  [Parameter(Mandatory = $true)][string]$InstallDir,
+  [Parameter(Mandatory = $true)][int]$OriginalInstallerPid,
+  [Parameter(Mandatory = $true)][int]$LegacyHelperPid,
+  [Parameter(Mandatory = $true)][string]$ExpectedVersion,
+  [Parameter(Mandatory = $true)][ValidateSet('0', '1')][string]$ReopenAfterInstall,
+  [Parameter(Mandatory = $true)][string]$ReadyPath,
+  [Parameter(Mandatory = $true)][string]$WorkDir,
+  [Parameter(Mandatory = $true)][string]$LogPath
+)
+
+$ErrorActionPreference = 'Stop'
+$dataPath = Join-Path $InstallDir 'data'
+$backupPath = Join-Path $WorkDir 'data-backup'
+$stagingRoot = Split-Path -Parent $WorkDir
+$lockPath = Join-Path $stagingRoot 'active.lock'
+$appExe = Join-Path $InstallDir 'Memmy.exe'
+$installerExit = 1
+$dataMoved = $false
+$dataRestored = $false
+$lockAcquired = $false
+$resolvedReopenAfterInstall = $ReopenAfterInstall
+
+function Write-MemmyUpgradeLog([string]$Message) {
+  $logDirectory = Split-Path -Parent $LogPath
+  if ($logDirectory) {
+    New-Item -ItemType Directory -Force -Path $logDirectory | Out-Null
+  }
+  Add-Content -LiteralPath $LogPath -Value ('[{0:O}] {1}' -f (Get-Date), $Message)
+}
+
+function Resolve-MemmyLegacyHelperReopenIntent([int]$HelperPid, [string]$MarkerPath, [string]$Fallback) {
+  try {
+    $helper = Get-CimInstance -ClassName Win32_Process -Filter ("ProcessId = {0}" -f $HelperPid) -ErrorAction Stop
+    $commandLine = [string]$helper.CommandLine
+    if (-not $commandLine) {
+      throw "legacy helper command line is unavailable"
+    }
+    $pattern = '(?:^|\s)"?(?<intent>[01])"?\s+"?' + [Regex]::Escape($MarkerPath) + '"?(?:\s|$)'
+    $match = [Regex]::Match($commandLine, $pattern, [Text.RegularExpressions.RegexOptions]::IgnoreCase)
+    if (-not $match.Success) {
+      throw "legacy helper reopen argument is unavailable"
+    }
+    $intent = $match.Groups['intent'].Value
+    Write-MemmyUpgradeLog "reopen intent resolved from legacy helper pid ${HelperPid}: $intent"
+    return $intent
+  } catch {
+    Write-MemmyUpgradeLog "reopen intent fallback=$Fallback legacyHelperPid=$HelperPid reason=$($_.Exception.Message)"
+    return $Fallback
+  }
+}
+
+function Wait-MemmyProcessExit([int]$ProcessId, [int]$TimeoutSeconds) {
+  $process = Get-Process -Id $ProcessId -ErrorAction SilentlyContinue
+  if ($null -eq $process) {
+    return
+  }
+  Write-MemmyUpgradeLog "waiting for original installer pid $ProcessId"
+  if (-not $process.WaitForExit($TimeoutSeconds * 1000)) {
+    throw "original installer pid $ProcessId did not exit"
+  }
+}
+
+function Move-MemmyDirectory([string]$Source, [string]$Destination) {
+  New-Item -ItemType Directory -Force -Path (Split-Path -Parent $Destination) | Out-Null
+  for ($attempt = 1; $attempt -le 120; $attempt++) {
+    try {
+      [System.IO.Directory]::Move($Source, $Destination)
+      return
+    } catch {
+      if ($attempt -eq 120) {
+        throw
+      }
+      Start-Sleep -Milliseconds 500
+    }
+  }
+}
+
+function Restore-MemmyData {
+  if (-not $dataMoved) {
+    $script:dataRestored = $true
+    return
+  }
+  if (-not (Test-Path -LiteralPath $backupPath -PathType Container)) {
+    if (Test-Path -LiteralPath $dataPath -PathType Container) {
+      $script:dataRestored = $true
+      Write-MemmyUpgradeLog "data restore verified by child installer $dataPath"
+      return
+    }
+    throw "data backup is missing: $backupPath"
+  }
+  if (Test-Path -LiteralPath $dataPath) {
+    $installerDataPath = Join-Path $WorkDir 'installer-created-data'
+    if (Test-Path -LiteralPath $installerDataPath) {
+      throw "installer-created data backup already exists: $installerDataPath"
+    }
+    Move-MemmyDirectory -Source $dataPath -Destination $installerDataPath
+    Write-MemmyUpgradeLog "preserved installer-created data at $installerDataPath"
+  }
+  New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
+  Move-MemmyDirectory -Source $backupPath -Destination $dataPath
+  if (-not (Test-Path -LiteralPath $dataPath -PathType Container)) {
+    throw "restored data directory is unavailable: $dataPath"
+  }
+  $script:dataRestored = $true
+  Write-MemmyUpgradeLog "data restore verified $dataPath"
+}
+
+function Get-MemmyInstalledVersion {
+  if (-not (Test-Path -LiteralPath $appExe -PathType Leaf)) {
+    return ''
+  }
+  $versionInfo = [System.Diagnostics.FileVersionInfo]::GetVersionInfo($appExe)
+  foreach ($value in @($versionInfo.ProductVersion, $versionInfo.FileVersion)) {
+    if ($value) {
+      return $value
+    }
+  }
+  return ''
+}
+
+function Clear-MemmyUpdateMarkers {
+  $markerPath = Join-Path $dataPath 'Memmy\prepared-required-update.json'
+  foreach ($path in @($markerPath, "$markerPath.lock", "$markerPath.prompt", "$markerPath.attempt")) {
+    Remove-Item -LiteralPath $path -Recurse -Force -ErrorAction SilentlyContinue
+  }
+}
+
+function Start-MemmyInstalledApp {
+  if (-not (Test-Path -LiteralPath $appExe -PathType Leaf)) {
+    Write-MemmyUpgradeLog "app executable is unavailable for reopen: $appExe"
+    return
+  }
+  Start-Process -FilePath $appExe -WorkingDirectory $InstallDir -WindowStyle Normal
+  Write-MemmyUpgradeLog "started app $appExe"
+}
+
+function Test-MemmyInstalledAppRunning {
+  $expectedPath = [System.IO.Path]::GetFullPath($appExe)
+  foreach ($process in @(Get-Process -Name 'Memmy' -ErrorAction SilentlyContinue)) {
+    try {
+      if ([string]::Equals([System.IO.Path]::GetFullPath($process.Path), $expectedPath, [System.StringComparison]::OrdinalIgnoreCase)) {
+        return $true
+      }
+    } catch {
+      continue
+    }
+  }
+  return $false
+}
+
+function Ensure-MemmyInstalledAppStarted {
+  for ($attempt = 1; $attempt -le 4; $attempt++) {
+    if (Test-MemmyInstalledAppRunning) {
+      Write-MemmyUpgradeLog "app already started by child installer $appExe"
+      return
+    }
+    if ($attempt -lt 4) {
+      Start-Sleep -Milliseconds 100
+    }
+  }
+  Start-MemmyInstalledApp
+}
+
+function Schedule-MemmyStagingCleanup {
+  $cleanupScriptPath = Join-Path $WorkDir 'MemmyWindowsUpgradeCleanup.ps1'
+  if (-not (Test-Path -LiteralPath $cleanupScriptPath -PathType Leaf)) {
+    return
+  }
+  $powershellPath = Join-Path $PSHOME 'powershell.exe'
+  $cleanupArguments = "-NoProfile -NonInteractive -ExecutionPolicy Bypass -WindowStyle Hidden -File `"$cleanupScriptPath`" -WorkDir `"$WorkDir`""
+  Start-Process -FilePath $powershellPath -ArgumentList $cleanupArguments -WorkingDirectory $stagingRoot -WindowStyle Hidden
+}
+
+try {
+  New-Item -ItemType Directory -Force -Path $WorkDir | Out-Null
+  Write-MemmyUpgradeLog "relay starting installer=$InstallerPath installDir=$InstallDir expected=$ExpectedVersion reopenFallback=$ReopenAfterInstall"
+  $markerPath = Join-Path $dataPath 'Memmy\prepared-required-update.json'
+  $resolvedReopenAfterInstall = Resolve-MemmyLegacyHelperReopenIntent -HelperPid $LegacyHelperPid -MarkerPath $markerPath -Fallback $ReopenAfterInstall
+  New-Item -ItemType Directory -Path $lockPath -ErrorAction Stop | Out-Null
+  $lockAcquired = $true
+  [System.IO.File]::WriteAllText($ReadyPath, $resolvedReopenAfterInstall)
+  Write-MemmyUpgradeLog "relay ready reopen=$resolvedReopenAfterInstall"
+  Wait-MemmyProcessExit -ProcessId $OriginalInstallerPid -TimeoutSeconds 120
+
+  if (Test-Path -LiteralPath $dataPath -PathType Container) {
+    if (Test-Path -LiteralPath $backupPath) {
+      throw "refusing to overwrite existing data backup: $backupPath"
+    }
+    Move-MemmyDirectory -Source $dataPath -Destination $backupPath
+    $dataMoved = $true
+    Write-MemmyUpgradeLog "data moved to $backupPath"
+  }
+
+  $arguments = @('/S', '--updated', '--memmy-upgrade-relayed', '/currentuser', ('/D=' + $InstallDir))
+  $env:MEMMY_UPGRADE_WORK_DIR = $WorkDir
+  $env:MEMMY_UPGRADE_REOPEN_AFTER_INSTALL = $resolvedReopenAfterInstall
+  Write-MemmyUpgradeLog "child installer context workDir=$env:MEMMY_UPGRADE_WORK_DIR reopen=$env:MEMMY_UPGRADE_REOPEN_AFTER_INSTALL"
+  $installerProcess = Start-Process -FilePath $InstallerPath -ArgumentList $arguments -PassThru -WindowStyle Hidden
+  $installerProcess.WaitForExit()
+  $installerExit = if ($null -eq $installerProcess.ExitCode) { 1 } else { $installerProcess.ExitCode }
+  Write-MemmyUpgradeLog "installer exit $installerExit"
+} catch {
+  Write-MemmyUpgradeLog ('relay error: ' + ($_ | Out-String))
+  if ($installerExit -eq 0) {
+    $installerExit = 1
+  }
+} finally {
+  try {
+    Restore-MemmyData
+  } catch {
+    Write-MemmyUpgradeLog ('data restore failed: ' + ($_ | Out-String))
+    $dataRestored = $false
+  }
+  if ($lockAcquired) {
+    Remove-Item -LiteralPath $lockPath -Recurse -Force -ErrorAction SilentlyContinue
+  }
+}
+
+if (-not $dataRestored) {
+  Write-MemmyUpgradeLog "upgrade stopped with recoverable data backup $backupPath"
+  exit 3
+}
+
+$installedVersion = Get-MemmyInstalledVersion
+$upgradeVerified = $installerExit -eq 0 -and $installedVersion.StartsWith($ExpectedVersion, [System.StringComparison]::OrdinalIgnoreCase)
+if ($upgradeVerified) {
+  Clear-MemmyUpdateMarkers
+  Write-MemmyUpgradeLog "upgrade verified installedVersion=$installedVersion"
+  if ($resolvedReopenAfterInstall -eq '1') {
+    Ensure-MemmyInstalledAppStarted
+  }
+  Schedule-MemmyStagingCleanup
+  exit 0
+}
+
+Write-MemmyUpgradeLog "upgrade not verified installedVersion=$installedVersion installerExit=$installerExit"
+if ($resolvedReopenAfterInstall -eq '1') {
+  Start-MemmyInstalledApp
+}
+exit $(if ($installerExit -ne 0) { $installerExit } else { 4 })

--- a/App/shell/desktop/build/installer-win-unsigned.nsh
+++ b/App/shell/desktop/build/installer-win-unsigned.nsh
@@ -1,3 +1,6 @@
+!include "FileFunc.nsh"
+!include "getProcessInfo.nsh"
+
 !ifndef MEMMY_WM_SETTINGCHANGE
   !define MEMMY_WM_SETTINGCHANGE 0x001A
 !endif
@@ -19,10 +22,27 @@
 !macroend
 
 !ifndef BUILD_UNINSTALLER
+  Var MemmyIsRelayedUpgrade
+  Var MemmyUpgradeWorkDir
+  Var MemmyUpgradeReopenAfterInstall
+
+  ; The 1.0.8 updater starts the downloaded installer from $INSTDIR\data. electron-builder's
+  ; normal upgrade path asks the old uninstaller to move all of $INSTDIR, so that running
+  ; installer keeps the directory busy and the old uninstaller exits with code 2. Relay only
+  ; this legacy --updated invocation through a copy outside $INSTDIR. The relayed child carries
+  ; an explicit marker so normal installs and future upgrades continue through electron-builder.
+  !macro customInit
+    Call MemmyRelayLegacyUpgrade
+  !macroend
+
   !macro customInstall
+    Call MemmyRestoreRelayedUpgradeData
     Call MemmyAddCliToUserPath
     Call MemmyInstallLaunchProxy
     !insertmacro MemmyPointShortcutsToLaunchProxy
+    Call MemmyClearRelayedUpgradeMarkers
+    Call MemmyLaunchRelayedUpgrade
+    Call MemmyScheduleRelayedUpgradeCleanup
   !macroend
 !endif
 
@@ -34,6 +54,168 @@
 !endif
 
 !ifndef BUILD_UNINSTALLER
+Function MemmyRelayLegacyUpgrade
+  ${GetParameters} $R0
+
+  ClearErrors
+  ${GetOptions} $R0 "--memmy-upgrade-relayed" $R1
+  IfErrors memmy_relay_check_legacy
+  Call MemmyReadRelayedUpgradeContext
+  Return
+
+  memmy_relay_check_legacy:
+    ClearErrors
+    ${GetOptions} $R0 "--updated" $R1
+    IfErrors memmy_relay_done
+
+    System::Call 'kernel32::GetCurrentProcessId() i .r2'
+    StrCmp $2 "" memmy_relay_failed
+    StrCmp $2 "0" memmy_relay_failed
+    ${GetProcessInfo} $2 $2 $3 $4 $5 $6
+    StrCmp $3 "" memmy_relay_failed
+    StrCmp $3 "0" memmy_relay_failed
+    StrCpy $R1 "$LOCALAPPDATA\Memmy\upgrade-staging\$2"
+    StrCpy $R3 "$R1\MemmyWindowsUpgradeRelay.ps1"
+    StrCpy $R4 "$R1\Memmy-${VERSION}-upgrade.exe"
+    StrCpy $R5 "$SYSDIR\WindowsPowerShell\v1.0\powershell.exe"
+    StrCpy $R7 "$LOCALAPPDATA\Memmy\upgrade-logs\windows-upgrade.log"
+    StrCpy $R8 "$R1\relay-ready"
+
+    ; Direct/manual updates reopen Memmy. A prepared update without the boot-attempt marker was
+    ; launched during normal app shutdown and must remain closed. Boot fallback writes .attempt.
+    StrCpy $R6 "1"
+    IfFileExists "$INSTDIR\data\Memmy\prepared-required-update.json" 0 memmy_relay_stage
+    IfFileExists "$INSTDIR\data\Memmy\prepared-required-update.json.attempt" memmy_relay_stage
+    StrCpy $R6 "0"
+
+  memmy_relay_stage:
+    ; Refresh the launch proxy before the relay moves $INSTDIR\data. The 1.0.8 proxy only knows
+    ; the install-local marker lock, which disappears with that move; the refreshed proxy also
+    ; recognizes the relay lock outside $INSTDIR and keeps desktop launches blocked throughout.
+    Call MemmyInstallLaunchProxy
+    ClearErrors
+    CreateDirectory "$R1"
+    SetOutPath "$R1"
+    File /oname=MemmyWindowsUpgradeRelay.ps1 "${BUILD_RESOURCES_DIR}\MemmyWindowsUpgradeRelay.ps1"
+    IfErrors memmy_relay_failed
+    IfFileExists "$R3" 0 memmy_relay_failed
+    File /oname=MemmyWindowsUpgradeCleanup.ps1 "${BUILD_RESOURCES_DIR}\MemmyWindowsUpgradeCleanup.ps1"
+    IfErrors memmy_relay_failed
+    IfFileExists "$R1\MemmyWindowsUpgradeCleanup.ps1" 0 memmy_relay_failed
+
+    ClearErrors
+    CopyFiles /SILENT "$EXEPATH" "$R4"
+    IfErrors memmy_relay_failed
+    IfFileExists "$R4" 0 memmy_relay_failed
+    IfFileExists "$R5" 0 memmy_relay_failed
+    Delete "$R8"
+
+    ClearErrors
+    ExecShell "open" "$R5" '-NoProfile -NonInteractive -ExecutionPolicy Bypass -WindowStyle Hidden -File $\"$R3$\" -InstallerPath $\"$R4$\" -InstallDir $\"$INSTDIR$\" -OriginalInstallerPid $2 -LegacyHelperPid $3 -ExpectedVersion $\"${VERSION}$\" -ReopenAfterInstall $R6 -ReadyPath $\"$R8$\" -WorkDir $\"$R1$\" -LogPath $\"$R7$\"' SW_HIDE
+    IfErrors memmy_relay_failed
+    StrCpy $R9 "0"
+
+  memmy_relay_wait_ready:
+    IfFileExists "$R8" memmy_relay_ready
+    Sleep 100
+    IntOp $R9 $R9 + 1
+    IntCmp $R9 100 memmy_relay_failed memmy_relay_wait_ready memmy_relay_failed
+
+  memmy_relay_ready:
+
+    ; The old 1.0.8 helper must not reopen the old executable while the relay owns the upgrade.
+    SetErrorLevel 1602
+    Quit
+
+  memmy_relay_failed:
+    SetOutPath "$INSTDIR"
+    SetErrorLevel 2
+    Quit
+
+  memmy_relay_done:
+FunctionEnd
+
+Function MemmyReadRelayedUpgradeContext
+  StrCpy $MemmyIsRelayedUpgrade "0"
+  ReadEnvStr $MemmyUpgradeWorkDir "MEMMY_UPGRADE_WORK_DIR"
+  ReadEnvStr $MemmyUpgradeReopenAfterInstall "MEMMY_UPGRADE_REOPEN_AFTER_INSTALL"
+  StrCmp $MemmyUpgradeWorkDir "" memmy_relay_context_failed
+  StrCmp $MemmyUpgradeReopenAfterInstall "0" memmy_relay_context_validate_path
+  StrCmp $MemmyUpgradeReopenAfterInstall "1" memmy_relay_context_validate_path memmy_relay_context_failed
+
+  memmy_relay_context_validate_path:
+    StrCpy $0 "$LOCALAPPDATA\Memmy\upgrade-staging\"
+    StrLen $1 $0
+    StrLen $2 $MemmyUpgradeWorkDir
+    IntCmp $2 $1 memmy_relay_context_failed memmy_relay_context_failed memmy_relay_context_compare_path
+
+  memmy_relay_context_compare_path:
+    StrCpy $3 $MemmyUpgradeWorkDir $1
+    StrCmp $3 $0 0 memmy_relay_context_failed
+    StrCpy $MemmyIsRelayedUpgrade "1"
+    Return
+
+  memmy_relay_context_failed:
+    SetErrorLevel 2
+    Quit
+FunctionEnd
+
+Function MemmyRestoreRelayedUpgradeData
+  StrCmp $MemmyIsRelayedUpgrade "1" 0 memmy_restore_relayed_data_done
+  StrCpy $0 "$MemmyUpgradeWorkDir\data-backup"
+  StrCpy $1 "$INSTDIR\data"
+  StrCpy $2 "$MemmyUpgradeWorkDir\installer-created-data"
+  IfFileExists "$0\*" 0 memmy_restore_relayed_data_failed
+  IfFileExists "$2\*" memmy_restore_relayed_data_failed
+  IfFileExists "$1\*" 0 memmy_restore_relayed_data_backup
+  ClearErrors
+  Rename "$1" "$2"
+  IfErrors memmy_restore_relayed_data_failed
+
+  memmy_restore_relayed_data_backup:
+    ClearErrors
+    Rename "$0" "$1"
+    IfErrors memmy_restore_relayed_data_failed
+    IfFileExists "$1\*" memmy_restore_relayed_data_done memmy_restore_relayed_data_failed
+
+  memmy_restore_relayed_data_failed:
+    SetErrorLevel 3
+    Quit
+
+  memmy_restore_relayed_data_done:
+FunctionEnd
+
+Function MemmyClearRelayedUpgradeMarkers
+  StrCmp $MemmyIsRelayedUpgrade "1" 0 memmy_clear_relayed_markers_done
+  StrCpy $0 "$INSTDIR\data\Memmy\prepared-required-update.json"
+  Delete "$0"
+  RMDir /r "$0.lock"
+  Delete "$0.prompt"
+  Delete "$0.attempt"
+  RMDir /r "$LOCALAPPDATA\Memmy\upgrade-staging\active.lock"
+
+  memmy_clear_relayed_markers_done:
+FunctionEnd
+
+Function MemmyLaunchRelayedUpgrade
+  StrCmp $MemmyIsRelayedUpgrade "1" 0 memmy_launch_relayed_upgrade_done
+  StrCmp $MemmyUpgradeReopenAfterInstall "1" 0 memmy_launch_relayed_upgrade_done
+  Exec '$\"$INSTDIR\${PRODUCT_FILENAME}.exe$\" --updated'
+
+  memmy_launch_relayed_upgrade_done:
+FunctionEnd
+
+Function MemmyScheduleRelayedUpgradeCleanup
+  StrCmp $MemmyIsRelayedUpgrade "1" 0 memmy_schedule_relayed_cleanup_done
+  StrCpy $0 "$MemmyUpgradeWorkDir\MemmyWindowsUpgradeCleanup.ps1"
+  StrCpy $1 "$SYSDIR\WindowsPowerShell\v1.0\powershell.exe"
+  IfFileExists "$0" 0 memmy_schedule_relayed_cleanup_done
+  IfFileExists "$1" 0 memmy_schedule_relayed_cleanup_done
+  ExecShell "open" "$1" '-NoProfile -NonInteractive -ExecutionPolicy Bypass -WindowStyle Hidden -File $\"$0$\" -WorkDir $\"$MemmyUpgradeWorkDir$\"' SW_HIDE
+
+  memmy_schedule_relayed_cleanup_done:
+FunctionEnd
+
 Function MemmyPathContains
   Exch $R1
   Exch
@@ -103,6 +285,10 @@ Function MemmyInstallLaunchProxy
   FileWrite $1 "languagePath = dataRoot & $\"\Memmy\update-prompt-language.txt$\"$\r$\n"
   FileWrite $1 "markerPath = dataRoot & $\"\Memmy\prepared-required-update.json$\"$\r$\n"
   FileWrite $1 "lockPath = markerPath & $\".lock$\"$\r$\n"
+  FileWrite $1 "relayLockPath = shell.ExpandEnvironmentStrings($\"%LOCALAPPDATA%$\") & $\"\Memmy\upgrade-staging\active.lock$\"$\r$\n"
+  FileWrite $1 "If fso.FolderExists(relayLockPath) Then$\r$\n"
+  FileWrite $1 "  lockPath = relayLockPath$\r$\n"
+  FileWrite $1 "End If$\r$\n"
   FileWrite $1 "promptMarkerPath = markerPath & $\".prompt$\"$\r$\n"
   FileWrite $1 "If fso.FolderExists(lockPath) And fso.FileExists(promptMarkerPath) Then$\r$\n"
   FileWrite $1 "  If fso.FileExists(powerShellPath) And fso.FileExists(promptPath) Then$\r$\n"

--- a/App/shell/desktop/src/main/main.ts
+++ b/App/shell/desktop/src/main/main.ts
@@ -1727,7 +1727,26 @@ function resolvePreparedRequiredUpdatePath(): string {
  * @returns The lock directory path next to the marker file.
  */
 function resolvePreparedRequiredUpdateLockPath(): string {
+  const relayLockPath = resolveWindowsUpgradeRelayLockPath();
+  if (relayLockPath && existsSync(relayLockPath)) {
+    return relayLockPath;
+  }
   return `${resolvePreparedRequiredUpdatePath()}.lock`;
+}
+
+/**
+ * Resolves the install-independent lock held by the Windows legacy-upgrade relay.
+ *
+ * The relay moves the old install-local data directory out of the way, so the legacy marker lock
+ * temporarily disappears. New Windows builds prefer this external lock while preserving the old
+ * marker lock as a fallback for updates that do not need the relay.
+ *
+ * @returns The relay lock path on Windows, or null when it cannot be resolved.
+ */
+function resolveWindowsUpgradeRelayLockPath(): string | null {
+  if (process.platform !== "win32") return null;
+  const localAppData = process.env.LOCALAPPDATA?.trim();
+  return localAppData ? join(localAppData, "Memmy", "upgrade-staging", "active.lock") : null;
 }
 
 /**

--- a/App/shell/desktop/tests/packaged-runtime-boundary.test.ts
+++ b/App/shell/desktop/tests/packaged-runtime-boundary.test.ts
@@ -32,6 +32,7 @@ const packageWinPath = fileURLToPath(new URL("../../../../scripts/package-win.sh
 const packageWinX64Path = fileURLToPath(new URL("../../../../scripts/internal/win/build-nsis.sh", import.meta.url));
 const winUnsignedBuilderPath = fileURLToPath(new URL("../electron-builder.win.unsigned.yml", import.meta.url));
 const winUnsignedInstallerIncludePath = fileURLToPath(new URL("../build/installer-win-unsigned.nsh", import.meta.url));
+const winUpgradeRelayScriptPath = fileURLToPath(new URL("../build/MemmyWindowsUpgradeRelay.ps1", import.meta.url));
 const desktopInterfacePath = fileURLToPath(new URL("../interface/src/index.ts", import.meta.url));
 const localApiContractsPath = fileURLToPath(new URL("../../../../App/backend/local-api-contracts/src/index.ts", import.meta.url));
 const rootPackagePath = fileURLToPath(new URL("../../../../package.json", import.meta.url));
@@ -546,6 +547,61 @@ describe("desktop packaged runtime boundaries", () => {
     expect(includeSource).toContain("CRCCheck off");
   });
 
+  it("relays legacy in-app upgrades outside the installed data directory", () => {
+    const signedBuilderConfig = readFileSync(winElectronBuilderPath, "utf8");
+    const unsignedBuilderConfig = readFileSync(winUnsignedBuilderPath, "utf8");
+    const includeSource = readFileSync(winUnsignedInstallerIncludePath, "utf8");
+    const relaySource = readFileSync(winUpgradeRelayScriptPath, "utf8");
+    const mainSource = readFileSync(mainSourcePath, "utf8");
+
+    expect(signedBuilderConfig).toContain("include: build/installer-win-unsigned.nsh");
+    expect(unsignedBuilderConfig).toContain("include: build/installer-win-unsigned.nsh");
+    expect(includeSource).toContain("!macro customInit");
+    expect(includeSource).toContain("--memmy-upgrade-relayed");
+    expect(includeSource).toContain("MemmyWindowsUpgradeRelay.ps1");
+    expect(includeSource).toContain('$LOCALAPPDATA\\Memmy\\upgrade-staging');
+    expect(includeSource).toContain("GetCurrentProcessId");
+    expect(includeSource).toContain('upgrade-staging\\$2');
+    expect(includeSource).toContain("OriginalInstallerPid $2");
+    expect(includeSource).toContain("LegacyHelperPid $3");
+    expect(includeSource).toContain("ReopenAfterInstall");
+    expect(includeSource).toContain("Call MemmyRestoreRelayedUpgradeData");
+    expect(includeSource).toContain("Call MemmyClearRelayedUpgradeMarkers");
+    expect(includeSource).toContain("Call MemmyLaunchRelayedUpgrade");
+    expect(includeSource).toContain("Call MemmyScheduleRelayedUpgradeCleanup");
+    expect(includeSource).toContain("MEMMY_UPGRADE_WORK_DIR");
+    expect(includeSource).toContain("MEMMY_UPGRADE_REOPEN_AFTER_INSTALL");
+    expect(includeSource).toContain("relay-ready");
+    expect(includeSource).toContain("ReadyPath");
+    expect(includeSource).toContain("MemmyWindowsUpgradeCleanup.ps1");
+    expect(includeSource).toContain('ExecShell "open" "$R5"');
+    expect(includeSource).toContain('ExecShell "open" "$1"');
+    expect(includeSource.match(/ExecShell "open" .* SW_HIDE/g)).toHaveLength(2);
+    expect(includeSource).not.toContain('Exec \'$\\\"$R5$\\\"');
+    expect(includeSource).toContain('Exec \'$\\\"$INSTDIR\\${PRODUCT_FILENAME}.exe$\\\" --updated\'');
+    expect(includeSource).toContain('$LOCALAPPDATA\\Memmy\\upgrade-staging\\active.lock');
+    const relayInitIndex = includeSource.indexOf("Function MemmyRelayLegacyUpgrade");
+    const earlyLaunchProxyIndex = includeSource.indexOf("Call MemmyInstallLaunchProxy", relayInitIndex);
+    const relayStartIndex = includeSource.indexOf('ExecShell "open" "$R5"', relayInitIndex);
+    expect(earlyLaunchProxyIndex).toBeGreaterThan(relayInitIndex);
+    expect(earlyLaunchProxyIndex).toBeLessThan(relayStartIndex);
+    expect(includeSource).toContain("SetErrorLevel");
+    expect(relaySource).toContain("Move-MemmyDirectory");
+    expect(relaySource).toContain("Restore-MemmyData");
+    expect(relaySource).toContain("Resolve-MemmyLegacyHelperReopenIntent");
+    expect(relaySource).toContain("MEMMY_UPGRADE_WORK_DIR");
+    expect(relaySource).toContain("MEMMY_UPGRADE_REOPEN_AFTER_INSTALL");
+    expect(relaySource).toContain("$installerProcess.WaitForExit()");
+    expect(relaySource).not.toContain("-Wait -PassThru");
+    expect(relaySource).toContain("MemmyWindowsUpgradeCleanup.ps1");
+    expect(relaySource).not.toContain("cmd.exe");
+    expect(relaySource).not.toContain("$env:ComSpec");
+    expect(relaySource).not.toContain("ping.exe");
+    expect(relaySource).toContain("--memmy-upgrade-relayed");
+    expect(relaySource).toContain("upgrade verified");
+    expect(mainSource).toContain('spawn("/bin/zsh", [helperPath, filePath, destinationAppPath, logPath, String(process.pid), options.openAfterInstall ? "1" : "0"');
+  });
+
   it("adds packaged Windows CLI launchers to the user PATH", () => {
     const signedBuilderConfig = readFileSync(winElectronBuilderPath, "utf8");
     const unsignedBuilderConfig = readFileSync(winUnsignedBuilderPath, "utf8");
@@ -586,6 +642,9 @@ describe("desktop packaged runtime boundaries", () => {
     expect(includeSource).toContain('dataRoot = $\\"$INSTDIR\\data$\\"');
     expect(includeSource).toContain('languagePath = dataRoot & $\\"\\Memmy\\update-prompt-language.txt$\\"');
     expect(includeSource).toContain('markerPath = dataRoot & $\\"\\Memmy\\prepared-required-update.json$\\"');
+    expect(includeSource).toContain('relayLockPath = shell.ExpandEnvironmentStrings($\\"%LOCALAPPDATA%$\\") & $\\"\\Memmy\\upgrade-staging\\active.lock$\\"');
+    expect(includeSource).toContain("If fso.FolderExists(relayLockPath) Then");
+    expect(includeSource).toContain("lockPath = relayLockPath");
     expect(includeSource).toContain("WindowsPowerShell\\v1.0\\powershell.exe");
     expect(includeSource).toContain('promptMarkerPath = markerPath & $\\".prompt$\\"');
     expect(includeSource).toContain("If fso.FolderExists(lockPath) And fso.FileExists(promptMarkerPath) Then");
@@ -825,6 +884,8 @@ describe("desktop packaged runtime boundaries", () => {
     expect(mainSource).toContain("openAfterInstall: false");
     expect(mainSource).not.toContain('openAfterInstall: process.platform === "win32"');
     expect(mainSource).toContain("function resolvePreparedRequiredUpdateLockPath");
+    expect(mainSource).toContain("function resolveWindowsUpgradeRelayLockPath");
+    expect(mainSource).toContain('join(localAppData, "Memmy", "upgrade-staging", "active.lock")');
     expect(mainSource).toContain("async function waitForPreparedRequiredUpdateLock");
     expect(mainSource).toContain("async function waitForWindowsPreparedRequiredUpdateBeforeBoot");
     expect(mainSource).toContain('boot:prepared-required-update waiting-for-lock win32');

--- a/App/shell/desktop/tests/windows-upgrade-relay.test.ts
+++ b/App/shell/desktop/tests/windows-upgrade-relay.test.ts
@@ -1,0 +1,224 @@
+import { execFile as execFileCallback, spawn, type ChildProcess } from "node:child_process";
+import { existsSync } from "node:fs";
+import { copyFile, mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { promisify } from "node:util";
+import { afterEach, describe, expect, it } from "vitest";
+
+const execFile = promisify(execFileCallback);
+const relayScriptPath = resolve(import.meta.dirname, "../build/MemmyWindowsUpgradeRelay.ps1");
+const cleanupScriptPath = resolve(import.meta.dirname, "../build/MemmyWindowsUpgradeCleanup.ps1");
+const temporaryDirectories: string[] = [];
+const helperProcesses: ChildProcess[] = [];
+const descendantProcessIds: number[] = [];
+const describeOnWindows = process.platform === "win32" ? describe : describe.skip;
+
+afterEach(async () => {
+  await Promise.all(helperProcesses.splice(0).map(async (process) => {
+    if (process.exitCode !== null) return;
+    await new Promise<void>((resolvePromise) => {
+      process.once("exit", () => resolvePromise());
+      process.kill();
+    });
+  }));
+  for (const processId of descendantProcessIds.splice(0)) {
+    try {
+      process.kill(processId);
+    } catch {
+      // The descendant may already have exited.
+    }
+    for (let attempt = 0; attempt < 30; attempt += 1) {
+      try {
+        process.kill(processId, 0);
+        await new Promise((resolvePromise) => setTimeout(resolvePromise, 100));
+      } catch {
+        break;
+      }
+    }
+  }
+  await Promise.all(temporaryDirectories.splice(0).map((directory) => rm(directory, {
+    recursive: true,
+    force: true,
+    maxRetries: 20,
+    retryDelay: 100
+  })));
+});
+
+const createRelayFixture = async (installerExitCode: number, options: { spawnLongLivedDescendant?: boolean } = {}) => {
+  const root = await mkdtemp(join(tmpdir(), "memmy-upgrade-relay-"));
+  temporaryDirectories.push(root);
+  const installDir = join(root, "installed Memmy");
+  const dataDir = join(installDir, "data", "Memmy");
+  const workDir = join(root, "relay-work");
+  const logPath = join(root, "logs", "windows-upgrade.log");
+  const installerPath = join(root, `fake-installer-${installerExitCode}.cmd`);
+  const descendantPidPath = join(root, "installer-descendant.pid");
+  const descendantScriptPath = join(root, "installer-descendant.ps1");
+  await mkdir(dataDir, { recursive: true });
+  await mkdir(workDir, { recursive: true });
+  await copyFile(cleanupScriptPath, join(workDir, "MemmyWindowsUpgradeCleanup.ps1"));
+  await writeFile(join(dataDir, "sentinel.txt"), "keep-me", "utf8");
+  await writeFile(join(dataDir, "prepared-required-update.json"), "{}", "utf8");
+  await mkdir(join(dataDir, "prepared-required-update.json.lock"), { recursive: true });
+  await writeFile(join(dataDir, "prepared-required-update.json.prompt"), "prompt", "utf8");
+  await writeFile(join(dataDir, "prepared-required-update.json.attempt"), "1.0.9", "utf8");
+  const windowsDirectory = process.env.SystemRoot ?? "C:\\Windows";
+  const appStubPath = join(windowsDirectory, "System32", "where.exe");
+  await writeFile(join(installDir, "Memmy.exe"), await readFile(appStubPath));
+  const escapedInstallDir = installDir.replaceAll("%", "%%");
+  const escapedAppStubPath = appStubPath.replaceAll("%", "%%");
+  const installerLines = [
+    "@echo off",
+  ];
+  if (options.spawnLongLivedDescendant) {
+    const powershellPath = join(windowsDirectory, "System32", "WindowsPowerShell", "v1.0", "powershell.exe");
+    await writeFile(descendantScriptPath, [
+      `$PID | Set-Content -LiteralPath '${descendantPidPath.replaceAll("'", "''")}'`,
+      "Start-Sleep -Seconds 20",
+      ""
+    ].join("\r\n"), "utf8");
+    installerLines.push(`start "" /b "${powershellPath.replaceAll("%", "%%")}" -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "${descendantScriptPath.replaceAll("%", "%%")}"`);
+  }
+  installerLines.push(
+    `rmdir /s /q "${escapedInstallDir}"`,
+    `mkdir "${escapedInstallDir}"`,
+    `copy /y "${escapedAppStubPath}" "${escapedInstallDir}\\Memmy.exe" >nul`,
+    "if not defined MEMMY_UPGRADE_WORK_DIR goto installer_done",
+    ">\"%MEMMY_UPGRADE_WORK_DIR%\\child-reopen-intent.txt\" echo(%MEMMY_UPGRADE_REOPEN_AFTER_INSTALL%",
+    `move /y "%MEMMY_UPGRADE_WORK_DIR%\\data-backup" "${escapedInstallDir}\\data" >nul`,
+    ":installer_done",
+    `exit /b ${installerExitCode}`,
+    ""
+  );
+  await writeFile(installerPath, installerLines.join("\r\n"), "utf8");
+  return { root, installDir, dataDir, workDir, logPath, installerPath, descendantPidPath };
+};
+
+const runRelay = async (
+  fixture: Awaited<ReturnType<typeof createRelayFixture>>,
+  options: { legacyHelperPid?: number; reopenAfterInstall?: "0" | "1" } = {}
+) => {
+  const powershellPath = join(process.env.SystemRoot ?? "C:\\Windows", "System32", "WindowsPowerShell", "v1.0", "powershell.exe");
+  return execFile(powershellPath, [
+    "-NoProfile",
+    "-ExecutionPolicy",
+    "Bypass",
+    "-File",
+    relayScriptPath,
+    "-InstallerPath",
+    fixture.installerPath,
+    "-InstallDir",
+    fixture.installDir,
+    "-OriginalInstallerPid",
+    "2147483647",
+    "-LegacyHelperPid",
+    String(options.legacyHelperPid ?? 2147483647),
+    "-ExpectedVersion",
+    "10.",
+    "-ReopenAfterInstall",
+    options.reopenAfterInstall ?? "0",
+    "-ReadyPath",
+    join(fixture.workDir, "relay-ready"),
+    "-WorkDir",
+    fixture.workDir,
+    "-LogPath",
+    fixture.logPath
+  ], { timeout: 30_000, windowsHide: true });
+};
+
+const startLegacyUpdateHelper = async (fixture: Awaited<ReturnType<typeof createRelayFixture>>, reopenAfterInstall: "0" | "1") => {
+  const powershellPath = join(process.env.SystemRoot ?? "C:\\Windows", "System32", "WindowsPowerShell", "v1.0", "powershell.exe");
+  const helperPath = join(fixture.root, "legacy update helper.ps1");
+  const markerPath = join(fixture.dataDir, "prepared-required-update.json");
+  await writeFile(helperPath, "param($AppPid, $OpenAfterInstall, $MarkerPath)\nStart-Sleep -Seconds 20\n", "utf8");
+  const helper = spawn(powershellPath, [
+    "-NoProfile",
+    "-File",
+    helperPath,
+    "43188",
+    reopenAfterInstall,
+    markerPath
+  ], { windowsHide: true, stdio: "ignore" });
+  helperProcesses.push(helper);
+  await new Promise((resolvePromise) => setTimeout(resolvePromise, 250));
+  if (!helper.pid) {
+    throw new Error("legacy update helper did not start");
+  }
+  return helper.pid;
+};
+
+const waitForPathAbsent = async (path: string) => {
+  const deadline = Date.now() + 10_000;
+  while (existsSync(path) && Date.now() < deadline) {
+    await new Promise((resolvePromise) => setTimeout(resolvePromise, 100));
+  }
+};
+
+const waitForPathPresent = async (path: string) => {
+  const deadline = Date.now() + 10_000;
+  while (!existsSync(path) && Date.now() < deadline) {
+    await new Promise((resolvePromise) => setTimeout(resolvePromise, 100));
+  }
+};
+
+describeOnWindows("Windows upgrade relay", () => {
+  it("restores install-local data and clears prepared markers after a verified upgrade", async () => {
+    expect(existsSync(relayScriptPath)).toBe(true);
+    const fixture = await createRelayFixture(0);
+    await runRelay(fixture);
+
+    expect(await readFile(join(fixture.dataDir, "sentinel.txt"), "utf8")).toBe("keep-me");
+    expect(existsSync(join(fixture.installDir, "Memmy.exe"))).toBe(true);
+    expect(existsSync(join(fixture.dataDir, "prepared-required-update.json"))).toBe(false);
+    expect(existsSync(join(fixture.dataDir, "prepared-required-update.json.lock"))).toBe(false);
+    expect(existsSync(join(fixture.dataDir, "prepared-required-update.json.prompt"))).toBe(false);
+    expect(existsSync(join(fixture.dataDir, "prepared-required-update.json.attempt"))).toBe(false);
+    const log = await readFile(fixture.logPath, "utf8");
+    expect(log).toContain("data restore verified");
+    expect(log).toContain("upgrade verified");
+    await waitForPathAbsent(fixture.workDir);
+    expect(existsSync(fixture.workDir)).toBe(false);
+  });
+
+  it("restores data and retains update markers when the staged installer exits 2", async () => {
+    expect(existsSync(relayScriptPath)).toBe(true);
+    const fixture = await createRelayFixture(2);
+    await expect(runRelay(fixture)).rejects.toMatchObject({ code: 2 });
+
+    expect(await readFile(join(fixture.dataDir, "sentinel.txt"), "utf8")).toBe("keep-me");
+    expect(existsSync(join(fixture.dataDir, "prepared-required-update.json"))).toBe(true);
+    const log = await readFile(fixture.logPath, "utf8");
+    expect(log).toContain("installer exit 2");
+    expect(log).toContain("data restore verified");
+    expect(log).not.toContain("upgrade verified");
+  });
+
+  it("uses the legacy helper's explicit manual reopen intent and lets the child installer restore data", async () => {
+    const fixture = await createRelayFixture(0);
+    const helperPid = await startLegacyUpdateHelper(fixture, "1");
+
+    await runRelay(fixture, { legacyHelperPid: helperPid, reopenAfterInstall: "0" });
+
+    expect(await readFile(join(fixture.workDir, "child-reopen-intent.txt"), "utf8")).toBe("1\r\n");
+    expect(await readFile(join(fixture.workDir, "relay-ready"), "utf8")).toBe("1");
+    expect(await readFile(join(fixture.dataDir, "sentinel.txt"), "utf8")).toBe("keep-me");
+    const log = await readFile(fixture.logPath, "utf8");
+    expect(log).toContain(`reopen intent resolved from legacy helper pid ${helperPid}: 1`);
+    expect(log).toContain("data restore verified by child installer");
+    await waitForPathAbsent(fixture.workDir);
+  });
+
+  it("waits for the installer itself without waiting for its long-lived descendant", async () => {
+    const fixture = await createRelayFixture(0, { spawnLongLivedDescendant: true });
+    const startedAt = Date.now();
+
+    await runRelay(fixture);
+
+    expect(Date.now() - startedAt).toBeLessThan(10_000);
+    await waitForPathPresent(fixture.descendantPidPath);
+    expect(existsSync(fixture.descendantPidPath)).toBe(true);
+    descendantProcessIds.push(Number.parseInt((await readFile(fixture.descendantPidPath, "utf8")).trim(), 10));
+    await waitForPathAbsent(fixture.workDir);
+  });
+});


### PR DESCRIPTION
## Summary

- Relay legacy Windows in-app installers outside the install-local data directory so the 1.0.8 updater can uninstall the old application.
- Preserve install-local data, the update launch gate, and manual versus silent restart behavior while the relay owns the upgrade.
- Infer the auth channel for unmarked legacy sessions so a valid 1.0.8 INTL login survives the application update.
- Keep mock update server files and documentation out of the change.

## Verification

- Backend account/session tests: 20 passed.
- Windows upgrade relay tests: 4 passed.
- Packaged runtime boundary regression: 1 passed.
- Desktop typecheck passed.
- Backend lint passed.
- Windows package flows manually verified for 1.0.8 to 1.0.10 and 1.0.9 to 1.0.10, both manual and silent updates.

## Scope

Normal double-click overwrite installs and downgrade reinstalls are unchanged by this PR.