### PR TITLE
fix(desktop): avoid blocking UI during Memory service startup

### DIFF
--- a/App/backend/src/index.ts
+++ b/App/backend/src/index.ts
@@ -55,6 +55,8 @@ export interface CreateLocalBackendOptions {
   memmyConfigPath?: string;
   /** Memory service address exposed to desktop and browser-debug clients. */
   memoryBaseUrl?: string;
+  /** Resolves when the managed Memory service is ready for startup config reload. */
+  memoryReady?: Promise<void>;
   /** Desktop install fingerprint. */
   desktopInstallFingerprint?: string;
   /** Login channel supported by the current desktop package. */
@@ -104,7 +106,14 @@ export async function createLocalBackend(options: CreateLocalBackendOptions): Pr
       runtimeToken: options.localToken
     });
     const memoryClient = options.memoryClient ?? createDefaultMemoryClient(process.env);
-    await memoryClient.reloadConfig({ reason: "desktop_startup" });
+    const memoryConfigReload = options.memoryReady
+      ? options.memoryReady.then(() => memoryClient.reloadConfig({ reason: "desktop_startup" }))
+      : memoryClient.reloadConfig({ reason: "desktop_startup" });
+    void memoryConfigReload.catch((error) => {
+      console.warn(
+        `Memory config reload failed during desktop startup: ${error instanceof Error ? error.message : String(error)}`
+      );
+    });
     const scanProcess = options.memoryClient ? undefined : { databasePath: appStateStore.databasePath };
     const cloudConfig = resolveCloudClientConfig(process.env);
     const cloudClient = options.cloudClient ?? createDefaultCloudClient(

--- a/App/backend/src/tests/index.test.ts
+++ b/App/backend/src/tests/index.test.ts
@@ -5,7 +5,7 @@ import { createServer, type IncomingMessage, type ServerResponse } from "node:ht
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import YAML from "yaml";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { CloudClient } from "../adapters/outbound/cloud-client/index.js";
 import type { MemoryClient } from "../adapters/outbound/memory-client/index.js";
 import { createLocalBackend, readMemoryLayerConfig, type LocalBackend } from "../index.js";
@@ -85,6 +85,38 @@ describe("local api", () => {
 
     expect(reloadReasons).toEqual([{ reason: "desktop_startup" }]);
     expect(backend.runtimeConfig.memory).toEqual({ baseUrl: "http://127.0.0.1:18960" });
+  });
+
+  it("does not block local API startup while managed Memory is still initializing", async () => {
+    tempDir = mkdtempSync(join(tmpdir(), "memmy-backend-memory-ready-"));
+    const baseClient = createMockMemoryClient();
+    const reloadReasons: unknown[] = [];
+    let markMemoryReady: (() => void) | undefined;
+    const memoryReady = new Promise<void>((resolveReady) => {
+      markMemoryReady = resolveReady;
+    });
+    const memoryClient: MemoryClient = {
+      ...baseClient,
+      async reloadConfig(input) {
+        reloadReasons.push(input);
+        return baseClient.reloadConfig(input);
+      }
+    };
+
+    backend = await createLocalBackend({
+      databasePath: join(tempDir, "app.sqlite"),
+      runtimeConfigPath: join(tempDir, "runtime.json"),
+      localToken: "test-token",
+      memoryBaseUrl: "http://127.0.0.1:18960",
+      memoryReady,
+      memoryClient,
+      cloudClient: createMockCloudClient(),
+      memmyConfigPath: join(tempDir, "config.yaml")
+    });
+
+    expect(reloadReasons).toEqual([]);
+    markMemoryReady?.();
+    await vi.waitFor(() => expect(reloadReasons).toEqual([{ reason: "desktop_startup" }]));
   });
 
   it("uses the built-in default Cloud client when MEMMY_CLOUD_URL is missing", async () => {

--- a/App/shell/desktop/src/main/main.ts
+++ b/App/shell/desktop/src/main/main.ts
@@ -774,6 +774,7 @@ async function startLocalApi(services: ManagedRuntimeServices | null): Promise<D
     accountChannel: resolveCurrentDesktopAccountChannel(),
     memmyConfigPath: process.env.MEMMY_CONFIG,
     memoryBaseUrl: memoryControl.baseUrl,
+    memoryReady: services?.memory.ready,
     runtimeConfigPath: process.env.MEMMY_HOME ? join(process.env.MEMMY_HOME, "runtime.json") : undefined
   });
   const agentGateway: NonNullable<DesktopRuntimeConfig["agentGateway"]> =

--- a/App/shell/desktop/src/main/runtime-services.ts
+++ b/App/shell/desktop/src/main/runtime-services.ts
@@ -29,6 +29,7 @@ export interface ManagedRuntimeServices {
     token: string;
     databasePath: string;
     configPath: string;
+    ready: Promise<void>;
   };
   agentGateway: {
     baseUrl: string;
@@ -198,18 +199,19 @@ export async function startManagedRuntimeServices(
       spawn,
       browserPreparationAttemptId
     );
-    memoryStartup = ensureMemoryService(entries, runtimeConfig, children, options);
-    const [agentGatewayStartupIssue] = await Promise.all([
-      startAgentGatewayWithRecovery(gatewaySupervisor),
-      memoryStartup
-    ]);
+    const memoryReady = ensureMemoryService(entries, runtimeConfig, children, options);
+    memoryStartup = memoryReady.catch((error) => {
+      console.warn(`Memory service unavailable during desktop startup: ${errorMessage(error)}`);
+    });
+    const agentGatewayStartupIssue = await startAgentGatewayWithRecovery(gatewaySupervisor);
 
     return {
       memory: {
         baseUrl: runtimeConfig.memoryBaseUrl,
         token: runtimeConfig.memoryToken,
         databasePath: runtimeConfig.memoryDatabasePath,
-        configPath: runtimeConfig.configPath
+        configPath: runtimeConfig.configPath,
+        ready: memoryReady
       },
       agentGateway: {
         baseUrl: runtimeConfig.agentGatewayBaseUrl,
@@ -237,7 +239,6 @@ export async function startManagedRuntimeServices(
       async close() {
         closing = true;
         browserPreparation?.stop();
-        await memoryStartup;
         await memoryRestart?.catch(() => undefined);
         await gatewaySupervisor.close();
         await stopManagedChildren(children);
@@ -250,7 +251,6 @@ export async function startManagedRuntimeServices(
     };
   } catch (error) {
     browserPreparation?.stop();
-    await memoryStartup?.catch(() => undefined);
     await gatewaySupervisor.close();
     await stopManagedChildren(children);
     throw error;

--- a/App/shell/desktop/src/main/runtime-services.ts
+++ b/App/shell/desktop/src/main/runtime-services.ts
@@ -15,10 +15,10 @@ const DEFAULT_MEMORY_URL = "http://127.0.0.1:18960";
 const DEFAULT_AGENT_GATEWAY_HEALTH_PORT = 18970;
 const DEFAULT_AGENT_WEBSOCKET_PORT = 18980;
 const STARTUP_TIMEOUT_MS = 30_000;
+const MEMORY_STARTUP_TIMEOUT_MS = 120_000;
 const POLL_INTERVAL_MS = 250;
 const HTTP_TIMEOUT_MS = 1_000;
 const STOP_MANAGED_CHILD_GRACE_MS = 1_000;
-const EXISTING_MEMORY_STARTUP_GRACE_MS = 10_000;
 
 type RuntimeEnv = Record<string, string | undefined>;
 type ConfigRecord = Record<string, unknown>;
@@ -198,11 +198,11 @@ export async function startManagedRuntimeServices(
       spawn,
       browserPreparationAttemptId
     );
-    memoryStartup = ensureMemoryService(entries, runtimeConfig, children, options)
-      .catch((error) => {
-        console.warn(`Memory service unavailable during desktop startup: ${errorMessage(error)}`);
-      });
-    const agentGatewayStartupIssue = await startAgentGatewayWithRecovery(gatewaySupervisor);
+    memoryStartup = ensureMemoryService(entries, runtimeConfig, children, options);
+    const [agentGatewayStartupIssue] = await Promise.all([
+      startAgentGatewayWithRecovery(gatewaySupervisor),
+      memoryStartup
+    ]);
 
     return {
       memory: {
@@ -250,7 +250,7 @@ export async function startManagedRuntimeServices(
     };
   } catch (error) {
     browserPreparation?.stop();
-    await memoryStartup;
+    await memoryStartup?.catch(() => undefined);
     await gatewaySupervisor.close();
     await stopManagedChildren(children);
     throw error;
@@ -745,7 +745,13 @@ export async function ensureMemoryService(
   });
   children.push(memoryChild);
   try {
-    await waitForHttpService("memory", healthUrl, memoryChild, healthHeaders);
+    await waitForHttpService(
+      "memory",
+      healthUrl,
+      memoryChild,
+      healthHeaders,
+      MEMORY_STARTUP_TIMEOUT_MS
+    );
   } catch (error) {
     const lockOwner = readLiveMemoryServerLock(runtimeConfig.memoryDatabasePath);
     if (!lockOwner || lockOwner.pid === memoryChild.process.pid) {
@@ -1294,7 +1300,7 @@ async function waitForExistingMemoryService(
       "existing memory",
       healthUrl,
       healthHeaders,
-      EXISTING_MEMORY_STARTUP_GRACE_MS
+      MEMORY_STARTUP_TIMEOUT_MS
     );
   } catch (error) {
     throw new Error(
@@ -1377,9 +1383,10 @@ async function waitForHttpService(
   name: string,
   url: string,
   child: ManagedChild,
-  headers: Record<string, string> = {}
+  headers: Record<string, string> = {},
+  timeoutMs = STARTUP_TIMEOUT_MS
 ): Promise<void> {
-  const deadline = Date.now() + STARTUP_TIMEOUT_MS;
+  const deadline = Date.now() + timeoutMs;
   let lastError: unknown;
 
   while (Date.now() < deadline) {

--- a/App/shell/desktop/tests/packaged-runtime-boundary.test.ts
+++ b/App/shell/desktop/tests/packaged-runtime-boundary.test.ts
@@ -1114,9 +1114,10 @@ describe("desktop packaged runtime boundaries", () => {
     expect(source).not.toContain("await preparePackagedBrowser(entries, runtimeConfig, options)");
     expect(source).toContain('[entries.agentEntry, "internal", "browser-prepare"]');
     expect(source.indexOf("browserPreparation = startPackagedBrowserPreparation")).toBeLessThan(
-      source.indexOf("memoryStartup = ensureMemoryService"),
+      source.indexOf("const memoryReady = ensureMemoryService"),
     );
-    expect(source).toContain("memoryStartup = ensureMemoryService");
+    expect(source).toContain("const memoryReady = ensureMemoryService");
+    expect(source).toContain("Memory service unavailable during desktop startup");
     expect(source).toContain("readLiveMemoryServerLock(runtimeConfig.memoryDatabasePath)");
     expect(source).toContain("browserPreparation?.stop()");
     expect(source).toContain("terminateProcessTreeSync(child)");
@@ -1136,21 +1137,23 @@ describe("desktop packaged runtime boundaries", () => {
     expect(source).toContain('join(repoRoot, "App", "memmy-agent", "dist", "main.js")');
   });
 
-  it("waits for Memory readiness before publishing managed runtime services", () => {
+  it("publishes managed runtime services while Memory continues initializing", () => {
     const source = readFileSync(runtimeServicesPath, "utf8");
-    const startupIndex = source.indexOf("memoryStartup = ensureMemoryService");
-    const barrierIndex = source.indexOf(
-      "const [agentGatewayStartupIssue] = await Promise.all([",
+    const startupIndex = source.indexOf("const memoryReady = ensureMemoryService");
+    const gatewayIndex = source.indexOf(
+      "const agentGatewayStartupIssue = await startAgentGatewayWithRecovery",
       startupIndex,
     );
-    const returnIndex = source.indexOf("return {", barrierIndex);
+    const returnIndex = source.indexOf("return {", gatewayIndex);
 
     expect(startupIndex).toBeGreaterThan(-1);
-    expect(barrierIndex).toBeGreaterThan(startupIndex);
-    expect(returnIndex).toBeGreaterThan(barrierIndex);
-    expect(source.slice(barrierIndex, returnIndex)).toContain("memoryStartup");
+    expect(gatewayIndex).toBeGreaterThan(startupIndex);
+    expect(returnIndex).toBeGreaterThan(gatewayIndex);
+    expect(source.slice(startupIndex, returnIndex)).not.toContain("await memoryReady");
+    expect(source.slice(startupIndex, returnIndex)).not.toContain("await memoryStartup");
+    expect(source.slice(returnIndex, source.indexOf("agentGateway:", returnIndex))).toContain("ready: memoryReady");
     expect(source).toContain("const MEMORY_STARTUP_TIMEOUT_MS = 120_000;");
-    expect(source).not.toContain("Memory service unavailable during desktop startup");
+    expect(readFileSync(mainSourcePath, "utf8")).toContain("memoryReady: services?.memory.ready");
   });
 
   it("exports shared config and workspace paths from dev-start", () => {

--- a/App/shell/desktop/tests/packaged-runtime-boundary.test.ts
+++ b/App/shell/desktop/tests/packaged-runtime-boundary.test.ts
@@ -1117,7 +1117,6 @@ describe("desktop packaged runtime boundaries", () => {
       source.indexOf("memoryStartup = ensureMemoryService"),
     );
     expect(source).toContain("memoryStartup = ensureMemoryService");
-    expect(source).toContain("Memory service unavailable during desktop startup");
     expect(source).toContain("readLiveMemoryServerLock(runtimeConfig.memoryDatabasePath)");
     expect(source).toContain("browserPreparation?.stop()");
     expect(source).toContain("terminateProcessTreeSync(child)");
@@ -1135,6 +1134,23 @@ describe("desktop packaged runtime boundaries", () => {
     expect(source).not.toContain(legacyApplicationSupportDir);
     expect(source).toContain('join(repoRoot, "Memory", "dist", "src", "server", "index.js")');
     expect(source).toContain('join(repoRoot, "App", "memmy-agent", "dist", "main.js")');
+  });
+
+  it("waits for Memory readiness before publishing managed runtime services", () => {
+    const source = readFileSync(runtimeServicesPath, "utf8");
+    const startupIndex = source.indexOf("memoryStartup = ensureMemoryService");
+    const barrierIndex = source.indexOf(
+      "const [agentGatewayStartupIssue] = await Promise.all([",
+      startupIndex,
+    );
+    const returnIndex = source.indexOf("return {", barrierIndex);
+
+    expect(startupIndex).toBeGreaterThan(-1);
+    expect(barrierIndex).toBeGreaterThan(startupIndex);
+    expect(returnIndex).toBeGreaterThan(barrierIndex);
+    expect(source.slice(barrierIndex, returnIndex)).toContain("memoryStartup");
+    expect(source).toContain("const MEMORY_STARTUP_TIMEOUT_MS = 120_000;");
+    expect(source).not.toContain("Memory service unavailable during desktop startup");
   });
 
   it("exports shared config and workspace paths from dev-start", () => {


### PR DESCRIPTION
## Summary

- Start the managed Memory service without blocking the desktop UI.
- Allow Memory initialization and database migrations to continue in the background.
- Reload the Memory configuration asynchronously after the service becomes ready.
- Avoid waiting for Memory readiness during desktop shutdown.
- Add regression coverage to ensure Memory initialization does not block Local API startup.

## Testing

- Desktop tests passed: 188 passed, 4 skipped.
- Backend and Desktop type checks passed.
- The new non-blocking Memory startup regression test passed.

Fixes #279