### PR TITLE
fix(updater): harden Windows upgrade recovery

### DIFF
--- a/App/shell/desktop/build/MemmyWindowsUpgradeCleanup.ps1
+++ b/App/shell/desktop/build/MemmyWindowsUpgradeCleanup.ps1
@@ -1,6 +1,14 @@
 param(
-  [Parameter(Mandatory = $true)][string]$WorkDir
+  [Parameter(Mandatory = $true)][string]$WorkDir,
+  [string]$BackupRoot = ''
 )
 
 Start-Sleep -Seconds 3
 Remove-Item -LiteralPath $WorkDir -Recurse -Force -ErrorAction SilentlyContinue
+if ($BackupRoot) {
+  $backupParent = Split-Path -Parent $BackupRoot
+  if ((Split-Path -Leaf $backupParent).EndsWith('.memmy-upgrade-backup', [System.StringComparison]::OrdinalIgnoreCase)) {
+    Remove-Item -LiteralPath $BackupRoot -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -LiteralPath $backupParent -Force -ErrorAction SilentlyContinue
+  }
+}

--- a/App/shell/desktop/build/MemmyWindowsUpgradeRecovery.ps1
+++ b/App/shell/desktop/build/MemmyWindowsUpgradeRecovery.ps1
@@ -1,0 +1,200 @@
+param(
+  [Parameter(Mandatory = $true)][string]$InstallDir,
+  [Parameter(Mandatory = $true)][string]$LockPath,
+  [Parameter(Mandatory = $true)][string]$LogPath
+)
+
+$ErrorActionPreference = 'Stop'
+$normalizedInstallDir = [System.IO.Path]::GetFullPath($InstallDir).TrimEnd('\')
+$dataPath = Join-Path $normalizedInstallDir 'data'
+$expectedBackupParent = "$normalizedInstallDir.memmy-upgrade-backup"
+$normalizedLockPath = [System.IO.Path]::GetFullPath($LockPath).TrimEnd('\')
+$expectedStagingRoot = Split-Path -Parent $normalizedLockPath
+$statePath = Join-Path $LockPath 'state.json'
+
+function Write-MemmyUpgradeRecoveryLog([string]$Message) {
+  $logDirectory = Split-Path -Parent $LogPath
+  if ($logDirectory) {
+    New-Item -ItemType Directory -Force -Path $logDirectory | Out-Null
+  }
+  Add-Content -LiteralPath $LogPath -Value ('[{0:O}] recovery: {1}' -f (Get-Date), $Message)
+}
+
+function Resolve-MemmyNormalizedPath([string]$Path) {
+  return [System.IO.Path]::GetFullPath($Path).TrimEnd('\')
+}
+
+function Test-MemmyUpgradeProcessRunning($ProcessId, $StartedAtUtc, [string]$ExpectedPath = '') {
+  $parsedProcessId = 0
+  if (-not [int]::TryParse([string]$ProcessId, [ref]$parsedProcessId) -or $parsedProcessId -le 0) {
+    return $false
+  }
+  $process = Get-Process -Id $parsedProcessId -ErrorAction SilentlyContinue
+  if ($null -eq $process) {
+    return $false
+  }
+  try {
+    if ($ExpectedPath) {
+      $actualPath = Resolve-MemmyNormalizedPath $process.Path
+      $normalizedExpectedPath = Resolve-MemmyNormalizedPath $ExpectedPath
+      if (-not [string]::Equals($actualPath, $normalizedExpectedPath, [System.StringComparison]::OrdinalIgnoreCase)) {
+        return $false
+      }
+    }
+    if (-not $StartedAtUtc) {
+      return $true
+    }
+    $expectedStart = [DateTime]::Parse([string]$StartedAtUtc).ToUniversalTime()
+    $actualStart = $process.StartTime.ToUniversalTime()
+    return [Math]::Abs(($actualStart - $expectedStart).TotalSeconds) -lt 5
+  } catch {
+    return $true
+  }
+}
+
+function Test-MemmyInstallerPathRunning([string]$InstallerPath) {
+  if (-not $InstallerPath) {
+    return $false
+  }
+  $normalizedExpectedPath = Resolve-MemmyNormalizedPath $InstallerPath
+  try {
+    $processes = @(Get-CimInstance -ClassName Win32_Process -ErrorAction Stop)
+  } catch {
+    Write-MemmyUpgradeRecoveryLog "unable to enumerate installer processes; leaving recovery locked: $($_.Exception.Message)"
+    return $true
+  }
+  foreach ($process in $processes) {
+    if (-not $process.ExecutablePath) {
+      continue
+    }
+    try {
+      $actualPath = Resolve-MemmyNormalizedPath ([string]$process.ExecutablePath)
+      if ([string]::Equals($actualPath, $normalizedExpectedPath, [System.StringComparison]::OrdinalIgnoreCase)) {
+        return $true
+      }
+    } catch {
+      continue
+    }
+  }
+  return $false
+}
+
+function Assert-MemmySameVolume([string]$Source, [string]$Destination) {
+  $sourceRoot = [System.IO.Path]::GetPathRoot((Resolve-MemmyNormalizedPath $Source))
+  $destinationRoot = [System.IO.Path]::GetPathRoot((Resolve-MemmyNormalizedPath $Destination))
+  if (-not [string]::Equals($sourceRoot, $destinationRoot, [System.StringComparison]::OrdinalIgnoreCase)) {
+    throw "refusing cross-volume directory move: $Source -> $Destination"
+  }
+}
+
+function Move-MemmyRecoveryDirectory([string]$Source, [string]$Destination) {
+  Assert-MemmySameVolume -Source $Source -Destination $Destination
+  New-Item -ItemType Directory -Force -Path (Split-Path -Parent $Destination) | Out-Null
+  for ($attempt = 1; $attempt -le 120; $attempt++) {
+    try {
+      [System.IO.Directory]::Move($Source, $Destination)
+      return
+    } catch {
+      if ($attempt -eq 120) {
+        throw
+      }
+      Start-Sleep -Milliseconds 500
+    }
+  }
+}
+
+function Clear-MemmyRecoveryTransientMarkers {
+  $markerPath = Join-Path $dataPath 'Memmy\prepared-required-update.json'
+  foreach ($path in @("$markerPath.lock", "$markerPath.prompt")) {
+    Remove-Item -LiteralPath $path -Recurse -Force -ErrorAction SilentlyContinue
+  }
+  Write-MemmyUpgradeRecoveryLog "cleared transient prepared-update lock and prompt markers"
+}
+
+if (-not (Test-Path -LiteralPath $LockPath -PathType Container)) {
+  exit 0
+}
+
+try {
+  if (-not (Test-Path -LiteralPath $statePath -PathType Leaf)) {
+    $lockAge = (Get-Date) - (Get-Item -LiteralPath $LockPath).LastWriteTime
+    if ($lockAge.TotalMinutes -lt 2 -or -not (Test-Path -LiteralPath $dataPath -PathType Container)) {
+      Write-MemmyUpgradeRecoveryLog "active lock has no recovery state; leaving it in place"
+      exit 2
+    }
+    Clear-MemmyRecoveryTransientMarkers
+    Remove-Item -LiteralPath $LockPath -Recurse -Force
+    Write-MemmyUpgradeRecoveryLog "cleared stale state-less lock because installed data is present"
+    exit 0
+  }
+
+  $state = Get-Content -LiteralPath $statePath -Raw | ConvertFrom-Json
+  $phase = [string]$state.phase
+  if (@('relay-ready', 'data-moved', 'installer-starting', 'installer-running', 'installer-exited') -notcontains $phase) {
+    throw "recovery state has an unsupported phase: $phase"
+  }
+  $stateInstallDir = Resolve-MemmyNormalizedPath ([string]$state.installDir)
+  $stateWorkDir = Resolve-MemmyNormalizedPath ([string]$state.workDir)
+  $stateInstallerPath = Resolve-MemmyNormalizedPath ([string]$state.installerPath)
+  $backupRoot = Resolve-MemmyNormalizedPath ([string]$state.backupRoot)
+  if (-not [string]::Equals($stateInstallDir, $normalizedInstallDir, [System.StringComparison]::OrdinalIgnoreCase)) {
+    throw "recovery state install directory does not match launcher install directory"
+  }
+  if (-not [string]::Equals((Split-Path -Parent $stateWorkDir), $expectedStagingRoot, [System.StringComparison]::OrdinalIgnoreCase)) {
+    throw "recovery state work directory is outside the expected staging directory"
+  }
+  $workLeaf = Split-Path -Leaf $stateWorkDir
+  if (-not $workLeaf -or [string]::Equals($workLeaf, 'active.lock', [System.StringComparison]::OrdinalIgnoreCase)) {
+    throw "recovery state work directory has an invalid leaf"
+  }
+  if (-not [string]::Equals((Split-Path -Parent $stateInstallerPath), $stateWorkDir, [System.StringComparison]::OrdinalIgnoreCase)) {
+    throw "recovery state installer path is outside its work directory"
+  }
+  $expectedBackupRoot = Resolve-MemmyNormalizedPath (Join-Path $expectedBackupParent $workLeaf)
+  if (-not [string]::Equals($backupRoot, $expectedBackupRoot, [System.StringComparison]::OrdinalIgnoreCase)) {
+    throw "recovery state backup root does not match the expected install-local sibling"
+  }
+  if ((Test-MemmyUpgradeProcessRunning $state.relayPid $state.relayStartedAtUtc) -or
+      (Test-MemmyUpgradeProcessRunning $state.installerPid $state.installerStartedAtUtc $stateInstallerPath) -or
+      ($phase -eq 'installer-starting' -and (Test-MemmyInstallerPathRunning $stateInstallerPath))) {
+    Write-MemmyUpgradeRecoveryLog "upgrade process is still running; leaving active lock in place"
+    exit 2
+  }
+
+  $backupPath = Join-Path $backupRoot 'data-backup'
+  $installerDataPath = Join-Path $backupRoot 'installer-created-data'
+  if (Test-Path -LiteralPath $backupPath -PathType Container) {
+    if (Test-Path -LiteralPath $dataPath) {
+      if (Test-Path -LiteralPath $installerDataPath) {
+        throw "installer-created data backup already exists: $installerDataPath"
+      }
+      Move-MemmyRecoveryDirectory -Source $dataPath -Destination $installerDataPath
+      Write-MemmyUpgradeRecoveryLog "preserved installer-created data at $installerDataPath"
+    }
+    Move-MemmyRecoveryDirectory -Source $backupPath -Destination $dataPath
+    if (-not (Test-Path -LiteralPath $dataPath -PathType Container)) {
+      throw "restored data directory is unavailable: $dataPath"
+    }
+    Write-MemmyUpgradeRecoveryLog "stale upgrade data restored from $backupPath"
+  } elseif (Test-Path -LiteralPath $dataPath -PathType Container) {
+    Write-MemmyUpgradeRecoveryLog "stale upgrade already has installed data; clearing lock"
+  } else {
+    throw "both installed data and upgrade backup are missing"
+  }
+
+  Clear-MemmyRecoveryTransientMarkers
+  Remove-Item -LiteralPath $LockPath -Recurse -Force
+  Write-MemmyUpgradeRecoveryLog "stale active lock cleared"
+  if (Test-Path -LiteralPath $stateWorkDir -PathType Container) {
+    try {
+      Remove-Item -LiteralPath $stateWorkDir -Recurse -Force -ErrorAction Stop
+      Write-MemmyUpgradeRecoveryLog "stale staging work directory removed: $stateWorkDir"
+    } catch {
+      Write-MemmyUpgradeRecoveryLog "unable to remove stale staging work directory ${stateWorkDir}: $($_.Exception.Message)"
+    }
+  }
+  exit 0
+} catch {
+  Write-MemmyUpgradeRecoveryLog ('automatic recovery failed: ' + ($_ | Out-String))
+  exit 3
+}

--- a/App/shell/desktop/build/MemmyWindowsUpgradeRelay.ps1
+++ b/App/shell/desktop/build/MemmyWindowsUpgradeRelay.ps1
@@ -11,16 +11,25 @@ param(
 )
 
 $ErrorActionPreference = 'Stop'
-$dataPath = Join-Path $InstallDir 'data'
-$backupPath = Join-Path $WorkDir 'data-backup'
+$normalizedInstallDir = [System.IO.Path]::GetFullPath($InstallDir).TrimEnd('\')
+$dataPath = Join-Path $normalizedInstallDir 'data'
+$backupParent = "$normalizedInstallDir.memmy-upgrade-backup"
+$backupRoot = Join-Path $backupParent (Split-Path -Leaf $WorkDir)
+$backupPath = Join-Path $backupRoot 'data-backup'
+$installerDataPath = Join-Path $backupRoot 'installer-created-data'
 $stagingRoot = Split-Path -Parent $WorkDir
 $lockPath = Join-Path $stagingRoot 'active.lock'
-$appExe = Join-Path $InstallDir 'Memmy.exe'
+$lockStatePath = Join-Path $stagingRoot 'active.lock\state.json'
+$appExe = Join-Path $normalizedInstallDir 'Memmy.exe'
+$normalizedInstallerPath = [System.IO.Path]::GetFullPath($InstallerPath)
 $installerExit = 1
+$installerProcess = $null
 $dataMoved = $false
 $dataRestored = $false
 $lockAcquired = $false
+$relayPhase = 'relay-ready'
 $resolvedReopenAfterInstall = $ReopenAfterInstall
+$relayStartedAtUtc = (Get-Process -Id $PID -ErrorAction Stop).StartTime.ToUniversalTime().ToString('O')
 
 function Write-MemmyUpgradeLog([string]$Message) {
   $logDirectory = Split-Path -Parent $LogPath
@@ -62,7 +71,16 @@ function Wait-MemmyProcessExit([int]$ProcessId, [int]$TimeoutSeconds) {
   }
 }
 
+function Assert-MemmySameVolume([string]$Source, [string]$Destination) {
+  $sourceRoot = [System.IO.Path]::GetPathRoot([System.IO.Path]::GetFullPath($Source))
+  $destinationRoot = [System.IO.Path]::GetPathRoot([System.IO.Path]::GetFullPath($Destination))
+  if (-not [string]::Equals($sourceRoot, $destinationRoot, [System.StringComparison]::OrdinalIgnoreCase)) {
+    throw "refusing cross-volume directory move: $Source -> $Destination"
+  }
+}
+
 function Move-MemmyDirectory([string]$Source, [string]$Destination) {
+  Assert-MemmySameVolume -Source $Source -Destination $Destination
   New-Item -ItemType Directory -Force -Path (Split-Path -Parent $Destination) | Out-Null
   for ($attempt = 1; $attempt -le 120; $attempt++) {
     try {
@@ -75,6 +93,35 @@ function Move-MemmyDirectory([string]$Source, [string]$Destination) {
       Start-Sleep -Milliseconds 500
     }
   }
+}
+
+function Write-MemmyRelayState {
+  $installerPid = $null
+  $installerStartedAtUtc = $null
+  if ($null -ne $installerProcess) {
+    $installerPid = $installerProcess.Id
+    try {
+      $installerStartedAtUtc = $installerProcess.StartTime.ToUniversalTime().ToString('O')
+    } catch {
+      $installerStartedAtUtc = $null
+    }
+  }
+  $state = [ordered]@{
+    schemaVersion = 2
+    phase = $relayPhase
+    stateUpdatedAtUtc = [DateTime]::UtcNow.ToString('O')
+    relayPid = $PID
+    relayStartedAtUtc = $relayStartedAtUtc
+    installerPid = $installerPid
+    installerStartedAtUtc = $installerStartedAtUtc
+    installerPath = $normalizedInstallerPath
+    installDir = $normalizedInstallDir
+    workDir = [System.IO.Path]::GetFullPath($WorkDir).TrimEnd('\')
+    backupRoot = $backupRoot
+  }
+  $temporaryStatePath = "$lockStatePath.tmp"
+  [System.IO.File]::WriteAllText($temporaryStatePath, ($state | ConvertTo-Json -Compress))
+  Move-Item -LiteralPath $temporaryStatePath -Destination $lockStatePath -Force
 }
 
 function Restore-MemmyData {
@@ -91,7 +138,6 @@ function Restore-MemmyData {
     throw "data backup is missing: $backupPath"
   }
   if (Test-Path -LiteralPath $dataPath) {
-    $installerDataPath = Join-Path $WorkDir 'installer-created-data'
     if (Test-Path -LiteralPath $installerDataPath) {
       throw "installer-created data backup already exists: $installerDataPath"
     }
@@ -169,7 +215,7 @@ function Schedule-MemmyStagingCleanup {
     return
   }
   $powershellPath = Join-Path $PSHOME 'powershell.exe'
-  $cleanupArguments = "-NoProfile -NonInteractive -ExecutionPolicy Bypass -WindowStyle Hidden -File `"$cleanupScriptPath`" -WorkDir `"$WorkDir`""
+  $cleanupArguments = "-NoProfile -NonInteractive -ExecutionPolicy Bypass -WindowStyle Hidden -File `"$cleanupScriptPath`" -WorkDir `"$WorkDir`" -BackupRoot `"$backupRoot`""
   Start-Process -FilePath $powershellPath -ArgumentList $cleanupArguments -WorkingDirectory $stagingRoot -WindowStyle Hidden
 }
 
@@ -180,23 +226,29 @@ try {
   $resolvedReopenAfterInstall = Resolve-MemmyLegacyHelperReopenIntent -HelperPid $LegacyHelperPid -MarkerPath $markerPath -Fallback $ReopenAfterInstall
   New-Item -ItemType Directory -Path $lockPath -ErrorAction Stop | Out-Null
   $lockAcquired = $true
+  Write-MemmyRelayState
   [System.IO.File]::WriteAllText($ReadyPath, $resolvedReopenAfterInstall)
   Write-MemmyUpgradeLog "relay ready reopen=$resolvedReopenAfterInstall"
   Wait-MemmyProcessExit -ProcessId $OriginalInstallerPid -TimeoutSeconds 120
 
   if (Test-Path -LiteralPath $dataPath -PathType Container) {
-    if (Test-Path -LiteralPath $backupPath) {
-      throw "refusing to overwrite existing data backup: $backupPath"
+    if (Test-Path -LiteralPath $backupRoot) {
+      throw "refusing to overwrite existing upgrade backup root: $backupRoot"
     }
     Move-MemmyDirectory -Source $dataPath -Destination $backupPath
     $dataMoved = $true
+    $relayPhase = 'data-moved'
+    Write-MemmyRelayState
     Write-MemmyUpgradeLog "data moved to $backupPath"
   }
 
   $arguments = @('/S', '--updated', '--memmy-upgrade-relayed', '/currentuser', ('/D=' + $InstallDir))
   $env:MEMMY_UPGRADE_WORK_DIR = $WorkDir
+  $env:MEMMY_UPGRADE_BACKUP_ROOT = $backupRoot
   $env:MEMMY_UPGRADE_REOPEN_AFTER_INSTALL = $resolvedReopenAfterInstall
-  Write-MemmyUpgradeLog "child installer context workDir=$env:MEMMY_UPGRADE_WORK_DIR reopen=$env:MEMMY_UPGRADE_REOPEN_AFTER_INSTALL"
+  Write-MemmyUpgradeLog "child installer context workDir=$env:MEMMY_UPGRADE_WORK_DIR backupRoot=$env:MEMMY_UPGRADE_BACKUP_ROOT reopen=$env:MEMMY_UPGRADE_REOPEN_AFTER_INSTALL"
+  $relayPhase = 'installer-starting'
+  Write-MemmyRelayState
   $installerProcess = Start-Process -FilePath $InstallerPath -ArgumentList $arguments -PassThru -WindowStyle Hidden
   $installerProcess.WaitForExit()
   $installerExit = if ($null -eq $installerProcess.ExitCode) { 1 } else { $installerProcess.ExitCode }
@@ -213,8 +265,10 @@ try {
     Write-MemmyUpgradeLog ('data restore failed: ' + ($_ | Out-String))
     $dataRestored = $false
   }
-  if ($lockAcquired) {
+  if ($lockAcquired -and $dataRestored) {
     Remove-Item -LiteralPath $lockPath -Recurse -Force -ErrorAction SilentlyContinue
+  } elseif ($lockAcquired) {
+    Write-MemmyUpgradeLog "active lock retained for automatic recovery $lockPath"
   }
 }
 

--- a/App/shell/desktop/build/installer-win-unsigned.nsh
+++ b/App/shell/desktop/build/installer-win-unsigned.nsh
@@ -24,6 +24,7 @@
 !ifndef BUILD_UNINSTALLER
   Var MemmyIsRelayedUpgrade
   Var MemmyUpgradeWorkDir
+  Var MemmyUpgradeBackupRoot
   Var MemmyUpgradeReopenAfterInstall
 
   ; The 1.0.8 updater starts the downloaded installer from $INSTDIR\data. electron-builder's
@@ -104,6 +105,9 @@ Function MemmyRelayLegacyUpgrade
     IfFileExists "$R1\MemmyWindowsUpgradeCleanup.ps1" 0 memmy_relay_failed
 
     ClearErrors
+    FileOpen $0 "$R4" w
+    IfErrors memmy_relay_failed
+    FileClose $0
     CopyFiles /SILENT "$EXEPATH" "$R4"
     IfErrors memmy_relay_failed
     IfFileExists "$R4" 0 memmy_relay_failed
@@ -138,12 +142,18 @@ FunctionEnd
 Function MemmyReadRelayedUpgradeContext
   StrCpy $MemmyIsRelayedUpgrade "0"
   ReadEnvStr $MemmyUpgradeWorkDir "MEMMY_UPGRADE_WORK_DIR"
+  ReadEnvStr $MemmyUpgradeBackupRoot "MEMMY_UPGRADE_BACKUP_ROOT"
   ReadEnvStr $MemmyUpgradeReopenAfterInstall "MEMMY_UPGRADE_REOPEN_AFTER_INSTALL"
   StrCmp $MemmyUpgradeWorkDir "" memmy_relay_context_failed
+  StrCmp $MemmyUpgradeBackupRoot "" memmy_relay_context_failed
   StrCmp $MemmyUpgradeReopenAfterInstall "0" memmy_relay_context_validate_path
   StrCmp $MemmyUpgradeReopenAfterInstall "1" memmy_relay_context_validate_path memmy_relay_context_failed
 
   memmy_relay_context_validate_path:
+    GetFullPathName $4 "$MemmyUpgradeWorkDir"
+    StrCmp $4 $MemmyUpgradeWorkDir 0 memmy_relay_context_failed
+    GetFullPathName $5 "$MemmyUpgradeBackupRoot"
+    StrCmp $5 $MemmyUpgradeBackupRoot 0 memmy_relay_context_failed
     StrCpy $0 "$LOCALAPPDATA\Memmy\upgrade-staging\"
     StrLen $1 $0
     StrLen $2 $MemmyUpgradeWorkDir
@@ -152,6 +162,12 @@ Function MemmyReadRelayedUpgradeContext
   memmy_relay_context_compare_path:
     StrCpy $3 $MemmyUpgradeWorkDir $1
     StrCmp $3 $0 0 memmy_relay_context_failed
+    StrCpy $4 $MemmyUpgradeWorkDir "" $1
+    StrCmp $4 "" memmy_relay_context_failed
+    ${GetFileName} "$MemmyUpgradeWorkDir" $5
+    StrCmp $4 $5 0 memmy_relay_context_failed
+    StrCpy $0 "$INSTDIR.memmy-upgrade-backup\$4"
+    StrCmp $MemmyUpgradeBackupRoot $0 0 memmy_relay_context_failed
     StrCpy $MemmyIsRelayedUpgrade "1"
     Return
 
@@ -162,9 +178,9 @@ FunctionEnd
 
 Function MemmyRestoreRelayedUpgradeData
   StrCmp $MemmyIsRelayedUpgrade "1" 0 memmy_restore_relayed_data_done
-  StrCpy $0 "$MemmyUpgradeWorkDir\data-backup"
+  StrCpy $0 "$MemmyUpgradeBackupRoot\data-backup"
   StrCpy $1 "$INSTDIR\data"
-  StrCpy $2 "$MemmyUpgradeWorkDir\installer-created-data"
+  StrCpy $2 "$MemmyUpgradeBackupRoot\installer-created-data"
   IfFileExists "$0\*" 0 memmy_restore_relayed_data_failed
   IfFileExists "$2\*" memmy_restore_relayed_data_failed
   IfFileExists "$1\*" 0 memmy_restore_relayed_data_backup
@@ -211,7 +227,7 @@ Function MemmyScheduleRelayedUpgradeCleanup
   StrCpy $1 "$SYSDIR\WindowsPowerShell\v1.0\powershell.exe"
   IfFileExists "$0" 0 memmy_schedule_relayed_cleanup_done
   IfFileExists "$1" 0 memmy_schedule_relayed_cleanup_done
-  ExecShell "open" "$1" '-NoProfile -NonInteractive -ExecutionPolicy Bypass -WindowStyle Hidden -File $\"$0$\" -WorkDir $\"$MemmyUpgradeWorkDir$\"' SW_HIDE
+  ExecShell "open" "$1" '-NoProfile -NonInteractive -ExecutionPolicy Bypass -WindowStyle Hidden -File $\"$0$\" -WorkDir $\"$MemmyUpgradeWorkDir$\" -BackupRoot $\"$MemmyUpgradeBackupRoot$\"' SW_HIDE
 
   memmy_schedule_relayed_cleanup_done:
 FunctionEnd
@@ -274,6 +290,7 @@ Function MemmyInstallLaunchProxy
   SetOutPath "$0"
   File /oname=Memmy.ico "${BUILD_RESOURCES_DIR}\icon.ico"
   File /oname=MemmyUpdatePrompt.ps1 "${BUILD_RESOURCES_DIR}\MemmyUpdatePrompt.ps1"
+  File /oname=MemmyWindowsUpgradeRecovery.ps1 "${BUILD_RESOURCES_DIR}\MemmyWindowsUpgradeRecovery.ps1"
 
   FileOpen $1 "$0\MemmyLauncher.vbs" w
   FileWrite $1 "Set shell = CreateObject($\"WScript.Shell$\")$\r$\n"
@@ -282,10 +299,15 @@ Function MemmyInstallLaunchProxy
   FileWrite $1 "dataRoot = $\"$INSTDIR\data$\"$\r$\n"
   FileWrite $1 "powerShellPath = shell.ExpandEnvironmentStrings($\"%SystemRoot%$\") & $\"\System32\WindowsPowerShell\v1.0\powershell.exe$\"$\r$\n"
   FileWrite $1 "promptPath = $\"$0\MemmyUpdatePrompt.ps1$\"$\r$\n"
+  FileWrite $1 "recoveryPath = $\"$0\MemmyWindowsUpgradeRecovery.ps1$\"$\r$\n"
+  FileWrite $1 "upgradeLogPath = shell.ExpandEnvironmentStrings($\"%LOCALAPPDATA%$\") & $\"\Memmy\upgrade-logs\windows-upgrade.log$\"$\r$\n"
   FileWrite $1 "languagePath = dataRoot & $\"\Memmy\update-prompt-language.txt$\"$\r$\n"
   FileWrite $1 "markerPath = dataRoot & $\"\Memmy\prepared-required-update.json$\"$\r$\n"
   FileWrite $1 "lockPath = markerPath & $\".lock$\"$\r$\n"
   FileWrite $1 "relayLockPath = shell.ExpandEnvironmentStrings($\"%LOCALAPPDATA%$\") & $\"\Memmy\upgrade-staging\active.lock$\"$\r$\n"
+  FileWrite $1 "If fso.FolderExists(relayLockPath) And fso.FileExists(recoveryPath) Then$\r$\n"
+  FileWrite $1 "  shell.Run Chr(34) & powerShellPath & Chr(34) & $\" -NoProfile -NonInteractive -ExecutionPolicy Bypass -WindowStyle Hidden -File $\" & Chr(34) & recoveryPath & Chr(34) & $\" -InstallDir $\" & Chr(34) & fso.GetParentFolderName(appExe) & Chr(34) & $\" -LockPath $\" & Chr(34) & relayLockPath & Chr(34) & $\" -LogPath $\" & Chr(34) & upgradeLogPath & Chr(34), 0, True$\r$\n"
+  FileWrite $1 "End If$\r$\n"
   FileWrite $1 "If fso.FolderExists(relayLockPath) Then$\r$\n"
   FileWrite $1 "  lockPath = relayLockPath$\r$\n"
   FileWrite $1 "End If$\r$\n"

--- a/App/shell/desktop/tests/packaged-runtime-boundary.test.ts
+++ b/App/shell/desktop/tests/packaged-runtime-boundary.test.ts
@@ -33,6 +33,7 @@ const packageWinX64Path = fileURLToPath(new URL("../../../../scripts/internal/wi
 const winUnsignedBuilderPath = fileURLToPath(new URL("../electron-builder.win.unsigned.yml", import.meta.url));
 const winUnsignedInstallerIncludePath = fileURLToPath(new URL("../build/installer-win-unsigned.nsh", import.meta.url));
 const winUpgradeRelayScriptPath = fileURLToPath(new URL("../build/MemmyWindowsUpgradeRelay.ps1", import.meta.url));
+const winUpgradeRecoveryScriptPath = fileURLToPath(new URL("../build/MemmyWindowsUpgradeRecovery.ps1", import.meta.url));
 const desktopInterfacePath = fileURLToPath(new URL("../interface/src/index.ts", import.meta.url));
 const localApiContractsPath = fileURLToPath(new URL("../../../../App/backend/local-api-contracts/src/index.ts", import.meta.url));
 const rootPackagePath = fileURLToPath(new URL("../../../../package.json", import.meta.url));
@@ -552,6 +553,7 @@ describe("desktop packaged runtime boundaries", () => {
     const unsignedBuilderConfig = readFileSync(winUnsignedBuilderPath, "utf8");
     const includeSource = readFileSync(winUnsignedInstallerIncludePath, "utf8");
     const relaySource = readFileSync(winUpgradeRelayScriptPath, "utf8");
+    const recoverySource = readFileSync(winUpgradeRecoveryScriptPath, "utf8");
     const mainSource = readFileSync(mainSourcePath, "utf8");
 
     expect(signedBuilderConfig).toContain("include: build/installer-win-unsigned.nsh");
@@ -559,6 +561,7 @@ describe("desktop packaged runtime boundaries", () => {
     expect(includeSource).toContain("!macro customInit");
     expect(includeSource).toContain("--memmy-upgrade-relayed");
     expect(includeSource).toContain("MemmyWindowsUpgradeRelay.ps1");
+    expect(includeSource).toContain("MemmyWindowsUpgradeRecovery.ps1");
     expect(includeSource).toContain('$LOCALAPPDATA\\Memmy\\upgrade-staging');
     expect(includeSource).toContain("GetCurrentProcessId");
     expect(includeSource).toContain('upgrade-staging\\$2');
@@ -574,12 +577,18 @@ describe("desktop packaged runtime boundaries", () => {
     expect(includeSource).toContain("relay-ready");
     expect(includeSource).toContain("ReadyPath");
     expect(includeSource).toContain("MemmyWindowsUpgradeCleanup.ps1");
+    expect(includeSource).toContain('FileOpen $0 "$R4" w');
+    expect(includeSource.indexOf('FileOpen $0 "$R4" w')).toBeLessThan(includeSource.indexOf('CopyFiles /SILENT "$EXEPATH" "$R4"'));
     expect(includeSource).toContain('ExecShell "open" "$R5"');
     expect(includeSource).toContain('ExecShell "open" "$1"');
     expect(includeSource.match(/ExecShell "open" .* SW_HIDE/g)).toHaveLength(2);
     expect(includeSource).not.toContain('Exec \'$\\\"$R5$\\\"');
     expect(includeSource).toContain('Exec \'$\\\"$INSTDIR\\${PRODUCT_FILENAME}.exe$\\\" --updated\'');
     expect(includeSource).toContain('$LOCALAPPDATA\\Memmy\\upgrade-staging\\active.lock');
+    expect(includeSource).toContain('GetFullPathName $4 "$MemmyUpgradeWorkDir"');
+    expect(includeSource).toContain('GetFullPathName $5 "$MemmyUpgradeBackupRoot"');
+    expect(includeSource).toContain('${GetFileName} "$MemmyUpgradeWorkDir" $5');
+    expect(includeSource).toContain('StrCpy $0 "$INSTDIR.memmy-upgrade-backup\\$4"');
     const relayInitIndex = includeSource.indexOf("Function MemmyRelayLegacyUpgrade");
     const earlyLaunchProxyIndex = includeSource.indexOf("Call MemmyInstallLaunchProxy", relayInitIndex);
     const relayStartIndex = includeSource.indexOf('ExecShell "open" "$R5"', relayInitIndex);
@@ -587,18 +596,26 @@ describe("desktop packaged runtime boundaries", () => {
     expect(earlyLaunchProxyIndex).toBeLessThan(relayStartIndex);
     expect(includeSource).toContain("SetErrorLevel");
     expect(relaySource).toContain("Move-MemmyDirectory");
+    expect(relaySource).toContain("Assert-MemmySameVolume");
+    expect(relaySource).toContain(".memmy-upgrade-backup");
+    expect(relaySource).toContain("active.lock\\state.json");
     expect(relaySource).toContain("Restore-MemmyData");
     expect(relaySource).toContain("Resolve-MemmyLegacyHelperReopenIntent");
     expect(relaySource).toContain("MEMMY_UPGRADE_WORK_DIR");
     expect(relaySource).toContain("MEMMY_UPGRADE_REOPEN_AFTER_INSTALL");
     expect(relaySource).toContain("$installerProcess.WaitForExit()");
     expect(relaySource).not.toContain("-Wait -PassThru");
+    expect(relaySource.indexOf("Write-MemmyRelayState", relaySource.indexOf("$installerProcess = Start-Process"))).toBe(-1);
     expect(relaySource).toContain("MemmyWindowsUpgradeCleanup.ps1");
     expect(relaySource).not.toContain("cmd.exe");
     expect(relaySource).not.toContain("$env:ComSpec");
     expect(relaySource).not.toContain("ping.exe");
     expect(relaySource).toContain("--memmy-upgrade-relayed");
     expect(relaySource).toContain("upgrade verified");
+    expect(recoverySource).toContain("Test-MemmyUpgradeProcessRunning");
+    expect(recoverySource).toContain("data-backup");
+    expect(recoverySource).toContain("installer-created-data");
+    expect(recoverySource).toContain("Remove-Item -LiteralPath $LockPath");
     expect(mainSource).toContain('spawn("/bin/zsh", [helperPath, filePath, destinationAppPath, logPath, String(process.pid), options.openAfterInstall ? "1" : "0"');
   });
 
@@ -637,12 +654,15 @@ describe("desktop packaged runtime boundaries", () => {
     expect(includeSource).toContain('StrCpy $0 "$LOCALAPPDATA\\Memmy\\launcher"');
     expect(includeSource).toContain('File /oname=Memmy.ico "${BUILD_RESOURCES_DIR}\\icon.ico"');
     expect(includeSource).toContain('File /oname=MemmyUpdatePrompt.ps1 "${BUILD_RESOURCES_DIR}\\MemmyUpdatePrompt.ps1"');
+    expect(includeSource).toContain('File /oname=MemmyWindowsUpgradeRecovery.ps1 "${BUILD_RESOURCES_DIR}\\MemmyWindowsUpgradeRecovery.ps1"');
     expect(includeSource).toContain('FileOpen $1 "$0\\MemmyLauncher.vbs" w');
     expect(includeSource).toContain('promptPath = $\\"$0\\MemmyUpdatePrompt.ps1$\\"');
     expect(includeSource).toContain('dataRoot = $\\"$INSTDIR\\data$\\"');
     expect(includeSource).toContain('languagePath = dataRoot & $\\"\\Memmy\\update-prompt-language.txt$\\"');
     expect(includeSource).toContain('markerPath = dataRoot & $\\"\\Memmy\\prepared-required-update.json$\\"');
     expect(includeSource).toContain('relayLockPath = shell.ExpandEnvironmentStrings($\\"%LOCALAPPDATA%$\\") & $\\"\\Memmy\\upgrade-staging\\active.lock$\\"');
+    expect(includeSource).toContain('recoveryPath = $\\"$0\\MemmyWindowsUpgradeRecovery.ps1$\\"');
+    expect(includeSource).toContain("If fso.FolderExists(relayLockPath) And fso.FileExists(recoveryPath) Then");
     expect(includeSource).toContain("If fso.FolderExists(relayLockPath) Then");
     expect(includeSource).toContain("lockPath = relayLockPath");
     expect(includeSource).toContain("WindowsPowerShell\\v1.0\\powershell.exe");

--- a/App/shell/desktop/tests/windows-upgrade-relay.test.ts
+++ b/App/shell/desktop/tests/windows-upgrade-relay.test.ts
@@ -1,14 +1,15 @@
 import { execFile as execFileCallback, spawn, type ChildProcess } from "node:child_process";
 import { existsSync } from "node:fs";
-import { copyFile, mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { copyFile, mkdtemp, mkdir, readFile, rename, rm, utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { dirname, join, resolve } from "node:path";
+import { basename, dirname, join, resolve } from "node:path";
 import { promisify } from "node:util";
 import { afterEach, describe, expect, it } from "vitest";
 
 const execFile = promisify(execFileCallback);
 const relayScriptPath = resolve(import.meta.dirname, "../build/MemmyWindowsUpgradeRelay.ps1");
 const cleanupScriptPath = resolve(import.meta.dirname, "../build/MemmyWindowsUpgradeCleanup.ps1");
+const recoveryScriptPath = resolve(import.meta.dirname, "../build/MemmyWindowsUpgradeRecovery.ps1");
 const temporaryDirectories: string[] = [];
 const helperProcesses: ChildProcess[] = [];
 const descendantProcessIds: number[] = [];
@@ -16,7 +17,7 @@ const describeOnWindows = process.platform === "win32" ? describe : describe.ski
 
 afterEach(async () => {
   await Promise.all(helperProcesses.splice(0).map(async (process) => {
-    if (process.exitCode !== null) return;
+    if (process.exitCode !== null || process.signalCode !== null) return;
     await new Promise<void>((resolvePromise) => {
       process.once("exit", () => resolvePromise());
       process.kill();
@@ -45,14 +46,16 @@ afterEach(async () => {
   })));
 });
 
-const createRelayFixture = async (installerExitCode: number, options: { spawnLongLivedDescendant?: boolean } = {}) => {
+const createRelayFixture = async (installerExitCode: number, options: { installerDelaySeconds?: number; spawnLongLivedDescendant?: boolean } = {}) => {
   const root = await mkdtemp(join(tmpdir(), "memmy-upgrade-relay-"));
   temporaryDirectories.push(root);
   const installDir = join(root, "installed Memmy");
   const dataDir = join(installDir, "data", "Memmy");
   const workDir = join(root, "relay-work");
+  const backupRoot = join(`${installDir}.memmy-upgrade-backup`, basename(workDir));
+  const backupPath = join(backupRoot, "data-backup");
   const logPath = join(root, "logs", "windows-upgrade.log");
-  const installerPath = join(root, `fake-installer-${installerExitCode}.cmd`);
+  const installerPath = join(workDir, `fake-installer-${installerExitCode}.cmd`);
   const descendantPidPath = join(root, "installer-descendant.pid");
   const descendantScriptPath = join(root, "installer-descendant.ps1");
   await mkdir(dataDir, { recursive: true });
@@ -71,6 +74,9 @@ const createRelayFixture = async (installerExitCode: number, options: { spawnLon
   const installerLines = [
     "@echo off",
   ];
+  if (options.installerDelaySeconds) {
+    installerLines.push(`ping 127.0.0.1 -n ${options.installerDelaySeconds + 1} >nul`);
+  }
   if (options.spawnLongLivedDescendant) {
     const powershellPath = join(windowsDirectory, "System32", "WindowsPowerShell", "v1.0", "powershell.exe");
     await writeFile(descendantScriptPath, [
@@ -86,13 +92,31 @@ const createRelayFixture = async (installerExitCode: number, options: { spawnLon
     `copy /y "${escapedAppStubPath}" "${escapedInstallDir}\\Memmy.exe" >nul`,
     "if not defined MEMMY_UPGRADE_WORK_DIR goto installer_done",
     ">\"%MEMMY_UPGRADE_WORK_DIR%\\child-reopen-intent.txt\" echo(%MEMMY_UPGRADE_REOPEN_AFTER_INSTALL%",
-    `move /y "%MEMMY_UPGRADE_WORK_DIR%\\data-backup" "${escapedInstallDir}\\data" >nul`,
+    `move /y "${backupPath.replaceAll("%", "%%")}" "${escapedInstallDir}\\data" >nul`,
+    ...(installerExitCode === 0 ? ['rmdir /s /q "%MEMMY_UPGRADE_WORK_DIR%\\..\\active.lock"'] : []),
     ":installer_done",
     `exit /b ${installerExitCode}`,
     ""
   );
   await writeFile(installerPath, installerLines.join("\r\n"), "utf8");
-  return { root, installDir, dataDir, workDir, logPath, installerPath, descendantPidPath };
+  return { root, installDir, dataDir, workDir, backupRoot, backupPath, logPath, installerPath, descendantPidPath };
+};
+
+const runRecovery = async (fixture: Awaited<ReturnType<typeof createRelayFixture>>) => {
+  const powershellPath = join(process.env.SystemRoot ?? "C:\\Windows", "System32", "WindowsPowerShell", "v1.0", "powershell.exe");
+  return execFile(powershellPath, [
+    "-NoProfile",
+    "-ExecutionPolicy",
+    "Bypass",
+    "-File",
+    recoveryScriptPath,
+    "-InstallDir",
+    fixture.installDir,
+    "-LockPath",
+    join(fixture.root, "active.lock"),
+    "-LogPath",
+    fixture.logPath
+  ], { timeout: 30_000, windowsHide: true });
 };
 
 const runRelay = async (
@@ -100,7 +124,13 @@ const runRelay = async (
   options: { legacyHelperPid?: number; reopenAfterInstall?: "0" | "1" } = {}
 ) => {
   const powershellPath = join(process.env.SystemRoot ?? "C:\\Windows", "System32", "WindowsPowerShell", "v1.0", "powershell.exe");
-  return execFile(powershellPath, [
+  return execFile(powershellPath, buildRelayArguments(fixture, options), { timeout: 30_000, windowsHide: true });
+};
+
+const buildRelayArguments = (
+  fixture: Awaited<ReturnType<typeof createRelayFixture>>,
+  options: { legacyHelperPid?: number; reopenAfterInstall?: "0" | "1" } = {}
+) => [
     "-NoProfile",
     "-ExecutionPolicy",
     "Bypass",
@@ -124,8 +154,7 @@ const runRelay = async (
     fixture.workDir,
     "-LogPath",
     fixture.logPath
-  ], { timeout: 30_000, windowsHide: true });
-};
+  ];
 
 const startLegacyUpdateHelper = async (fixture: Awaited<ReturnType<typeof createRelayFixture>>, reopenAfterInstall: "0" | "1") => {
   const powershellPath = join(process.env.SystemRoot ?? "C:\\Windows", "System32", "WindowsPowerShell", "v1.0", "powershell.exe");
@@ -175,8 +204,10 @@ describeOnWindows("Windows upgrade relay", () => {
     expect(existsSync(join(fixture.dataDir, "prepared-required-update.json.prompt"))).toBe(false);
     expect(existsSync(join(fixture.dataDir, "prepared-required-update.json.attempt"))).toBe(false);
     const log = await readFile(fixture.logPath, "utf8");
+    expect(log).toContain(`data moved to ${fixture.backupPath}`);
     expect(log).toContain("data restore verified");
     expect(log).toContain("upgrade verified");
+    expect(log).not.toContain("relay error");
     await waitForPathAbsent(fixture.workDir);
     expect(existsSync(fixture.workDir)).toBe(false);
   });
@@ -221,4 +252,164 @@ describeOnWindows("Windows upgrade relay", () => {
     descendantProcessIds.push(Number.parseInt((await readFile(fixture.descendantPidPath, "utf8")).trim(), 10));
     await waitForPathAbsent(fixture.workDir);
   });
+
+  it("recovers original data and clears a stale active lock after the relay is gone", async () => {
+    expect(existsSync(recoveryScriptPath)).toBe(true);
+    const fixture = await createRelayFixture(0);
+    const lockPath = join(fixture.root, "active.lock");
+    const installerDataPath = join(fixture.installDir, "data", "Memmy", "installer-created.txt");
+
+    await mkdir(fixture.backupRoot, { recursive: true });
+    await rename(join(fixture.installDir, "data"), fixture.backupPath);
+    await mkdir(dirname(installerDataPath), { recursive: true });
+    await writeFile(installerDataPath, "preserve-new-data", "utf8");
+    await mkdir(lockPath, { recursive: true });
+    await writeFile(join(lockPath, "state.json"), JSON.stringify({
+      schemaVersion: 2,
+      phase: "data-moved",
+      stateUpdatedAtUtc: "2000-01-01T00:00:00.0000000Z",
+      relayPid: 2147483647,
+      relayStartedAtUtc: "2000-01-01T00:00:00.0000000Z",
+      installerPid: null,
+      installerStartedAtUtc: null,
+      installerPath: fixture.installerPath,
+      installDir: fixture.installDir,
+      workDir: fixture.workDir,
+      backupRoot: fixture.backupRoot
+    }), "utf8");
+
+    await runRecovery(fixture);
+
+    expect(await readFile(join(fixture.dataDir, "sentinel.txt"), "utf8")).toBe("keep-me");
+    expect(await readFile(join(fixture.backupRoot, "installer-created-data", "Memmy", "installer-created.txt"), "utf8"))
+      .toBe("preserve-new-data");
+    expect(existsSync(join(fixture.dataDir, "prepared-required-update.json"))).toBe(true);
+    expect(existsSync(join(fixture.dataDir, "prepared-required-update.json.lock"))).toBe(false);
+    expect(existsSync(join(fixture.dataDir, "prepared-required-update.json.prompt"))).toBe(false);
+    expect(existsSync(join(fixture.dataDir, "prepared-required-update.json.attempt"))).toBe(true);
+    expect(existsSync(lockPath)).toBe(false);
+    expect(existsSync(fixture.workDir)).toBe(false);
+    const log = await readFile(fixture.logPath, "utf8");
+    expect(log).toContain("stale upgrade data restored");
+  });
+
+  it("clears only transient prepared-update markers for a stale state-less lock", async () => {
+    const fixture = await createRelayFixture(0);
+    const lockPath = join(fixture.root, "active.lock");
+    await mkdir(lockPath, { recursive: true });
+    const staleTimestamp = new Date(Date.now() - 3 * 60_000);
+    await utimes(lockPath, staleTimestamp, staleTimestamp);
+
+    await runRecovery(fixture);
+
+    expect(existsSync(lockPath)).toBe(false);
+    expect(existsSync(join(fixture.dataDir, "prepared-required-update.json"))).toBe(true);
+    expect(existsSync(join(fixture.dataDir, "prepared-required-update.json.lock"))).toBe(false);
+    expect(existsSync(join(fixture.dataDir, "prepared-required-update.json.prompt"))).toBe(false);
+    expect(existsSync(join(fixture.dataDir, "prepared-required-update.json.attempt"))).toBe(true);
+  });
+
+  it("keeps recovery locked while an installer from the pre-launch state boundary is running", async () => {
+    const fixture = await createRelayFixture(0);
+    const lockPath = join(fixture.root, "active.lock");
+    const stagedInstallerPath = join(fixture.workDir, "installer-starting-boundary.exe");
+    const pingPath = join(process.env.SystemRoot ?? "C:\\Windows", "System32", "PING.EXE");
+
+    await mkdir(fixture.backupRoot, { recursive: true });
+    await rename(join(fixture.installDir, "data"), fixture.backupPath);
+    await copyFile(pingPath, stagedInstallerPath);
+    await mkdir(lockPath, { recursive: true });
+    const stagedInstaller = spawn(stagedInstallerPath, ["-n", "20", "127.0.0.1"], { windowsHide: true, stdio: "ignore" });
+    helperProcesses.push(stagedInstaller);
+    await new Promise((resolvePromise) => setTimeout(resolvePromise, 250));
+    expect(stagedInstaller.pid).toBeGreaterThan(0);
+
+    await writeFile(join(lockPath, "state.json"), JSON.stringify({
+      schemaVersion: 2,
+      phase: "installer-starting",
+      stateUpdatedAtUtc: new Date().toISOString(),
+      relayPid: 2147483647,
+      relayStartedAtUtc: "2000-01-01T00:00:00.0000000Z",
+      installerPid: null,
+      installerStartedAtUtc: null,
+      installerPath: stagedInstallerPath,
+      installDir: fixture.installDir,
+      workDir: fixture.workDir,
+      backupRoot: fixture.backupRoot
+    }), "utf8");
+
+    await expect(runRecovery(fixture)).rejects.toMatchObject({ code: 2 });
+    expect(existsSync(fixture.backupPath)).toBe(true);
+    expect(existsSync(join(fixture.installDir, "data"))).toBe(false);
+    expect(existsSync(lockPath)).toBe(true);
+
+    stagedInstaller.kill();
+    await new Promise<void>((resolvePromise) => {
+      if (stagedInstaller.exitCode !== null) {
+        resolvePromise();
+        return;
+      }
+      stagedInstaller.once("exit", () => resolvePromise());
+    });
+    await runRecovery(fixture);
+
+    expect(await readFile(join(fixture.dataDir, "sentinel.txt"), "utf8")).toBe("keep-me");
+    expect(existsSync(join(fixture.dataDir, "prepared-required-update.json.lock"))).toBe(false);
+    expect(existsSync(join(fixture.dataDir, "prepared-required-update.json.prompt"))).toBe(false);
+    expect(existsSync(lockPath)).toBe(false);
+    expect(existsSync(fixture.workDir)).toBe(false);
+  });
+
+  it("recovers automatically after the relay and child installer are force-killed", async () => {
+    const fixture = await createRelayFixture(0, { installerDelaySeconds: 20 });
+    const powershellPath = join(process.env.SystemRoot ?? "C:\\Windows", "System32", "WindowsPowerShell", "v1.0", "powershell.exe");
+    const relay = spawn(powershellPath, buildRelayArguments(fixture), { windowsHide: true, stdio: "ignore" });
+    helperProcesses.push(relay);
+    const statePath = join(fixture.root, "active.lock", "state.json");
+    let installerPid = 0;
+    const installerProcessName = basename(fixture.installerPath).replaceAll("'", "''");
+
+    for (let attempt = 0; attempt < 100; attempt += 1) {
+      if (existsSync(statePath) && existsSync(fixture.backupPath)) {
+        try {
+          const state = JSON.parse(await readFile(statePath, "utf8"));
+          if (state.phase === "installer-starting") {
+            const { stdout } = await execFile(powershellPath, [
+              "-NoProfile",
+              "-Command",
+              `(Get-CimInstance Win32_Process | Where-Object { $_.Name -eq 'cmd.exe' -and $_.CommandLine -like '*${installerProcessName}*' } | Select-Object -First 1 -ExpandProperty ProcessId)`
+            ], { timeout: 5_000, windowsHide: true });
+            installerPid = Number.parseInt(stdout.trim(), 10);
+            if (installerPid > 0) break;
+          }
+        } catch {
+          // The relay updates state.json atomically; retry until the completed file is visible.
+        }
+      }
+      await new Promise((resolvePromise) => setTimeout(resolvePromise, 100));
+    }
+
+    expect(installerPid).toBeGreaterThan(0);
+    relay.kill();
+    try {
+      process.kill(installerPid);
+    } catch {
+      // The child may have already terminated with the relay.
+    }
+    await new Promise<void>((resolvePromise) => {
+      if (relay.exitCode !== null) {
+        resolvePromise();
+        return;
+      }
+      relay.once("exit", () => resolvePromise());
+    });
+
+    await runRecovery(fixture);
+
+    expect(await readFile(join(fixture.dataDir, "sentinel.txt"), "utf8")).toBe("keep-me");
+    expect(existsSync(join(fixture.root, "active.lock"))).toBe(false);
+    expect(existsSync(fixture.workDir)).toBe(false);
+    const log = await readFile(fixture.logPath, "utf8");
+    expect(log).toContain("stale upgrade data restored");
+  }, 30_000);
 });

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "typecheck": "npm run memory:lint && npm run workspace:typecheck",
     "test": "npm run test:release-workflow && npm run test:packaging-guards && npm run memory:test && npm run workspace:test && npm run agent:test:tui-cursor",
     "test:release-workflow": "vitest run tests/release-workflow.test.ts",
-    "test:packaging-guards": "vitest run tests/package-version-guard.test.mjs tests/packaged-runtime-config.test.mjs",
+    "test:packaging-guards": "vitest run tests/package-version-guard.test.mjs tests/packaged-runtime-config.test.mjs tests/package-logging.test.mjs",
     "serve": "npm run memory:serve",
     "serve:local": "npm run memory:serve:local",
     "serve:dev": "npm run memory:serve:dev",

--- a/scripts/internal/shared/package-logging.sh
+++ b/scripts/internal/shared/package-logging.sh
@@ -46,6 +46,11 @@ package_log_init() {
   fi
 
   touch "$MEMMY_PACKAGE_LOG_FILE"
+  if [ "${MEMMY_PACKAGE_LOG_CAPTURE_ACTIVE:-}" != "1" ]; then
+    MEMMY_PACKAGE_LOG_CAPTURE_ACTIVE=1
+    export MEMMY_PACKAGE_LOG_CAPTURE_ACTIVE
+    exec > >(tee -a "$MEMMY_PACKAGE_LOG_FILE") 2> >(tee -a "$MEMMY_PACKAGE_LOG_FILE" >&2)
+  fi
   if [ -z "${MEMMY_PACKAGE_TOTAL_STARTED_AT:-}" ]; then
     MEMMY_PACKAGE_TOTAL_STARTED_AT="$(package_log_seconds)"
     export MEMMY_PACKAGE_TOTAL_STARTED_AT
@@ -58,7 +63,7 @@ package_log() {
   local line
   line="[$(package_log_now)] $*"
   printf '\n%s\n' "$line"
-  if [ -n "${MEMMY_PACKAGE_LOG_FILE:-}" ]; then
+  if [ -n "${MEMMY_PACKAGE_LOG_FILE:-}" ] && [ "${MEMMY_PACKAGE_LOG_CAPTURE_ACTIVE:-}" != "1" ]; then
     printf '%s\n' "$line" >> "$MEMMY_PACKAGE_LOG_FILE"
   fi
 }
@@ -118,6 +123,7 @@ package_log_error_trap() {
 }
 
 package_install_error_trap() {
+  set -o errtrace
   trap 'package_log_error_trap "$?" "$LINENO" "$BASH_COMMAND"' ERR
 }
 

--- a/tests/package-logging.test.mjs
+++ b/tests/package-logging.test.mjs
@@ -1,0 +1,61 @@
+import { execFile as execFileCallback } from "node:child_process";
+import { mkdir, mkdtemp, readFile, rm } from "node:fs/promises";
+import { join, relative, resolve } from "node:path";
+import { promisify } from "node:util";
+import { afterEach, describe, expect, it } from "vitest";
+
+const execFile = promisify(execFileCallback);
+const temporaryDirectories = [];
+
+afterEach(async () => {
+  await Promise.all(temporaryDirectories.splice(0).map((directory) => rm(directory, {
+    recursive: true,
+    force: true
+  })));
+});
+
+describe("package logging", () => {
+  it("captures command output and marks failures raised inside shell functions", async () => {
+    const repositoryRoot = resolve(import.meta.dirname, "..");
+    const parent = join(repositoryRoot, ".tmp");
+    await mkdir(parent, { recursive: true });
+    const temporaryDirectory = await mkdtemp(join(parent, "memmy-package-logging-"));
+    temporaryDirectories.push(temporaryDirectory);
+    const logPath = join(temporaryDirectory, "package.log");
+    const bashLogPath = relative(repositoryRoot, logPath).replaceAll("\\", "/");
+    const script = [
+      "set -euo pipefail",
+      "source scripts/internal/shared/package-logging.sh",
+      `MEMMY_PACKAGE_LOG_FILE='${bashLogPath.replaceAll("'", "'\\''")}'`,
+      "export MEMMY_PACKAGE_LOG_FILE",
+      "package_log_init test-package-logging .",
+      "package_install_error_trap",
+      "package_step_start nested-function",
+      "fail_nested() {",
+      "  printf 'REAL_STDOUT\\n'",
+      "  printf 'REAL_STDERR\\n' >&2",
+      "  return 23",
+      "}",
+      "invoke_nested() { fail_nested; }",
+      "invoke_nested"
+    ].join("\n");
+
+    let failure;
+    try {
+      await execFile("bash", ["-c", script], {
+        cwd: repositoryRoot
+      });
+    } catch (error) {
+      failure = error;
+    }
+    expect({ code: failure?.code, stdout: failure?.stdout, stderr: failure?.stderr }).toMatchObject({ code: 23 });
+    expect(failure?.stdout).toContain("REAL_STDOUT");
+    expect(failure?.stderr).toContain("REAL_STDERR");
+
+    const log = await readFile(logPath, "utf8");
+    expect(log).toContain("REAL_STDOUT");
+    expect(log).toContain("REAL_STDERR");
+    expect(log).toContain("FAILED: nested-function");
+    expect(log).toContain("with exit code 23");
+  });
+});


### PR DESCRIPTION
## Summary

- pre-create the NSIS self-copy target and fail closed on copy errors
- keep relay data backups on the installation volume and add stale-upgrade recovery
- capture package stdout/stderr with errtrace-enabled failure logging
- add regression coverage for relay termination, recovery, and package logging

## Verification

- `npm run test:packaging-guards` (16 passed)
- Windows relay/recovery and package logging tests (9 passed)
- packaged runtime boundary regression (1 passed)
- PowerShell parser and diff checks passed
- unsigned Windows package built and verified
- real 1.0.9 -> 1.1.0 cross-volume mock upgrade passed, including login-state preservation and manual restart/reopen