### PR TITLE
fix(release): accept both Memmy release branch formats

### DIFF
--- a/.github/workflows/github-draft-release-v2.yml
+++ b/.github/workflows/github-draft-release-v2.yml
@@ -40,7 +40,8 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       (github.event.pull_request.merged == true &&
        github.event.pull_request.head.repo.full_name == github.repository &&
-       startsWith(github.event.pull_request.head.ref, 'release/v'))
+       (startsWith(github.event.pull_request.head.ref, 'v') ||
+        startsWith(github.event.pull_request.head.ref, 'release/v')))
     concurrency:
       # Tag and Draft Release mutations are repository-global. Queue automatic
       # and manual recovery runs so they cannot mutate assets concurrently.
@@ -69,11 +70,11 @@ jobs:
           create_draft="false"
           manual_target_sha_supplied="false"
           if [[ "$EVENT_NAME" == "pull_request_target" ]]; then
-            if [[ ! "$PR_HEAD_REF" =~ ^release/v((0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*))$ ]]; then
-              echo "Release branch must match release/vX.Y.Z" >&2
+            if [[ ! "$PR_HEAD_REF" =~ ^(release/)?v((0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*))$ ]]; then
+              echo "Release branch must match vX.Y.Z or release/vX.Y.Z" >&2
               exit 1
             fi
-            version="${BASH_REMATCH[1]}"
+            version="${BASH_REMATCH[2]}"
             target_sha="$PR_MERGE_SHA"
             preflight_level="full"
             create_draft="true"

--- a/tests/release-workflow.test.ts
+++ b/tests/release-workflow.test.ts
@@ -233,7 +233,7 @@ describe("GitHub Draft Release v2 workflow", () => {
     }
   });
 
-  it("creates Draft Releases only from merged release/vX.Y.Z PRs and keeps manual fallback", () => {
+  it("creates Draft Releases only from merged vX.Y.Z or release/vX.Y.Z PRs and keeps manual fallback", () => {
     expect(draftWorkflow.on.pull_request_target).toEqual({
       types: ["closed"],
       branches: ["main"],
@@ -252,17 +252,17 @@ describe("GitHub Draft Release v2 workflow", () => {
       "github.event_name == 'workflow_dispatch' || " +
       "(github.event.pull_request.merged == true && " +
       "github.event.pull_request.head.repo.full_name == github.repository && " +
-      "startsWith(github.event.pull_request.head.ref, 'release/v'))",
+      "(startsWith(github.event.pull_request.head.ref, 'v') || " +
+      "startsWith(github.event.pull_request.head.ref, 'release/v')))",
     );
 
     const resolve = draftScript("Resolve and validate release");
     expect(resolve).toContain('if [[ "$EVENT_NAME" == "pull_request_target" ]]');
     expect(resolve).toContain(
-      "^release/v((0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*))$",
+      "^(release/)?v((0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*))$",
     );
-    expect(resolve).toContain("Release branch must match release/vX.Y.Z");
-    expect(resolve).not.toContain("vX.Y.Z or release/vX.Y.Z");
-    expect(resolve).toContain('version="${BASH_REMATCH[1]}"');
+    expect(resolve).toContain("Release branch must match vX.Y.Z or release/vX.Y.Z");
+    expect(resolve).toContain('version="${BASH_REMATCH[2]}"');
     expect(resolve).toContain('target_sha="$PR_MERGE_SHA"');
     expect(resolve).toContain('preflight_level="full"');
     expect(resolve).toContain('create_draft="true"');


### PR DESCRIPTION
## 目标

让 `GitHub Draft Release v2` 同时兼容团队实际使用的两种发版分支：

- `vX.Y.Z`
- `release/vX.Y.Z`

解决 `v1.1.0` 这类分支合入 `main` 后工作流被 Skipped、无法自动创建 Draft Release 的问题。

## 安全边界

- 仍只接受合入 `main` 的已合并 PR
- 仍只接受主仓分支，不接受 fork PR 自动发版
- 仍要求严格、无前后缀的 SemVer 分支名
- 保留仓库级串行锁，避免重复创建 tag / Draft Release
- 后续仍执行完整版本、安装包、checksum、evidence 和 106 配置预检
- 只创建 Draft Release，不自动 Publish、不直接修改官网或发布 production

## 验证

- `npm run test:release-workflow`：20/20 通过
- 合法分支 `v1.1.0`、`release/v1.1.0` 均可解析版本
- 非法分支 `version-fix`、`v1.1`、`v1.1.0-beta`、`fork/v1.1.0` 均被拒绝
- `git diff --check`：通过
- Workflow YAML 语法检查：通过