### PR TITLE
fix(updater): preserve authoritative Windows data during upgrade

### DIFF
--- a/App/backend/src/services/runtime-config-sync-service.ts
+++ b/App/backend/src/services/runtime-config-sync-service.ts
@@ -7,14 +7,25 @@ import {
 import {
   clearAccountModelProjectionFromMemmyConfig,
   readRuntimeMemmyConfigState,
+  writeAccountModelProjectionToMemmyConfig,
   type RuntimeMemmyConfigState
 } from "../infrastructure/memmy-config/index.js";
+
+export interface RuntimeConfigMigrationConsistency {
+  /** The account database was replaced from an explicitly trusted install generation. */
+  accountSourceIsAuthoritative: boolean;
+  /** Runtime config was copied from a migration source instead of retaining the target. */
+  runtimeSourceWasMigrated: boolean;
+  /** Account and runtime directories came from the same trusted install generation. */
+  categorySourcesShareGeneration: boolean;
+}
 
 export interface SyncRuntimeConfigWithAppStateOptions {
   appStateStore: AppStateStore;
   memmyConfigPath: string;
   /** Login channel supported by the current desktop package. */
   accountChannel?: AccountChannel;
+  migrationConsistency?: RuntimeConfigMigrationConsistency;
 }
 
 export interface SyncRuntimeConfigForStartupOptions {
@@ -22,6 +33,7 @@ export interface SyncRuntimeConfigForStartupOptions {
   memmyConfigPath: string;
   /** Login channel supported by the current desktop package. */
   accountChannel?: AccountChannel;
+  migrationConsistency?: RuntimeConfigMigrationConsistency;
 }
 
 export interface RuntimeConfigSyncResult {
@@ -47,7 +59,10 @@ type RuntimeConfigSyncErrorState = {
 export async function syncRuntimeConfigWithAppState(
   options: SyncRuntimeConfigWithAppStateOptions
 ): Promise<RuntimeConfigSyncResult> {
-  const state = await readRuntimeMemmyConfigState(options.memmyConfigPath);
+  let state = await readRuntimeMemmyConfigState(options.memmyConfigPath);
+  if (options.migrationConsistency) {
+    state = await reconcileMigratedAccountProjection(options, state);
+  }
   const activeChannelMismatch = await clearMismatchedActiveSession(options, state);
   if (activeChannelMismatch) {
     const clearedUntrustedProjection = await clearUntrustedAccountProjection(
@@ -129,11 +144,77 @@ export async function syncRuntimeConfigForStartup(
     return await syncRuntimeConfigWithAppState({
       appStateStore,
       memmyConfigPath: options.memmyConfigPath,
-      accountChannel: options.accountChannel
+      accountChannel: options.accountChannel,
+      migrationConsistency: options.migrationConsistency
     });
   } finally {
     appStateStore.close();
   }
+}
+
+async function reconcileMigratedAccountProjection(
+  options: SyncRuntimeConfigWithAppStateOptions,
+  state: RuntimeMemmyConfigState
+): Promise<RuntimeMemmyConfigState> {
+  const session = options.appStateStore.repositories.accountSession.get();
+  const projection = accountProjectionFromState(state);
+  if (!session.authenticated) {
+    if (projection || (
+      options.migrationConsistency?.accountSourceIsAuthoritative
+      && options.appStateStore.repositories.bootstrap.getAppSettings().userMode === "account"
+    )) {
+      throw createMigrationConsistencyError(
+        "Migrated account runtime config has no authenticated local account session"
+      );
+    }
+    return state;
+  }
+
+  const sessionChannel = options.appStateStore.repositories.accountSession.getAuthChannel();
+  if (options.accountChannel && sessionChannel !== options.accountChannel) {
+    throw createMigrationConsistencyError(
+      `Migrated account authentication channel ${String(sessionChannel)} does not match package channel ${options.accountChannel}`
+    );
+  }
+  const cloudUuid = options.appStateStore.repositories.accountSession.getCloudUuid();
+  if (!cloudUuid) {
+    throw createMigrationConsistencyError("Migrated account session is missing its cloud credential");
+  }
+
+  const projectionMatchesSession = projection
+    && projection.cloudUuid === cloudUuid
+    && projection.userId === session.profile.userId;
+  if (projection && !projectionMatchesSession) {
+    if (
+      !options.migrationConsistency?.accountSourceIsAuthoritative
+      || options.migrationConsistency.categorySourcesShareGeneration
+    ) {
+      throw createMigrationConsistencyError(
+        "Migrated account database and runtime model projection have different owners"
+      );
+    }
+  }
+
+  if (!projectionMatchesSession || state.status === "no_model_config") {
+    await writeAccountModelProjectionToMemmyConfig({
+      cloudUuid,
+      userId: session.profile.userId
+    }, options.memmyConfigPath);
+    const repaired = await readRuntimeMemmyConfigState(options.memmyConfigPath);
+    const repairedProjection = accountProjectionFromState(repaired);
+    if (
+      !repairedProjection
+      || repairedProjection.cloudUuid !== cloudUuid
+      || repairedProjection.userId !== session.profile.userId
+      || (repaired.status !== "valid_account" && repaired.status !== "valid_byok")
+    ) {
+      throw createMigrationConsistencyError(
+        "Migrated account model projection could not be restored from the authoritative account database"
+      );
+    }
+    return repaired;
+  }
+  return state;
 }
 
 function hydrateByokRuntimeConfig(
@@ -264,5 +345,12 @@ function createRuntimeConfigSyncError(state: RuntimeConfigSyncErrorState): Error
     configPath: state.configPath,
     reason: state.reason,
     status: state.status
+  });
+}
+
+function createMigrationConsistencyError(reason: string): Error {
+  return Object.assign(new Error(`Windows data migration consistency check failed: ${reason}`), {
+    code: "windows_data_migration_inconsistent" as const,
+    reason
   });
 }

--- a/App/backend/src/services/tests/runtime-config-sync-service.test.ts
+++ b/App/backend/src/services/tests/runtime-config-sync-service.test.ts
@@ -3,7 +3,7 @@ import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import YAML from "yaml";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { createAppStateStore, type AppStateStore } from "../../infrastructure/app-state-store/index.js";
 import { createMemmyConfigWriter } from "../../infrastructure/memmy-config/index.js";
 import { createAppConfigService } from "../app-config-service.js";
@@ -11,12 +11,19 @@ import { syncRuntimeConfigWithAppState } from "../runtime-config-sync-service.js
 
 let tempDir: string | undefined;
 let store: AppStateStore | undefined;
+const originalCloudService = process.env.MEMMY_CLOUD_SERVICE;
+
+beforeEach(() => {
+  process.env.MEMMY_CLOUD_SERVICE = "https://cloud.example.test";
+});
 
 afterEach(() => {
   store?.close();
   store = undefined;
   if (tempDir) rmSync(tempDir, { recursive: true, force: true });
   tempDir = undefined;
+  if (originalCloudService === undefined) delete process.env.MEMMY_CLOUD_SERVICE;
+  else process.env.MEMMY_CLOUD_SERVICE = originalCloudService;
 });
 
 describe("syncRuntimeConfigWithAppState", () => {
@@ -348,6 +355,153 @@ describe("syncRuntimeConfigWithAppState", () => {
     expect(context.store.repositories.bootstrap.getAppSettings().userMode).toBe("account");
   });
 
+  it("restores the account model projection from an authoritative migrated session without losing BYOK", async () => {
+    const context = createContext();
+    seedAccountSession(context);
+    const byok = currentByokCatalog() as any;
+    context.writeConfig({
+      ...byok,
+      app: { ...byok.app, userMode: "account" }
+    });
+
+    await expect(syncRuntimeConfigWithAppState({
+      ...context,
+      accountChannel: "email",
+      migrationConsistency: {
+        accountSourceIsAuthoritative: true,
+        runtimeSourceWasMigrated: false,
+        categorySourcesShareGeneration: false
+      }
+    })).resolves.toMatchObject({
+      source: "runtime_config",
+      mode: "account",
+      provider: "memmy_account",
+      hydratedAppState: true
+    });
+
+    const saved = YAML.parse(readFileSync(context.memmyConfigPath, "utf8"));
+    expect(saved.providers.openai).toEqual(byok.providers.openai);
+    expect(saved.modelAssignments.byok).toEqual(byok.modelAssignments.byok);
+    expect(saved.providers.memmy_account).toMatchObject({
+      ownerAccountId: "owner-a",
+      apiKey: "cloud-token-a"
+    });
+    expect(saved.modelAssignments.account.ownerAccountId).toBe("owner-a");
+  });
+
+  it("uses an authoritative migrated account database to replace only a stale account projection", async () => {
+    const context = createContext();
+    seedAccountSession(context);
+    const byok = currentByokCatalog() as any;
+    const staleAccount = currentAccountCatalog() as any;
+    staleAccount.app.cloudUuid = "stale-cloud-token";
+    staleAccount.app.userId = "stale-owner";
+    staleAccount.providers.memmy_account.apiKey = "stale-cloud-token";
+    staleAccount.providers.memmy_account.ownerAccountId = "stale-owner";
+    staleAccount.modelPresets.platform.ownerAccountId = "stale-owner";
+    staleAccount.modelAssignments.account.ownerAccountId = "stale-owner";
+    context.writeConfig({
+      ...byok,
+      app: { ...staleAccount.app, userMode: "account" },
+      providers: { ...byok.providers, ...staleAccount.providers },
+      modelPresets: { ...byok.modelPresets, ...staleAccount.modelPresets },
+      modelAssignments: {
+        byok: byok.modelAssignments.byok,
+        account: staleAccount.modelAssignments.account
+      }
+    });
+
+    await expect(syncRuntimeConfigWithAppState({
+      ...context,
+      accountChannel: "email",
+      migrationConsistency: {
+        accountSourceIsAuthoritative: true,
+        runtimeSourceWasMigrated: false,
+        categorySourcesShareGeneration: false
+      }
+    })).resolves.toMatchObject({ mode: "account", hydratedAppState: true });
+
+    const saved = YAML.parse(readFileSync(context.memmyConfigPath, "utf8"));
+    expect(saved.providers.openai).toEqual(byok.providers.openai);
+    expect(saved.modelAssignments.byok).toEqual(byok.modelAssignments.byok);
+    expect(saved.providers.memmy_account.ownerAccountId).toBe("owner-a");
+    expect(saved.modelAssignments.account.ownerAccountId).toBe("owner-a");
+    expect(JSON.stringify(saved)).not.toContain("stale-owner");
+  });
+
+  it("fills a missing migrated account owner from the authoritative account database", async () => {
+    const context = createContext();
+    seedAccountSession(context);
+    const config = currentAccountCatalog() as any;
+    delete config.app.userId;
+    delete config.providers.memmy_account.ownerAccountId;
+    delete config.modelPresets.platform.ownerAccountId;
+    delete config.modelAssignments.account.ownerAccountId;
+    context.writeConfig(config);
+
+    await expect(syncRuntimeConfigWithAppState({
+      ...context,
+      accountChannel: "email",
+      migrationConsistency: {
+        accountSourceIsAuthoritative: true,
+        runtimeSourceWasMigrated: false,
+        categorySourcesShareGeneration: false
+      }
+    })).resolves.toMatchObject({ mode: "account", hydratedAppState: true });
+
+    const saved = YAML.parse(readFileSync(context.memmyConfigPath, "utf8"));
+    expect(saved.app.userId).toBe("owner-a");
+    expect(saved.providers.memmy_account.ownerAccountId).toBe("owner-a");
+    expect(saved.modelAssignments.account.ownerAccountId).toBe("owner-a");
+  });
+
+  it("rejects a same-generation migrated account owner mismatch without clearing either side", async () => {
+    const context = createContext();
+    seedAccountSession(context);
+    const config = currentAccountCatalog() as any;
+    config.app.cloudUuid = "foreign-token";
+    config.app.userId = "foreign-owner";
+    config.providers.memmy_account.apiKey = "foreign-token";
+    config.providers.memmy_account.ownerAccountId = "foreign-owner";
+    config.modelPresets.platform.ownerAccountId = "foreign-owner";
+    config.modelAssignments.account.ownerAccountId = "foreign-owner";
+    context.writeConfig(config);
+
+    await expect(syncRuntimeConfigWithAppState({
+      ...context,
+      accountChannel: "email",
+      migrationConsistency: {
+        accountSourceIsAuthoritative: true,
+        runtimeSourceWasMigrated: true,
+        categorySourcesShareGeneration: true
+      }
+    })).rejects.toMatchObject({ code: "windows_data_migration_inconsistent" });
+
+    expect(context.store.repositories.accountSession.get()).toMatchObject({
+      authenticated: true,
+      profile: { userId: "owner-a" }
+    });
+    const saved = YAML.parse(readFileSync(context.memmyConfigPath, "utf8"));
+    expect(saved.providers.memmy_account.ownerAccountId).toBe("foreign-owner");
+  });
+
+  it("rejects a migrated authentication-channel mismatch without logging the user out", async () => {
+    const context = createContext();
+    seedAccountSession(context, "phone");
+    context.writeConfig(currentAccountCatalog());
+
+    await expect(syncRuntimeConfigWithAppState({
+      ...context,
+      accountChannel: "email",
+      migrationConsistency: {
+        accountSourceIsAuthoritative: true,
+        runtimeSourceWasMigrated: true,
+        categorySourcesShareGeneration: true
+      }
+    })).rejects.toMatchObject({ code: "windows_data_migration_inconsistent" });
+    expect(context.store.repositories.accountSession.get()).toMatchObject({ authenticated: true });
+  });
+
   it("never recreates missing YAML from legacy SQLite app-state", async () => {
     const context = createContext();
     context.store.repositories.bootstrap.updateAppSettings({ userMode: "byok" });
@@ -425,6 +579,30 @@ function currentAccountCatalog(): Record<string, unknown> {
       account: { ownerAccountId: "owner-a", agent: { candidates: ["platform"], default: "platform" } }
     }
   };
+}
+
+function seedAccountSession(
+  context: ReturnType<typeof createContext>,
+  authChannel: "email" | "phone" = "email"
+): void {
+  context.store.repositories.accountSession.upsert({
+    profile: {
+      userId: "owner-a",
+      email: authChannel === "email" ? "a@example.test" : null,
+      phoneNumber: authChannel === "phone" ? "13800138000" : null,
+      nickname: "a",
+      avatarUrl: null,
+      planType: "free",
+      hasFinishedGuide: false,
+      region: null,
+      registeredAt: "2026-06-02T10:00:00.000Z",
+      rawProfile: { id: "owner-a", userName: "a" }
+    },
+    uuid: "account-a",
+    cloudUuid: "cloud-token-a",
+    authChannel
+  });
+  context.store.repositories.bootstrap.updateAppSettings({ userMode: "account" });
 }
 
 function createContext(): {

--- a/App/frontend/desktop/src/app.tsx
+++ b/App/frontend/desktop/src/app.tsx
@@ -69,6 +69,7 @@ function RuntimeApp() {
   const { t } = useTranslation();
   const translationRef = useRef(t);
   const agentStateRef = useRef(state.agent);
+  const rendererReadyReportedRef = useRef(false);
   const [bootKey, setBootKey] = useState(0);
   translationRef.current = t;
   agentStateRef.current = state.agent;
@@ -91,6 +92,18 @@ function RuntimeApp() {
   useEffect(() => {
     setAnalyticsUserId(state.account.userId);
   }, [state.account.userId]);
+
+  useEffect(() => {
+    if (
+      rendererReadyReportedRef.current
+      || !clients
+      || !state.bootstrap
+      || typeof window === "undefined"
+      || !window.memmy?.notifyRendererReady
+    ) return;
+    rendererReadyReportedRef.current = true;
+    window.memmy.notifyRendererReady();
+  }, [clients, state.bootstrap]);
 
   useEffect(() => () => taskStateCoordinator?.dispose(), [taskStateCoordinator]);
 

--- a/App/frontend/desktop/src/global.d.ts
+++ b/App/frontend/desktop/src/global.d.ts
@@ -27,6 +27,7 @@ declare global {
   interface Window {
     memmy?: {
       platform: string;
+      notifyRendererReady(): void;
       getRuntimeConfig(): Promise<unknown>;
       getAppInfo(): Promise<DesktopAppInfo>;
       getInstallationId(): Promise<string>;

--- a/App/shell/desktop/build/MemmyWindowsDataMigration.ps1
+++ b/App/shell/desktop/build/MemmyWindowsDataMigration.ps1
@@ -1,0 +1,1411 @@
+param(
+  [Parameter(Mandatory = $true)]
+  [ValidateSet("Prepare", "Complete", "Rollback", "Recover", "RequireRecovery")]
+  [string]$Mode,
+
+  [Parameter(Mandatory = $true)]
+  [string]$SourceDataPath,
+
+  [ValidateSet(
+    "current-install-authority",
+    "selected-install-authority",
+    "relay-backup-authority",
+    "persisted-install-authority",
+    "untrusted-residual"
+  )]
+  [string]$SourceAuthority = "untrusted-residual",
+
+  [string]$SourceInstallDir = "",
+
+  [string]$SourceGeneration = "",
+
+  [string]$SourceInstalledVersion = "",
+
+  [string]$InstallationRecordPath = "",
+
+  [string]$LegacyRuntimeHomePath = "",
+
+  [string]$AllowedRememberedRuntimeHomePath = "",
+
+  [Parameter(Mandatory = $true)]
+  [string]$TargetUserDataPath,
+
+  [Parameter(Mandatory = $true)]
+  [string]$TargetRuntimeHomePath,
+
+  [Parameter(Mandatory = $true)]
+  [string]$PointerPath,
+
+  [Parameter(Mandatory = $true)]
+  [string]$StatePath,
+
+  [Parameter(Mandatory = $true)]
+  [string]$LockPath,
+
+  [Parameter(Mandatory = $true)]
+  [string]$LogPath,
+
+  [Parameter(Mandatory = $true)]
+  [ValidateSet("relay", "installer")]
+  [string]$Owner,
+
+  [int]$InstallerPid = 0,
+
+  [string]$InstallerPath = "",
+
+  [string]$InstallerInstallDir = "",
+
+  [switch]$AcquireLock
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version 2.0
+$lockAcquiredHere = $false
+$effectiveSourceDataPath = $SourceDataPath
+$effectiveSourceAuthority = $SourceAuthority
+$effectiveSourceInstallDir = $SourceInstallDir
+$effectiveSourceGeneration = $SourceGeneration
+$effectiveSourceInstalledVersion = $SourceInstalledVersion
+
+function Ensure-ParentDirectory {
+  param([Parameter(Mandatory = $true)][string]$Path)
+
+  $parent = Split-Path -Parent $Path
+  if ($parent -and -not (Test-Path -LiteralPath $parent -PathType Container)) {
+    New-Item -ItemType Directory -Path $parent -Force | Out-Null
+  }
+}
+
+function Write-MigrationLog {
+  param([Parameter(Mandatory = $true)][string]$Message)
+
+  try {
+    Ensure-ParentDirectory -Path $LogPath
+    $line = "{0} {1}" -f ([DateTime]::UtcNow.ToString("o")), $Message
+    Add-Content -LiteralPath $LogPath -Value $line -Encoding UTF8
+  }
+  catch {}
+}
+
+function Get-NormalizedPath {
+  param([Parameter(Mandatory = $true)][string]$Path)
+
+  return [System.IO.Path]::GetFullPath($Path).TrimEnd('\', '/')
+}
+
+function Test-SamePath {
+  param(
+    [Parameter(Mandatory = $true)][string]$Left,
+    [Parameter(Mandatory = $true)][string]$Right
+  )
+
+  return [string]::Equals(
+    (Get-NormalizedPath -Path $Left),
+    (Get-NormalizedPath -Path $Right),
+    [System.StringComparison]::OrdinalIgnoreCase
+  )
+}
+
+function Read-DataRootPointer {
+  param([Parameter(Mandatory = $true)][string]$Path)
+
+  if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+    return $null
+  }
+
+  try {
+    $bytes = [System.IO.File]::ReadAllBytes($Path)
+    if ($bytes.Length -ge 2 -and $bytes[0] -eq 0xff -and $bytes[1] -eq 0xfe) {
+      $value = [System.Text.Encoding]::Unicode.GetString($bytes, 2, $bytes.Length - 2)
+    }
+    else {
+      $value = [System.Text.Encoding]::UTF8.GetString($bytes)
+    }
+    $value = $value.Trim([char]0xfeff).Trim()
+    if ($value -and [System.IO.Path]::IsPathRooted($value)) {
+      $normalizedValue = Get-NormalizedPath -Path $value
+      $runtimeRoot = [System.IO.Path]::GetPathRoot($normalizedValue)
+      $canonicalDriveRuntimeHome = if ($runtimeRoot) {
+        Join-Path $runtimeRoot "MemmyData\.memmy"
+      } else {
+        ""
+      }
+      if (($LegacyRuntimeHomePath -and (Test-SamePath -Left $normalizedValue -Right $LegacyRuntimeHomePath)) -or
+          (Test-SamePath -Left $normalizedValue -Right $TargetRuntimeHomePath) -or
+          ($canonicalDriveRuntimeHome -and (Test-SamePath -Left $normalizedValue -Right $canonicalDriveRuntimeHome)) -or
+          ($AllowedRememberedRuntimeHomePath -and
+            (Test-SamePath -Left $normalizedValue -Right $AllowedRememberedRuntimeHomePath))) {
+        return $normalizedValue
+      }
+      Write-MigrationLog -Message "Ignoring data-root pointer outside a supported Memmy runtime root: $normalizedValue"
+    }
+  }
+  catch {
+    Write-MigrationLog -Message ("Ignoring unreadable data-root pointer: {0}" -f $_.Exception.Message)
+  }
+  return $null
+}
+
+function Resolve-TrustedInstallDataPath {
+  if ($effectiveSourceAuthority -eq "untrusted-residual") {
+    Write-MigrationLog -Message "Install data source is not externally trusted; it cannot replace persistent targets: $effectiveSourceDataPath"
+    return $null
+  }
+  if (-not $effectiveSourceInstallDir -or -not [System.IO.Path]::IsPathRooted($effectiveSourceInstallDir)) {
+    throw "A trusted install source requires an absolute source installation directory."
+  }
+
+  $normalizedSourceDataPath = Get-NormalizedPath -Path $effectiveSourceDataPath
+  $normalizedSourceInstallDir = Get-NormalizedPath -Path $effectiveSourceInstallDir
+  if (@("current-install-authority", "selected-install-authority") -contains $effectiveSourceAuthority) {
+    if ($effectiveSourceAuthority -eq "selected-install-authority" -and $Owner -ne "installer") {
+      throw "Selected-install authority requires direct installer ownership."
+    }
+    $expectedSourceDataPath = Get-NormalizedPath -Path (Join-Path $normalizedSourceInstallDir "data")
+    if (-not (Test-SamePath -Left $normalizedSourceDataPath -Right $expectedSourceDataPath)) {
+      throw "Install source data is outside the exact installation directory."
+    }
+    return $normalizedSourceDataPath
+  }
+
+  if ($effectiveSourceAuthority -eq "relay-backup-authority") {
+    if ($Owner -ne "relay") {
+      throw "Relay backup authority requires relay ownership."
+    }
+    if (-not [string]::Equals(
+        (Split-Path -Leaf $normalizedSourceDataPath),
+        "data-backup",
+        [System.StringComparison]::OrdinalIgnoreCase
+      )) {
+      throw "Relay source data must be the validated data-backup directory."
+    }
+    $backupRoot = Split-Path -Parent $normalizedSourceDataPath
+    $backupParent = Split-Path -Parent $backupRoot
+    $expectedBackupParent = "$normalizedSourceInstallDir.memmy-upgrade-backup"
+    if (-not (Test-SamePath -Left $backupParent -Right $expectedBackupParent) -or
+        -not (Split-Path -Leaf $backupRoot)) {
+      throw "Relay source data is outside the validated installation backup directory."
+    }
+    return $normalizedSourceDataPath
+  }
+
+  if (-not $effectiveSourceGeneration) {
+    throw "A persisted install authority requires a recorded source generation."
+  }
+  $expectedPersistedDataPath = Get-NormalizedPath -Path (Join-Path $normalizedSourceInstallDir "data")
+  $failedBackupRoot = Split-Path -Parent $normalizedSourceDataPath
+  $failedBackupParent = Split-Path -Parent $failedBackupRoot
+  $expectedFailedBackupParent = Get-NormalizedPath -Path "$normalizedSourceInstallDir.memmy-migration-failed"
+  $isValidatedFailedBackup = [string]::Equals(
+      (Split-Path -Leaf $normalizedSourceDataPath),
+      "data-backup",
+      [System.StringComparison]::OrdinalIgnoreCase
+    ) -and
+    (Test-SamePath -Left $failedBackupParent -Right $expectedFailedBackupParent) -and
+    (Split-Path -Leaf $failedBackupRoot) -match '^[0-9]{14}-[a-f0-9]{32}$'
+  if (-not (Test-SamePath -Left $normalizedSourceDataPath -Right $expectedPersistedDataPath) -and
+      -not $isValidatedFailedBackup) {
+    throw "Persisted source data does not match its recorded installation directory."
+  }
+  return $normalizedSourceDataPath
+}
+
+function Resolve-SourceGeneration {
+  if ($effectiveSourceGeneration) {
+    return $effectiveSourceGeneration.Trim()
+  }
+  if ($effectiveSourceAuthority -eq "untrusted-residual") {
+    return $null
+  }
+  return "legacy-install:$((Get-NormalizedPath -Path $effectiveSourceInstallDir).ToLowerInvariant())"
+}
+
+function Test-CompleteInstallUserData {
+  param([Parameter(Mandatory = $true)][string]$Path)
+
+  return Test-Path -LiteralPath (Join-Path $Path "app.sqlite") -PathType Leaf
+}
+
+function Test-CompleteInstallRuntimeData {
+  param([Parameter(Mandatory = $true)][string]$Path)
+
+  return Test-Path -LiteralPath (Join-Path $Path "config.yaml") -PathType Leaf
+}
+
+function Read-InstallationRecord {
+  if (-not $InstallationRecordPath -or
+      -not (Test-Path -LiteralPath $InstallationRecordPath -PathType Leaf)) {
+    return $null
+  }
+  try {
+    $record = Get-Content -LiteralPath $InstallationRecordPath -Raw -Encoding UTF8 | ConvertFrom-Json
+    if ([int]$record.schemaVersion -ne 1 -or
+        -not $record.installDir -or
+        -not [System.IO.Path]::IsPathRooted([string]$record.installDir) -or
+        @("external-v1", "install-local-v1") -notcontains [string]$record.dataLayoutGeneration) {
+      Write-MigrationLog -Message "Ignoring an invalid installation data-layout record: $InstallationRecordPath"
+      return $null
+    }
+    return $record
+  }
+  catch {
+    Write-MigrationLog -Message "Ignoring an unreadable installation data-layout record: $($_.Exception.Message)"
+    return $null
+  }
+}
+
+function Test-IsKnownInstallLocalVersion {
+  if (-not $effectiveSourceInstalledVersion) { return $false }
+  $match = [Regex]::Match($effectiveSourceInstalledVersion.Trim(), '^(?<version>[0-9]+\.[0-9]+\.[0-9]+(?:\.[0-9]+)?)')
+  if (-not $match.Success) { return $false }
+  try {
+    $parsed = [Version]$match.Groups['version'].Value
+  }
+  catch {
+    return $false
+  }
+  return $parsed -ge [Version]'1.0.6' -and $parsed -lt [Version]'1.1.0'
+}
+
+function Resolve-EffectiveInstallSource {
+  $record = Read-InstallationRecord
+  if ($effectiveSourceAuthority -eq "untrusted-residual" -and
+      $null -ne $record -and
+      [string]$record.dataLayoutGeneration -eq "install-local-v1") {
+    $recordedInstallDir = Get-NormalizedPath -Path ([string]$record.installDir)
+    $script:effectiveSourceInstallDir = $recordedInstallDir
+    $script:effectiveSourceDataPath = if (
+      $record.PSObject.Properties.Name -contains "sourceDataPath" -and $record.sourceDataPath
+    ) {
+      Get-NormalizedPath -Path ([string]$record.sourceDataPath)
+    } else {
+      Get-NormalizedPath -Path (Join-Path $recordedInstallDir "data")
+    }
+    $script:effectiveSourceAuthority = "persisted-install-authority"
+    $script:effectiveSourceGeneration = if (
+      $record.PSObject.Properties.Name -contains "sourceGeneration" -and $record.sourceGeneration
+    ) {
+      [string]$record.sourceGeneration
+    } else {
+      "legacy-install:$($recordedInstallDir.ToLowerInvariant())"
+    }
+    Write-MigrationLog -Message "Using the persisted trusted install-local source: $effectiveSourceDataPath"
+  }
+  elseif (@("current-install-authority", "selected-install-authority", "relay-backup-authority") -contains $effectiveSourceAuthority -and
+      $null -ne $record -and
+      [string]$record.dataLayoutGeneration -eq "external-v1" -and
+      (Test-SamePath -Left ([string]$record.installDir) -Right $effectiveSourceInstallDir)) {
+    if (@("current-install-authority", "relay-backup-authority") -contains $effectiveSourceAuthority -and
+        (Test-IsKnownInstallLocalVersion)) {
+      Write-MigrationLog -Message "Installed version $effectiveSourceInstalledVersion uses the install-local layout; it remains authoritative despite an earlier external marker."
+    }
+    else {
+      Write-MigrationLog -Message "Install is already verified on the external layout; install-local residual data cannot replace targets."
+      $script:effectiveSourceAuthority = "untrusted-residual"
+      $script:effectiveSourceGeneration = ""
+    }
+  }
+}
+
+function Record-TrustedInstallLocalGeneration {
+  if ($Owner -ne "installer" -or
+      -not $InstallationRecordPath -or
+      @("current-install-authority", "selected-install-authority", "persisted-install-authority") -notcontains $effectiveSourceAuthority) {
+    return
+  }
+  $userDataPath = Join-Path $effectiveSourceDataPath "Memmy"
+  $runtimePath = Join-Path $effectiveSourceDataPath ".memmy"
+  if (-not (Test-CompleteInstallUserData -Path $userDataPath) -and
+      -not (Test-CompleteInstallRuntimeData -Path $runtimePath)) {
+    return
+  }
+  Write-JsonFileAtomically -Path $InstallationRecordPath -Value ([ordered]@{
+    schemaVersion = 1
+    dataLayoutGeneration = "install-local-v1"
+    installDir = (Get-NormalizedPath -Path $effectiveSourceInstallDir)
+    sourceDataPath = (Get-NormalizedPath -Path $effectiveSourceDataPath)
+    sourceGeneration = (Resolve-SourceGeneration)
+    sourceAppVersion = $effectiveSourceInstalledVersion
+    recordedAt = [DateTime]::UtcNow.ToString("o")
+  })
+}
+
+function Preserve-FailedDirectMigrationSource {
+  if ($Mode -ne "Prepare" -or
+      $Owner -ne "installer" -or
+      -not $InstallationRecordPath -or
+      @("current-install-authority", "selected-install-authority", "persisted-install-authority") -notcontains $effectiveSourceAuthority -or
+      -not (Test-Path -LiteralPath $effectiveSourceDataPath -PathType Container)) {
+    return
+  }
+
+  $backupToken = "{0}-{1}" -f [DateTime]::UtcNow.ToString("yyyyMMddHHmmss"), ([Guid]::NewGuid().ToString("N"))
+  $backupRoot = Join-Path "$effectiveSourceInstallDir.memmy-migration-failed" $backupToken
+  $backupPath = Join-Path $backupRoot "data-backup"
+  try {
+    New-Item -ItemType Directory -Path $backupPath -Force -ErrorAction Stop | Out-Null
+    Copy-DirectoryContents -Source $effectiveSourceDataPath -Destination $backupPath
+    $sourceFingerprint = Get-DirectoryFingerprint -Path $effectiveSourceDataPath
+    $backupFingerprint = Get-DirectoryFingerprint -Path $backupPath
+    if ($sourceFingerprint.FileCount -ne $backupFingerprint.FileCount -or
+        $sourceFingerprint.TotalBytes -ne $backupFingerprint.TotalBytes) {
+      throw "Unmigrated source preservation verification failed."
+    }
+    Write-JsonFileAtomically -Path $InstallationRecordPath -Value ([ordered]@{
+      schemaVersion = 1
+      dataLayoutGeneration = "install-local-v1"
+      installDir = (Get-NormalizedPath -Path $effectiveSourceInstallDir)
+      sourceDataPath = (Get-NormalizedPath -Path $backupPath)
+      sourceGeneration = (Resolve-SourceGeneration)
+      sourceAppVersion = $effectiveSourceInstalledVersion
+      migrationFailed = $true
+      recordedAt = [DateTime]::UtcNow.ToString("o")
+    })
+    Write-MigrationLog -Message "Preserved unmigrated install data for manual or automatic retry at $backupPath"
+  }
+  catch {
+    if (Test-Path -LiteralPath $backupRoot) {
+      Remove-Item -LiteralPath $backupRoot -Recurse -Force -ErrorAction SilentlyContinue
+    }
+    Write-MigrationLog -Message "Unable to preserve an additional unmigrated install-data copy; the original source was left untouched: $($_.Exception.Message)"
+  }
+}
+
+function Open-CriticalFilesForMigration {
+  param([Parameter(Mandatory = $true)][string]$RootPath)
+
+  if (-not (Test-Path -LiteralPath $RootPath -PathType Container)) {
+    return @()
+  }
+
+  $streams = @()
+  $criticalFiles = Get-ChildItem -LiteralPath $RootPath -Recurse -Force -File -ErrorAction Stop |
+    Where-Object { $_.Name -match '(?i)(\.sqlite(?:-wal|-shm)?|\.db(?:-wal|-shm)?)$' }
+  try {
+    foreach ($file in $criticalFiles) {
+      try {
+        $streams += [System.IO.File]::Open(
+          $file.FullName,
+          [System.IO.FileMode]::Open,
+          [System.IO.FileAccess]::Read,
+          [System.IO.FileShare]::Read
+        )
+      }
+      catch {
+        throw "Data file is still in use: $($file.FullName)"
+      }
+    }
+    return @($streams)
+  }
+  catch {
+    foreach ($stream in $streams) { $stream.Dispose() }
+    throw
+  }
+}
+
+function Get-DirectoryFingerprint {
+  param(
+    [Parameter(Mandatory = $true)][string]$Path,
+    [string[]]$ExcludeTopLevelNames = @()
+  )
+
+  $files = @()
+  foreach ($item in @(Get-ChildItem -LiteralPath $Path -Force -ErrorAction Stop)) {
+    if ($ExcludeTopLevelNames -contains $item.Name) { continue }
+    if ($item.PSIsContainer) {
+      $files += @(Get-ChildItem -LiteralPath $item.FullName -Recurse -Force -File -ErrorAction Stop)
+    }
+    else {
+      $files += $item
+    }
+  }
+  $totalBytes = [Int64]0
+  foreach ($file in $files) {
+    $totalBytes += $file.Length
+  }
+  return [PSCustomObject]@{
+    FileCount = $files.Count
+    TotalBytes = $totalBytes
+  }
+}
+
+function Test-DirectoryContainsData {
+  param(
+    [Parameter(Mandatory = $true)][string]$Path,
+    [string[]]$ExcludeTopLevelNames = @()
+  )
+
+  if (-not (Test-Path -LiteralPath $Path -PathType Container)) {
+    return $false
+  }
+  foreach ($item in @(Get-ChildItem -LiteralPath $Path -Force -ErrorAction Stop)) {
+    if ($ExcludeTopLevelNames -contains $item.Name) { continue }
+    if (-not $item.PSIsContainer) { return $true }
+    if ($null -ne (Get-ChildItem -LiteralPath $item.FullName -Recurse -Force -File -ErrorAction Stop |
+        Select-Object -First 1)) {
+      return $true
+    }
+  }
+  return $false
+}
+
+function Copy-DirectoryContents {
+  param(
+    [Parameter(Mandatory = $true)][string]$Source,
+    [Parameter(Mandatory = $true)][string]$Destination,
+    [string[]]$ExcludeTopLevelNames = @()
+  )
+
+  New-Item -ItemType Directory -Path $Destination -Force | Out-Null
+  foreach ($item in @(Get-ChildItem -LiteralPath $Source -Force -ErrorAction Stop)) {
+    if ($ExcludeTopLevelNames -contains $item.Name) { continue }
+    Copy-Item -LiteralPath $item.FullName -Destination $Destination -Recurse -Force -ErrorAction Stop
+  }
+}
+
+function Replace-TextOrdinalIgnoreCase {
+  param(
+    [Parameter(Mandatory = $true)][string]$Text,
+    [Parameter(Mandatory = $true)][string]$Search,
+    [Parameter(Mandatory = $true)][string]$Replacement
+  )
+
+  if (-not $Search) { return $Text }
+  $builder = New-Object System.Text.StringBuilder
+  $offset = 0
+  while ($true) {
+    $index = $Text.IndexOf($Search, $offset, [System.StringComparison]::OrdinalIgnoreCase)
+    if ($index -lt 0) { break }
+    [void]$builder.Append($Text.Substring($offset, $index - $offset))
+    [void]$builder.Append($Replacement)
+    $offset = $index + $Search.Length
+  }
+  [void]$builder.Append($Text.Substring($offset))
+  return $builder.ToString()
+}
+
+function Update-StagedRuntimeConfigDefaults {
+  param(
+    [Parameter(Mandatory = $true)][string]$StagingPath,
+    [Parameter(Mandatory = $true)][string]$SourceRuntimeHomePath,
+    [Parameter(Mandatory = $true)][string]$TargetRuntimeHomePath
+  )
+
+  $configPath = Join-Path $StagingPath "config.yaml"
+  if (-not (Test-Path -LiteralPath $configPath -PathType Leaf)) { return $false }
+
+  $sourceWorkspacePath = Join-Path $SourceRuntimeHomePath "workspace"
+  $targetWorkspacePath = Join-Path $TargetRuntimeHomePath "workspace"
+  $sourceMemoryDatabasePath = Join-Path $SourceRuntimeHomePath "memory-service\memory.sqlite"
+  $targetMemoryDatabasePath = Join-Path $TargetRuntimeHomePath "memory-service\memory.sqlite"
+  $original = [System.IO.File]::ReadAllText($configPath, [System.Text.Encoding]::UTF8)
+  $updated = $original
+  foreach ($replacement in @(
+      @($sourceWorkspacePath, $targetWorkspacePath),
+      @($sourceWorkspacePath.Replace('\', '/'), $targetWorkspacePath.Replace('\', '/')),
+      @($sourceWorkspacePath.Replace('\', '\\'), $targetWorkspacePath.Replace('\', '\\')),
+      @($sourceMemoryDatabasePath, $targetMemoryDatabasePath),
+      @($sourceMemoryDatabasePath.Replace('\', '/'), $targetMemoryDatabasePath.Replace('\', '/')),
+      @($sourceMemoryDatabasePath.Replace('\', '\\'), $targetMemoryDatabasePath.Replace('\', '\\'))
+    )) {
+    $updated = Replace-TextOrdinalIgnoreCase `
+      -Text $updated `
+      -Search ([string]$replacement[0]) `
+      -Replacement ([string]$replacement[1])
+  }
+  if ([string]::Equals($original, $updated, [System.StringComparison]::Ordinal)) { return $false }
+
+  $temporaryPath = "$configPath.rebase-$([Guid]::NewGuid().ToString('N')).tmp"
+  try {
+    [System.IO.File]::WriteAllText(
+      $temporaryPath,
+      $updated,
+      (New-Object System.Text.UTF8Encoding($false))
+    )
+    Move-Item -LiteralPath $temporaryPath -Destination $configPath -Force -ErrorAction Stop
+  }
+  finally {
+    if (Test-Path -LiteralPath $temporaryPath) {
+      Remove-Item -LiteralPath $temporaryPath -Force -ErrorAction SilentlyContinue
+    }
+  }
+  return $true
+}
+
+function Update-StagedStandaloneSessionBindings {
+  param(
+    [Parameter(Mandatory = $true)][string]$StagingPath,
+    [Parameter(Mandatory = $true)][string]$SourceRuntimeHomePath,
+    [Parameter(Mandatory = $true)][string]$TargetRuntimeHomePath
+  )
+
+  $sessionsPath = Join-Path $StagingPath "workspace\sessions"
+  if (-not (Test-Path -LiteralPath $sessionsPath -PathType Container)) { return 0 }
+  $sourceWorkspacePath = Join-Path $SourceRuntimeHomePath "workspace"
+  $targetWorkspacePath = Join-Path $TargetRuntimeHomePath "workspace"
+  $updatedCount = 0
+  $utf8 = New-Object System.Text.UTF8Encoding($false)
+
+  foreach ($sessionFile in @(Get-ChildItem -LiteralPath $sessionsPath -Filter "*.jsonl" -File -Recurse -ErrorAction Stop)) {
+    $bytes = [System.IO.File]::ReadAllBytes($sessionFile.FullName)
+    if ($bytes.Length -eq 0) { continue }
+    $newlineIndex = -1
+    for ($index = 0; $index -lt $bytes.Length; $index++) {
+      if ($bytes[$index] -eq 0x0a) {
+        $newlineIndex = $index
+        break
+      }
+    }
+    $firstLineLength = if ($newlineIndex -ge 0) { $newlineIndex } else { $bytes.Length }
+    if ($firstLineLength -gt 0 -and $bytes[$firstLineLength - 1] -eq 0x0d) {
+      $firstLineLength--
+    }
+    $firstLine = [System.Text.Encoding]::UTF8.GetString($bytes, 0, $firstLineLength).TrimStart([char]0xfeff)
+    try {
+      $record = $firstLine | ConvertFrom-Json -ErrorAction Stop
+    }
+    catch {
+      # Older runtime builds can leave plain-text or otherwise non-session JSONL
+      # files in this directory. They are user data, so preserve them verbatim.
+      continue
+    }
+    $metadataProperty = $record.PSObject.Properties["metadata"]
+    $keyProperty = $record.PSObject.Properties["key"]
+    if ($null -eq $metadataProperty -or $null -eq $metadataProperty.Value -or
+        $null -eq $keyProperty -or -not ([string]$keyProperty.Value).StartsWith("websocket:", [System.StringComparison]::Ordinal)) {
+      continue
+    }
+    $metadata = $metadataProperty.Value
+    $webuiProperty = $metadata.PSObject.Properties["webui"]
+    $projectProperty = $metadata.PSObject.Properties["webuiProjectId"]
+    $workspaceProperty = $metadata.PSObject.Properties["webuiWorkspaceCwd"]
+    if ($null -eq $webuiProperty -or $webuiProperty.Value -ne $true -or
+        $null -eq $projectProperty -or $null -ne $projectProperty.Value -or
+        $null -eq $workspaceProperty -or -not ($workspaceProperty.Value -is [string]) -or
+        -not (Test-SamePath -Left ([string]$workspaceProperty.Value) -Right $sourceWorkspacePath)) {
+      continue
+    }
+
+    $workspaceProperty.Value = $targetWorkspacePath
+    $updatedFirstLineBytes = $utf8.GetBytes(($record | ConvertTo-Json -Compress -Depth 100))
+    $suffixOffset = if ($newlineIndex -ge 0) { $firstLineLength } else { $bytes.Length }
+    $updatedBytes = New-Object byte[] ($updatedFirstLineBytes.Length + $bytes.Length - $suffixOffset)
+    [System.Buffer]::BlockCopy($updatedFirstLineBytes, 0, $updatedBytes, 0, $updatedFirstLineBytes.Length)
+    if ($suffixOffset -lt $bytes.Length) {
+      [System.Buffer]::BlockCopy(
+        $bytes,
+        $suffixOffset,
+        $updatedBytes,
+        $updatedFirstLineBytes.Length,
+        $bytes.Length - $suffixOffset
+      )
+    }
+    $temporaryPath = "$($sessionFile.FullName).rebase-$([Guid]::NewGuid().ToString('N')).tmp"
+    try {
+      [System.IO.File]::WriteAllBytes($temporaryPath, $updatedBytes)
+      Move-Item -LiteralPath $temporaryPath -Destination $sessionFile.FullName -Force -ErrorAction Stop
+    }
+    finally {
+      if (Test-Path -LiteralPath $temporaryPath) {
+        Remove-Item -LiteralPath $temporaryPath -Force -ErrorAction SilentlyContinue
+      }
+    }
+    $updatedCount++
+  }
+  return $updatedCount
+}
+
+function Update-StagedRuntimePaths {
+  param(
+    [Parameter(Mandatory = $true)][string]$StagingPath,
+    [Parameter(Mandatory = $true)][AllowEmptyCollection()][string[]]$SourceRuntimeHomePaths,
+    [Parameter(Mandatory = $true)][string]$TargetRuntimeHomePath
+  )
+
+  $configUpdated = $false
+  $sessionCount = 0
+  $processedSourcePaths = @()
+  foreach ($sourceRuntimeHomePath in @($SourceRuntimeHomePaths | Where-Object { $_ })) {
+    if (Test-SamePath -Left $sourceRuntimeHomePath -Right $TargetRuntimeHomePath) { continue }
+    if (@($processedSourcePaths | Where-Object { Test-SamePath -Left $_ -Right $sourceRuntimeHomePath }).Count -gt 0) {
+      continue
+    }
+    $processedSourcePaths += $sourceRuntimeHomePath
+    if (Update-StagedRuntimeConfigDefaults `
+        -StagingPath $StagingPath `
+        -SourceRuntimeHomePath $sourceRuntimeHomePath `
+        -TargetRuntimeHomePath $TargetRuntimeHomePath) {
+      $configUpdated = $true
+    }
+    $sessionCount += Update-StagedStandaloneSessionBindings `
+      -StagingPath $StagingPath `
+      -SourceRuntimeHomePath $sourceRuntimeHomePath `
+      -TargetRuntimeHomePath $TargetRuntimeHomePath
+  }
+  Write-MigrationLog -Message "Rebased staged runtime defaults config=$configUpdated standaloneSessions=$sessionCount sources=$($processedSourcePaths -join ';') target=$TargetRuntimeHomePath"
+}
+
+function Invoke-TransactionalDirectoryCopy {
+  param(
+    [Parameter(Mandatory = $true)][string]$Source,
+    [Parameter(Mandatory = $true)][string]$Destination,
+    [string[]]$ExcludeTopLevelNames = @(),
+    [Parameter(Mandatory = $true)][AllowEmptyCollection()][object[]]$PreviouslyPreparedCopies,
+    [Parameter(Mandatory = $true)][bool]$PreviousPointerExisted,
+    [AllowNull()][string]$PreviousPointerBytesBase64,
+    [AllowEmptyCollection()][object[]]$DeferredCleanupStates = @(),
+    [string[]]$RuntimeSourceHomePaths = @(),
+    [string]$RuntimeTargetHomePath = ""
+  )
+
+  if (Test-SamePath -Left $Source -Right $Destination) {
+    Write-MigrationLog -Message "Source already equals target: $Destination"
+    return $null
+  }
+
+  $criticalFileStreams = @(Open-CriticalFilesForMigration -RootPath $Source)
+  $destinationParent = Split-Path -Parent $Destination
+  if (-not (Test-Path -LiteralPath $destinationParent -PathType Container)) {
+    New-Item -ItemType Directory -Path $destinationParent -Force | Out-Null
+  }
+
+  $token = [Guid]::NewGuid().ToString("N")
+  $stagingPath = "$Destination.migrating-$token"
+  $backupPath = $null
+  $journalUpdated = $false
+  try {
+    Copy-DirectoryContents -Source $Source -Destination $stagingPath -ExcludeTopLevelNames $ExcludeTopLevelNames
+    $sourceFingerprint = Get-DirectoryFingerprint -Path $Source -ExcludeTopLevelNames $ExcludeTopLevelNames
+    $stagingFingerprint = Get-DirectoryFingerprint -Path $stagingPath
+    if ($sourceFingerprint.FileCount -ne $stagingFingerprint.FileCount -or
+        $sourceFingerprint.TotalBytes -ne $stagingFingerprint.TotalBytes) {
+      throw "Copied data verification failed for $Source"
+    }
+    if ($RuntimeSourceHomePaths.Count -gt 0 -and $RuntimeTargetHomePath) {
+      Update-StagedRuntimePaths `
+        -StagingPath $stagingPath `
+        -SourceRuntimeHomePaths $RuntimeSourceHomePaths `
+        -TargetRuntimeHomePath $RuntimeTargetHomePath
+    }
+
+    $destinationExisted = Test-Path -LiteralPath $Destination
+    $backupPath = if ($destinationExisted) { "$Destination.migration-backup-$token" } else { $null }
+    $copyRecord = [PSCustomObject]@{
+      SourcePath = $Source
+      DestinationPath = $Destination
+      BackupPath = $backupPath
+      StagingPath = $stagingPath
+    }
+    # Write-ahead: startup can safely roll back whether termination occurs before the
+    # destination move, between the two moves, or after the replacement.
+    Write-PreparedRollbackJournal `
+      -Copies @($PreviouslyPreparedCopies + $copyRecord) `
+      -PreviousPointerExisted $PreviousPointerExisted `
+      -PreviousPointerBytesBase64 $PreviousPointerBytesBase64 `
+      -DeferredCleanupStates $DeferredCleanupStates
+    $journalUpdated = $true
+
+    if ($destinationExisted) {
+      Move-Item -LiteralPath $Destination -Destination $backupPath -Force -ErrorAction Stop
+    }
+    Move-Item -LiteralPath $stagingPath -Destination $Destination -Force -ErrorAction Stop
+    Write-MigrationLog -Message "Prepared data copy: $Source -> $Destination"
+    return $copyRecord
+  }
+  catch {
+    $copyFailure = $_
+    try {
+      if (Test-Path -LiteralPath $stagingPath) {
+        Remove-Item -LiteralPath $stagingPath -Recurse -Force -ErrorAction Stop
+      }
+      if ($backupPath -and (Test-Path -LiteralPath $backupPath)) {
+        if (Test-Path -LiteralPath $Destination) {
+          Remove-Item -LiteralPath $Destination -Recurse -Force -ErrorAction Stop
+        }
+        Move-Item -LiteralPath $backupPath -Destination $Destination -Force -ErrorAction Stop
+      }
+      if ($journalUpdated) {
+        if ($PreviouslyPreparedCopies.Count -gt 0) {
+          Write-PreparedRollbackJournal `
+            -Copies $PreviouslyPreparedCopies `
+            -PreviousPointerExisted $PreviousPointerExisted `
+            -PreviousPointerBytesBase64 $PreviousPointerBytesBase64 `
+            -DeferredCleanupStates $DeferredCleanupStates
+        }
+        elseif (Test-Path -LiteralPath $StatePath -PathType Leaf) {
+          Remove-Item -LiteralPath $StatePath -Force -ErrorAction Stop
+        }
+      }
+    }
+    catch {
+      throw "Transactional copy failed and its original target could not be restored. Original data remains at '$backupPath'. Copy error: $($copyFailure.Exception.Message). Restore error: $($_.Exception.Message)"
+    }
+    throw $copyFailure
+  }
+  finally {
+    foreach ($stream in $criticalFileStreams) {
+      $stream.Dispose()
+    }
+  }
+}
+
+function Write-UnicodeFileAtomically {
+  param(
+    [Parameter(Mandatory = $true)][string]$Path,
+    [Parameter(Mandatory = $true)][string]$Value
+  )
+
+  Ensure-ParentDirectory -Path $Path
+  $temporaryPath = "$Path.tmp-$([Guid]::NewGuid().ToString('N'))"
+  $preamble = [System.Text.Encoding]::Unicode.GetPreamble()
+  $contents = [System.Text.Encoding]::Unicode.GetBytes($Value)
+  $bytes = New-Object byte[] ($preamble.Length + $contents.Length)
+  [Array]::Copy($preamble, 0, $bytes, 0, $preamble.Length)
+  [Array]::Copy($contents, 0, $bytes, $preamble.Length, $contents.Length)
+  [System.IO.File]::WriteAllBytes($temporaryPath, $bytes)
+  Move-Item -LiteralPath $temporaryPath -Destination $Path -Force
+}
+
+function Write-JsonFileAtomically {
+  param(
+    [Parameter(Mandatory = $true)][string]$Path,
+    [Parameter(Mandatory = $true)][object]$Value
+  )
+
+  Ensure-ParentDirectory -Path $Path
+  $temporaryPath = "$Path.tmp-$([Guid]::NewGuid().ToString('N'))"
+  $json = $Value | ConvertTo-Json -Depth 8
+  [System.IO.File]::WriteAllText(
+    $temporaryPath,
+    $json,
+    (New-Object System.Text.UTF8Encoding($false))
+  )
+  Move-Item -LiteralPath $temporaryPath -Destination $Path -Force
+}
+
+function Write-BytesFileAtomically {
+  param(
+    [Parameter(Mandatory = $true)][string]$Path,
+    [Parameter(Mandatory = $true)][AllowEmptyCollection()][byte[]]$Value
+  )
+
+  Ensure-ParentDirectory -Path $Path
+  $temporaryPath = "$Path.tmp-$([Guid]::NewGuid().ToString('N'))"
+  [System.IO.File]::WriteAllBytes($temporaryPath, $Value)
+  Move-Item -LiteralPath $temporaryPath -Destination $Path -Force
+}
+
+function Write-PreparedRollbackJournal {
+  param(
+    [Parameter(Mandatory = $true)][AllowEmptyCollection()][object[]]$Copies,
+    [Parameter(Mandatory = $true)][bool]$PreviousPointerExisted,
+    [AllowNull()][string]$PreviousPointerBytesBase64,
+    [AllowEmptyCollection()][object[]]$DeferredCleanupStates = @()
+  )
+
+  $backupPaths = @($Copies | ForEach-Object { $_.BackupPath } | Where-Object { $_ })
+  Write-JsonFileAtomically -Path $StatePath -Value ([ordered]@{
+    schemaVersion = 2
+    phase = "recovery-required"
+    owner = $Owner
+    sourceAuthority = $effectiveSourceAuthority
+    sourceGeneration = (Resolve-SourceGeneration)
+    sourceAppVersion = $effectiveSourceInstalledVersion
+    sourceInstallDir = if ($effectiveSourceInstallDir) { Get-NormalizedPath -Path $effectiveSourceInstallDir } else { $null }
+    sourceDataPath = (Get-NormalizedPath -Path $effectiveSourceDataPath)
+    targetUserDataPath = (Get-NormalizedPath -Path $TargetUserDataPath)
+    targetRuntimeHomePath = (Get-NormalizedPath -Path $TargetRuntimeHomePath)
+    pointerPath = (Get-NormalizedPath -Path $PointerPath)
+    backupPaths = @($backupPaths)
+    preparedCopies = @($Copies)
+    previousPointerExisted = $PreviousPointerExisted
+    previousPointerBytesBase64 = $PreviousPointerBytesBase64
+    deferredCleanupStates = @($DeferredCleanupStates)
+    journalOnly = $true
+    createdAt = [DateTime]::UtcNow.ToString("o")
+  })
+}
+
+function Restore-PreparedCopy {
+  param([Parameter(Mandatory = $true)]$Copy)
+
+  $destinationPath = [string]$Copy.DestinationPath
+  $backupPath = if ($Copy.BackupPath) { [string]$Copy.BackupPath } else { $null }
+  $stagingPath = if ($Copy.PSObject.Properties["StagingPath"] -and $Copy.StagingPath) { [string]$Copy.StagingPath } else { $null }
+  if ($stagingPath -and (Test-Path -LiteralPath $stagingPath)) {
+    Remove-Item -LiteralPath $stagingPath -Recurse -Force -ErrorAction Stop
+  }
+  if ($backupPath) {
+    if (Test-Path -LiteralPath $backupPath) {
+      if (Test-Path -LiteralPath $destinationPath) {
+        Remove-Item -LiteralPath $destinationPath -Recurse -Force -ErrorAction Stop
+      }
+      Move-Item -LiteralPath $backupPath -Destination $destinationPath -Force -ErrorAction Stop
+    }
+    elseif (-not (Test-Path -LiteralPath $destinationPath)) {
+      throw "Prepared migration backup and destination are both missing: $backupPath"
+    }
+    return
+  }
+
+  if (Test-Path -LiteralPath $destinationPath) {
+    Remove-Item -LiteralPath $destinationPath -Recurse -Force -ErrorAction Stop
+  }
+}
+
+function Undo-PreparedCopies {
+  param([Parameter(Mandatory = $true)][AllowEmptyCollection()][object[]]$Copies)
+
+  $copiesInReverse = @($Copies)
+  [Array]::Reverse($copiesInReverse)
+  foreach ($copy in $copiesInReverse) {
+    if ($null -eq $copy) {
+      continue
+    }
+    Restore-PreparedCopy -Copy $copy
+  }
+}
+
+function Rollback-PreparedMigration {
+  if (-not (Test-Path -LiteralPath $StatePath -PathType Leaf)) {
+    throw "Migration state is missing: $StatePath"
+  }
+
+  $state = Get-Content -LiteralPath $StatePath -Raw -Encoding UTF8 | ConvertFrom-Json
+  if (@("prepared", "recovery-required", "prepared-for-retry", "awaiting-app-verification", "app-verified") -notcontains [string]$state.phase) {
+    throw "Migration phase cannot be rolled back: $($state.phase)"
+  }
+  if (-not (Test-SamePath -Left $state.targetUserDataPath -Right $TargetUserDataPath) -or
+      -not (Test-SamePath -Left $state.targetRuntimeHomePath -Right $TargetRuntimeHomePath)) {
+    throw "Migration state target does not match the requested target."
+  }
+
+  $copies = @()
+  $preparedCopiesProperty = $state.PSObject.Properties["preparedCopies"]
+  if ($null -ne $preparedCopiesProperty) {
+    $copies = @($preparedCopiesProperty.Value)
+  }
+  else {
+    foreach ($backupPath in @($state.backupPaths)) {
+      if (-not $backupPath) { continue }
+      foreach ($targetPath in @($state.targetUserDataPath, $state.targetRuntimeHomePath)) {
+        $prefix = "$(Get-NormalizedPath -Path ([string]$targetPath)).migration-backup-"
+        $normalizedBackupPath = Get-NormalizedPath -Path ([string]$backupPath)
+        if ($normalizedBackupPath.StartsWith($prefix, [System.StringComparison]::OrdinalIgnoreCase)) {
+          $copies += [PSCustomObject]@{
+            DestinationPath = Get-NormalizedPath -Path ([string]$targetPath)
+            BackupPath = $normalizedBackupPath
+          }
+          break
+        }
+      }
+    }
+  }
+
+  $validatedCopies = @()
+  $validatedDestinationKeys = New-Object 'System.Collections.Generic.HashSet[string]' ([System.StringComparer]::OrdinalIgnoreCase)
+  foreach ($copy in $copies) {
+    if ($null -eq $copy -or -not $copy.DestinationPath) { continue }
+    $destinationPath = Get-NormalizedPath -Path ([string]$copy.DestinationPath)
+    if (-not (Test-SamePath -Left $destinationPath -Right $TargetUserDataPath) -and
+        -not (Test-SamePath -Left $destinationPath -Right $TargetRuntimeHomePath)) {
+      throw "Prepared copy destination is outside the requested migration targets: $destinationPath"
+    }
+    if (-not $validatedDestinationKeys.Add($destinationPath)) {
+      throw "Prepared migration state contains a duplicate destination: $destinationPath"
+    }
+    $backupPath = if ($copy.BackupPath) { Get-NormalizedPath -Path ([string]$copy.BackupPath) } else { $null }
+    if ($backupPath) {
+      $prefix = "$destinationPath.migration-backup-"
+      if (-not $backupPath.StartsWith($prefix, [System.StringComparison]::OrdinalIgnoreCase) -or
+          $backupPath.Substring($prefix.Length) -notmatch '^[a-f0-9]{32}$') {
+        throw "Prepared copy backup is outside the validated migration backup path: $backupPath"
+      }
+    }
+    $stagingPath = if ($copy.PSObject.Properties["StagingPath"] -and $copy.StagingPath) {
+      Get-NormalizedPath -Path ([string]$copy.StagingPath)
+    } else {
+      $null
+    }
+    if ($stagingPath) {
+      $stagingPrefix = "$destinationPath.migrating-"
+      if (-not $stagingPath.StartsWith($stagingPrefix, [System.StringComparison]::OrdinalIgnoreCase) -or
+          $stagingPath.Substring($stagingPrefix.Length) -notmatch '^[a-f0-9]{32}$') {
+        throw "Prepared copy staging path is outside the validated migration staging path: $stagingPath"
+      }
+    }
+    $validatedCopies += [PSCustomObject]@{
+      DestinationPath = $destinationPath
+      BackupPath = $backupPath
+      StagingPath = $stagingPath
+    }
+  }
+
+  $copiesInReverse = @($validatedCopies)
+  [Array]::Reverse($copiesInReverse)
+  foreach ($copy in $copiesInReverse) {
+    Restore-PreparedCopy -Copy $copy
+  }
+
+  $pointerExistedProperty = $state.PSObject.Properties["previousPointerExisted"]
+  if ($null -ne $pointerExistedProperty) {
+    if ([bool]$pointerExistedProperty.Value) {
+      $pointerBytesProperty = $state.PSObject.Properties["previousPointerBytesBase64"]
+      if ($null -eq $pointerBytesProperty) {
+        throw "Previous data-root pointer contents are unavailable."
+      }
+      $pointerBytes = [Convert]::FromBase64String([string]$pointerBytesProperty.Value)
+      Write-BytesFileAtomically -Path $PointerPath -Value $pointerBytes
+    }
+    elseif (Test-Path -LiteralPath $PointerPath) {
+      Remove-Item -LiteralPath $PointerPath -Force -ErrorAction Stop
+    }
+  }
+
+  Remove-Item -LiteralPath $StatePath -Force -ErrorAction Stop
+  Write-MigrationLog -Message "Prepared migration rolled back."
+}
+
+function Resume-PreservedMigrationForRetry {
+  if (-not (Test-Path -LiteralPath $StatePath -PathType Leaf)) {
+    return $false
+  }
+
+  $state = Get-Content -LiteralPath $StatePath -Raw -Encoding UTF8 | ConvertFrom-Json
+  if (@("prepared-for-retry", "app-verified") -notcontains [string]$state.phase) {
+    return $false
+  }
+  $statePointerPath = if ($state.PSObject.Properties.Name -contains "pointerPath") { [string]$state.pointerPath } else { $PointerPath }
+  if (-not (Test-SamePath -Left $state.targetUserDataPath -Right $TargetUserDataPath) -or
+      -not (Test-SamePath -Left $state.targetRuntimeHomePath -Right $TargetRuntimeHomePath) -or
+      -not (Test-SamePath -Left $statePointerPath -Right $PointerPath)) {
+    return $false
+  }
+
+  $currentTrustedDataPath = Resolve-TrustedInstallDataPath
+  if ($currentTrustedDataPath -and (
+      (Test-CompleteInstallUserData -Path (Join-Path $currentTrustedDataPath "Memmy")) -or
+      (Test-CompleteInstallRuntimeData -Path (Join-Path $currentTrustedDataPath ".memmy"))
+    )) {
+    Write-MigrationLog -Message "A current trusted install source supersedes the preserved migration state; rolling the preserved target back before preparing it."
+    Rollback-PreparedMigration
+    return $false
+  }
+
+  $statePreparedCopies = if ($state.PSObject.Properties.Name -contains "preparedCopies") { @($state.preparedCopies) } else { @() }
+  foreach ($copy in $statePreparedCopies) {
+    if ($null -ne $copy -and $copy.DestinationPath -and
+        -not (Test-Path -LiteralPath ([string]$copy.DestinationPath))) {
+      throw "Preserved migration destination is missing: $($copy.DestinationPath)"
+    }
+  }
+  $stateAccountAuthority = if ($state.PSObject.Properties.Name -contains "accountSourceAuthority") { [string]$state.accountSourceAuthority } else { "target-existing" }
+  $stateRuntimeAuthority = if ($state.PSObject.Properties.Name -contains "runtimeSourceAuthority") { [string]$state.runtimeSourceAuthority } else { "target-existing" }
+  if ($stateAccountAuthority -and
+      @("target-existing", "current-install-authority", "selected-install-authority", "relay-backup-authority", "persisted-install-authority") -notcontains $stateAccountAuthority) {
+    throw "Preserved migration account authority is invalid."
+  }
+  if ($stateRuntimeAuthority -and
+      @("target-existing", "legacy-home-fallback", "current-install-authority", "selected-install-authority", "relay-backup-authority", "persisted-install-authority") -notcontains $stateRuntimeAuthority) {
+    throw "Preserved migration runtime authority is invalid."
+  }
+  if ($stateAccountAuthority -ne "target-existing" -and
+      -not (Test-CompleteInstallUserData -Path $TargetUserDataPath)) {
+    throw "Preserved migrated account destination is incomplete."
+  }
+  if ($stateRuntimeAuthority -ne "target-existing" -and
+      -not (Test-CompleteInstallRuntimeData -Path $TargetRuntimeHomePath)) {
+    throw "Preserved migrated runtime destination is incomplete."
+  }
+
+  Write-UnicodeFileAtomically -Path $PointerPath -Value "$TargetRuntimeHomePath`r`n"
+  Write-MigrationLog -Message "Reusing preserved migration data without deleting its rollback artifacts."
+  return $true
+}
+
+function Recover-PreparedMigration {
+  if (-not (Test-Path -LiteralPath $StatePath -PathType Leaf)) {
+    throw "Migration state is missing: $StatePath"
+  }
+
+  $state = Get-Content -LiteralPath $StatePath -Raw -Encoding UTF8 | ConvertFrom-Json
+  $phase = [string]$state.phase
+  if (@("prepared-for-retry", "awaiting-app-verification", "app-verified") -contains $phase) {
+    Write-MigrationLog -Message "Migration recovery is already safe in phase $phase."
+    return
+  }
+  if (@("prepared", "recovery-required") -notcontains $phase) {
+    throw "Only a prepared migration can be recovered."
+  }
+  if (-not (Test-SamePath -Left $state.sourceDataPath -Right $SourceDataPath) -or
+      -not (Test-SamePath -Left $state.targetUserDataPath -Right $TargetUserDataPath) -or
+      -not (Test-SamePath -Left $state.targetRuntimeHomePath -Right $TargetRuntimeHomePath) -or
+      -not (Test-SamePath -Left $state.pointerPath -Right $PointerPath)) {
+    throw "Migration recovery paths do not match the prepared state."
+  }
+
+  $preparedCopies = @($state.preparedCopies | Where-Object { $null -ne $_ })
+  if ($preparedCopies.Count -eq 0) {
+    Rollback-PreparedMigration
+    return
+  }
+
+  $missingPreparedSource = $false
+  foreach ($copy in $preparedCopies) {
+    $sourcePaths = @()
+    if ($copy.PSObject.Properties["SourcePaths"]) {
+      $sourcePaths = @($copy.SourcePaths | Where-Object { $_ })
+    }
+    elseif ($copy.SourcePath) {
+      $sourcePaths = @([string]$copy.SourcePath)
+    }
+    if ($sourcePaths.Count -eq 0) {
+      $missingPreparedSource = $true
+      break
+    }
+    foreach ($preparedSourcePath in $sourcePaths) {
+      if (-not (Test-DirectoryContainsData -Path ([string]$preparedSourcePath) -ExcludeTopLevelNames @("updates"))) {
+        $missingPreparedSource = $true
+        break
+      }
+    }
+    if ($missingPreparedSource) { break }
+  }
+
+  if (-not $missingPreparedSource) {
+    Rollback-PreparedMigration
+    return
+  }
+
+  $state.phase = "prepared-for-retry"
+  $state | Add-Member -NotePropertyName recoveredAt -NotePropertyValue ([DateTime]::UtcNow.ToString("o")) -Force
+  Write-JsonFileAtomically -Path $StatePath -Value $state
+  Write-MigrationLog -Message "Old source is unavailable; preserved prepared data for an installation retry."
+}
+
+function Read-VerifiedPreviousMigrationForCarryForward {
+  if (-not (Test-Path -LiteralPath $StatePath -PathType Leaf)) {
+    return $null
+  }
+
+  $previousState = Get-Content -LiteralPath $StatePath -Raw -Encoding UTF8 | ConvertFrom-Json
+  if ([string]$previousState.phase -ne "app-verified") {
+    throw "A previous data migration still requires app verification. Open Memmy successfully before installing again."
+  }
+  if (-not $previousState.targetUserDataPath -or
+      -not $previousState.targetRuntimeHomePath -or
+      -not (Test-SamePath -Left ([string]$previousState.targetUserDataPath) -Right $TargetUserDataPath)) {
+    throw "Verified migration cleanup targets do not match the current trusted data layout. Open the existing Memmy again before changing its installation drive."
+  }
+
+  $rememberedRuntimeHomePath = Read-DataRootPointer -Path $PointerPath
+  $previousRuntimeTargetIsTrusted =
+    (Test-SamePath -Left ([string]$previousState.targetRuntimeHomePath) -Right $TargetRuntimeHomePath) -or
+    ($rememberedRuntimeHomePath -and
+      (Test-SamePath -Left ([string]$previousState.targetRuntimeHomePath) -Right $rememberedRuntimeHomePath))
+  if (-not $previousRuntimeTargetIsTrusted) {
+    throw "Verified migration cleanup targets do not match the current trusted data layout. Open the existing Memmy again before changing its installation drive."
+  }
+
+  Write-MigrationLog -Message "Carrying the previously verified migration rollback artifacts into the next migration transaction."
+  return $previousState
+}
+
+try {
+  if ($AcquireLock) {
+    Ensure-ParentDirectory -Path $LockPath
+    New-Item -ItemType Directory -Path $LockPath -ErrorAction Stop | Out-Null
+    $lockAcquiredHere = $true
+    if ($Owner -eq "installer") {
+      if ($InstallerPid -le 0 -or
+          -not $InstallerPath -or -not [System.IO.Path]::IsPathRooted($InstallerPath) -or
+          -not $InstallerInstallDir -or -not [System.IO.Path]::IsPathRooted($InstallerInstallDir)) {
+        throw "Direct installer identity is required before migration can acquire the update lock."
+      }
+      Write-JsonFileAtomically -Path (Join-Path $LockPath "state.json") -Value ([ordered]@{
+        schemaVersion = 3
+        owner = "installer"
+        phase = "direct-migration-running"
+        installerPid = $InstallerPid
+        installerPath = (Get-NormalizedPath -Path $InstallerPath)
+        installDir = (Get-NormalizedPath -Path $InstallerInstallDir)
+        targetUserDataPath = (Get-NormalizedPath -Path $TargetUserDataPath)
+        targetRuntimeHomePath = (Get-NormalizedPath -Path $TargetRuntimeHomePath)
+        createdAt = [DateTime]::UtcNow.ToString("o")
+      })
+    }
+  }
+  if (-not (Test-Path -LiteralPath $LockPath -PathType Container)) {
+    throw "Unified update lock is not held: $LockPath"
+  }
+
+  if ($Mode -eq "Prepare") {
+    Resolve-EffectiveInstallSource
+    if (Resume-PreservedMigrationForRetry) {
+      Write-MigrationLog -Message "Migration preparation resumed."
+    }
+    else {
+      $preparedCopies = @()
+      $preparedStateWritten = $false
+      $previousPointerExisted = $false
+      $previousPointerBytesBase64 = $null
+      [object[]]$deferredCleanupStates = @()
+      try {
+        $previousVerifiedState = Read-VerifiedPreviousMigrationForCarryForward
+        $previousPointerExisted = Test-Path -LiteralPath $PointerPath -PathType Leaf
+        $previousPointerBytesBase64 = if ($previousPointerExisted) {
+          [Convert]::ToBase64String([System.IO.File]::ReadAllBytes($PointerPath))
+        } else {
+          $null
+        }
+        $deferredCleanupStates = if ($null -ne $previousVerifiedState) {
+          ,$previousVerifiedState
+        } else {
+          @()
+        }
+        $rememberedRuntimeHomePath = Read-DataRootPointer -Path $PointerPath
+        $trustedInstallDataPath = Resolve-TrustedInstallDataPath
+        $resolvedSourceGeneration = Resolve-SourceGeneration
+        Record-TrustedInstallLocalGeneration
+        $installUserDataPath = if ($trustedInstallDataPath) {
+          Join-Path $trustedInstallDataPath "Memmy"
+        } else {
+          $null
+        }
+        $installRuntimeHomePath = if ($trustedInstallDataPath) {
+          Join-Path $trustedInstallDataPath ".memmy"
+        } else {
+          $null
+        }
+        $userDataExcludedNames = @(
+          "updates",
+          "data-root.txt",
+          "prepared-required-update.json",
+          "prepared-required-update.json.lock",
+          "prepared-required-update.json.prompt",
+          "prepared-required-update.json.attempt"
+        )
+
+        $targetUserDataHadData = Test-DirectoryContainsData `
+          -Path $TargetUserDataPath `
+          -ExcludeTopLevelNames $userDataExcludedNames
+        $accountSourcePath = if ($installUserDataPath -and
+            (Test-CompleteInstallUserData -Path $installUserDataPath)) {
+          Get-NormalizedPath -Path $installUserDataPath
+        } else {
+          $null
+        }
+        $accountSourceAuthority = if ($accountSourcePath) { $effectiveSourceAuthority } else { "target-existing" }
+        if ($accountSourcePath) {
+          $copy = Invoke-TransactionalDirectoryCopy `
+            -Source $accountSourcePath `
+            -Destination $TargetUserDataPath `
+            -ExcludeTopLevelNames $userDataExcludedNames `
+            -PreviouslyPreparedCopies $preparedCopies `
+            -PreviousPointerExisted $previousPointerExisted `
+            -PreviousPointerBytesBase64 $previousPointerBytesBase64 `
+            -DeferredCleanupStates $deferredCleanupStates
+          if ($null -ne $copy) {
+            $preparedCopies += $copy
+            $preparedStateWritten = $true
+          }
+          Write-MigrationLog -Message "Trusted install account data selected over target: $accountSourcePath"
+        }
+        elseif ($targetUserDataHadData) {
+          Write-MigrationLog -Message "No higher-authority account source exists; target user data retained."
+        }
+        elseif (-not (Test-Path -LiteralPath $TargetUserDataPath -PathType Container)) {
+          New-Item -ItemType Directory -Path $TargetUserDataPath -Force | Out-Null
+        }
+
+        $targetRuntimeHadData = Test-DirectoryContainsData `
+          -Path $TargetRuntimeHomePath `
+          -ExcludeTopLevelNames @("updates")
+        $runtimeSourcePath = if ($installRuntimeHomePath -and
+            (Test-CompleteInstallRuntimeData -Path $installRuntimeHomePath)) {
+          Get-NormalizedPath -Path $installRuntimeHomePath
+        } else {
+          $null
+        }
+        $runtimeSourceAuthority = if ($runtimeSourcePath) { $effectiveSourceAuthority } else { "target-existing" }
+        if (-not $runtimeSourcePath -and -not $targetRuntimeHadData) {
+          foreach ($candidate in @($rememberedRuntimeHomePath, $LegacyRuntimeHomePath)) {
+            if ($candidate -and
+                -not (Test-SamePath -Left $candidate -Right $TargetRuntimeHomePath) -and
+                (Test-DirectoryContainsData -Path $candidate -ExcludeTopLevelNames @("updates"))) {
+              $runtimeSourcePath = Get-NormalizedPath -Path $candidate
+              $runtimeSourceAuthority = "legacy-home-fallback"
+              break
+            }
+          }
+        }
+
+        if ($runtimeSourcePath) {
+          $runtimeRebaseSourceHomePaths = @($runtimeSourcePath)
+          if ($installRuntimeHomePath -and (Test-SamePath -Left $runtimeSourcePath -Right $installRuntimeHomePath)) {
+            $runtimeRebaseSourceHomePaths += Join-Path $effectiveSourceInstallDir "data\.memmy"
+          }
+          if ($LegacyRuntimeHomePath) {
+            $runtimeRebaseSourceHomePaths += $LegacyRuntimeHomePath
+          }
+          if ($rememberedRuntimeHomePath) {
+            $runtimeRebaseSourceHomePaths += $rememberedRuntimeHomePath
+          }
+          $copy = Invoke-TransactionalDirectoryCopy `
+            -Source $runtimeSourcePath `
+            -Destination $TargetRuntimeHomePath `
+            -ExcludeTopLevelNames @("updates") `
+            -PreviouslyPreparedCopies $preparedCopies `
+            -PreviousPointerExisted $previousPointerExisted `
+            -PreviousPointerBytesBase64 $previousPointerBytesBase64 `
+            -DeferredCleanupStates $deferredCleanupStates `
+            -RuntimeSourceHomePaths $runtimeRebaseSourceHomePaths `
+            -RuntimeTargetHomePath $TargetRuntimeHomePath
+          if ($null -ne $copy) {
+            $preparedCopies += $copy
+            $preparedStateWritten = $true
+          }
+          Write-MigrationLog -Message "Runtime data selected authority=$runtimeSourceAuthority source=$runtimeSourcePath"
+        }
+        elseif ($targetRuntimeHadData) {
+          Write-MigrationLog -Message "No higher-authority runtime source exists; target runtime data retained: $TargetRuntimeHomePath"
+        }
+        elseif (-not (Test-Path -LiteralPath $TargetRuntimeHomePath -PathType Container)) {
+          New-Item -ItemType Directory -Path $TargetRuntimeHomePath -Force | Out-Null
+        }
+
+        $runtimeSourcePaths = if ($runtimeSourcePath) { @($runtimeSourcePath) } else { @() }
+        $backupPaths = @($preparedCopies | ForEach-Object { $_.BackupPath } | Where-Object { $_ })
+        $state = [ordered]@{
+          schemaVersion = 2
+          phase = "prepared"
+          owner = $Owner
+          sourceAuthority = $effectiveSourceAuthority
+          sourceGeneration = $resolvedSourceGeneration
+          sourceAppVersion = $effectiveSourceInstalledVersion
+          sourceInstallDir = if ($effectiveSourceInstallDir) { Get-NormalizedPath -Path $effectiveSourceInstallDir } else { $null }
+          sourceDataPath = (Get-NormalizedPath -Path $effectiveSourceDataPath)
+          accountSourcePath = $accountSourcePath
+          accountSourceAuthority = $accountSourceAuthority
+          runtimeSourcePath = $runtimeSourcePath
+          runtimeSourcePaths = @($runtimeSourcePaths)
+          runtimeSourceAuthority = $runtimeSourceAuthority
+          categorySourcesShareGeneration = [bool]($accountSourcePath -and
+            $runtimeSourcePath -and
+            $runtimeSourceAuthority -eq $effectiveSourceAuthority)
+          targetUserDataHadData = $targetUserDataHadData
+          targetRuntimeHadData = $targetRuntimeHadData
+          targetUserDataPath = (Get-NormalizedPath -Path $TargetUserDataPath)
+          targetRuntimeHomePath = (Get-NormalizedPath -Path $TargetRuntimeHomePath)
+          pointerPath = (Get-NormalizedPath -Path $PointerPath)
+          backupPaths = @($backupPaths)
+          preparedCopies = @($preparedCopies)
+          previousPointerExisted = $previousPointerExisted
+          previousPointerBytesBase64 = $previousPointerBytesBase64
+          deferredCleanupStates = $deferredCleanupStates
+          createdAt = [DateTime]::UtcNow.ToString("o")
+        }
+        Write-JsonFileAtomically -Path $StatePath -Value $state
+        $preparedStateWritten = $true
+        Write-UnicodeFileAtomically -Path $PointerPath -Value "$TargetRuntimeHomePath`r`n"
+        Write-MigrationLog -Message "Migration preparation completed."
+      }
+      catch {
+        $prepareFailure = $_
+        if ($preparedCopies.Count -gt 0 -and -not $preparedStateWritten) {
+          try {
+            Write-PreparedRollbackJournal `
+              -Copies $preparedCopies `
+              -PreviousPointerExisted $previousPointerExisted `
+              -PreviousPointerBytesBase64 $previousPointerBytesBase64 `
+              -DeferredCleanupStates $deferredCleanupStates
+            $preparedStateWritten = $true
+          }
+          catch {
+            Write-MigrationLog -Message "Unable to persist the emergency rollback journal: $($_.Exception.Message)"
+          }
+        }
+        try {
+          Undo-PreparedCopies -Copies $preparedCopies
+          if ($preparedStateWritten -and (Test-Path -LiteralPath $StatePath)) {
+            Remove-Item -LiteralPath $StatePath -Force -ErrorAction SilentlyContinue
+          }
+        }
+        catch {
+          throw "Migration preparation failed and rollback requires recovery from '$StatePath'. Prepare error: $($prepareFailure.Exception.Message). Rollback error: $($_.Exception.Message)"
+        }
+        throw $prepareFailure
+      }
+    }
+  }
+  elseif ($Mode -eq "Complete") {
+    if (-not (Test-Path -LiteralPath $StatePath -PathType Leaf)) {
+      throw "Migration state is missing: $StatePath"
+    }
+    $state = Get-Content -LiteralPath $StatePath -Raw -Encoding UTF8 | ConvertFrom-Json
+    if (-not (Test-SamePath -Left $state.targetUserDataPath -Right $TargetUserDataPath) -or
+        -not (Test-SamePath -Left $state.targetRuntimeHomePath -Right $TargetRuntimeHomePath)) {
+      throw "Migration state target does not match the requested target."
+    }
+
+    foreach ($markerName in @(
+      "prepared-required-update.json",
+      "prepared-required-update.json.lock",
+      "prepared-required-update.json.prompt",
+      "prepared-required-update.json.attempt"
+    )) {
+      $markerPath = Join-Path $TargetUserDataPath $markerName
+      if (Test-Path -LiteralPath $markerPath) {
+        Remove-Item -LiteralPath $markerPath -Recurse -Force -ErrorAction Stop
+      }
+    }
+    $legacyUpdatesPath = Join-Path $TargetUserDataPath "updates"
+    if (Test-Path -LiteralPath $legacyUpdatesPath) {
+      Remove-Item -LiteralPath $legacyUpdatesPath -Recurse -Force -ErrorAction Stop
+    }
+
+    $state.phase = "awaiting-app-verification"
+    $state | Add-Member -NotePropertyName completedAt -NotePropertyValue ([DateTime]::UtcNow.ToString("o")) -Force
+    Write-JsonFileAtomically -Path $StatePath -Value $state
+    Write-MigrationLog -Message "Migration completion recorded; source and backups retained for app verification."
+  }
+  elseif ($Mode -eq "Rollback") {
+    Rollback-PreparedMigration
+  }
+  elseif ($Mode -eq "Recover") {
+    Recover-PreparedMigration
+  }
+  else {
+    if (-not (Test-Path -LiteralPath $StatePath -PathType Leaf)) {
+      throw "Migration state is missing: $StatePath"
+    }
+    $state = Get-Content -LiteralPath $StatePath -Raw -Encoding UTF8 | ConvertFrom-Json
+    if (-not (Test-SamePath -Left $state.targetUserDataPath -Right $TargetUserDataPath) -or
+        -not (Test-SamePath -Left $state.targetRuntimeHomePath -Right $TargetRuntimeHomePath)) {
+      throw "Migration state target does not match the requested target."
+    }
+    if (@("prepared", "recovery-required") -notcontains [string]$state.phase) {
+      throw "Only a prepared migration can require startup recovery."
+    }
+    $state.phase = "recovery-required"
+    $state | Add-Member -NotePropertyName recoveryRequiredAt -NotePropertyValue ([DateTime]::UtcNow.ToString("o")) -Force
+    Write-JsonFileAtomically -Path $StatePath -Value $state
+    Write-MigrationLog -Message "Migration marked as requiring startup rollback."
+  }
+  exit 0
+}
+catch {
+  try {
+    Preserve-FailedDirectMigrationSource
+  }
+  catch {}
+  if ($lockAcquiredHere -and (Test-Path -LiteralPath $LockPath)) {
+    Remove-Item -LiteralPath $LockPath -Recurse -Force -ErrorAction SilentlyContinue
+  }
+  try {
+    Write-MigrationLog -Message ("Migration failed: {0}" -f $_.Exception.Message)
+  }
+  catch {}
+  Write-Error $_.Exception.Message
+  exit 5
+}

--- a/App/shell/desktop/build/MemmyWindowsUpgradeRecovery.ps1
+++ b/App/shell/desktop/build/MemmyWindowsUpgradeRecovery.ps1
@@ -1,7 +1,14 @@
 param(
   [Parameter(Mandatory = $true)][string]$InstallDir,
   [Parameter(Mandatory = $true)][string]$LockPath,
-  [Parameter(Mandatory = $true)][string]$LogPath
+  [Parameter(Mandatory = $true)][string]$LogPath,
+  [string]$DirectMigrationStatePath = '',
+  [string]$DirectMigrationScriptPath = '',
+  [string]$DirectMigrationLogPath = '',
+  [string]$TargetUserDataPathOverride = '',
+  [string]$TargetRuntimeHomePathOverride = '',
+  [string]$LegacyRuntimeHomePathOverride = '',
+  [string]$MigrationStatePathOverride = ''
 )
 
 $ErrorActionPreference = 'Stop'
@@ -11,6 +18,46 @@ $expectedBackupParent = "$normalizedInstallDir.memmy-upgrade-backup"
 $normalizedLockPath = [System.IO.Path]::GetFullPath($LockPath).TrimEnd('\')
 $expectedStagingRoot = Split-Path -Parent $normalizedLockPath
 $statePath = Join-Path $LockPath 'state.json'
+$expectedTargetUserDataPath = if ($TargetUserDataPathOverride) {
+  [System.IO.Path]::GetFullPath($TargetUserDataPathOverride).TrimEnd('\')
+} else {
+  Join-Path $env:APPDATA 'Memmy'
+}
+$expectedTargetUserDataPath = [System.IO.Path]::GetFullPath([string]$expectedTargetUserDataPath).TrimEnd('\')
+$expectedLegacyRuntimeHomePath = if ($LegacyRuntimeHomePathOverride) {
+  [System.IO.Path]::GetFullPath($LegacyRuntimeHomePathOverride).TrimEnd('\')
+} else {
+  [System.IO.Path]::GetFullPath((Join-Path $env:USERPROFILE '.memmy')).TrimEnd('\')
+}
+$installDriveRoot = [System.IO.Path]::GetPathRoot($normalizedInstallDir)
+$expectedTargetRuntimeHomePath = if ($TargetRuntimeHomePathOverride) {
+  [System.IO.Path]::GetFullPath($TargetRuntimeHomePathOverride).TrimEnd('\')
+} elseif ([string]::Equals($installDriveRoot, 'C:\', [System.StringComparison]::OrdinalIgnoreCase)) {
+  $expectedLegacyRuntimeHomePath
+} else {
+  [System.IO.Path]::GetFullPath((Join-Path $installDriveRoot 'MemmyData\.memmy')).TrimEnd('\')
+}
+$expectedPointerPath = Join-Path $expectedTargetUserDataPath 'data-root.txt'
+$expectedMigrationStatePath = if ($MigrationStatePathOverride) {
+  [System.IO.Path]::GetFullPath($MigrationStatePathOverride).TrimEnd('\')
+} else {
+  [System.IO.Path]::GetFullPath((Join-Path $env:LOCALAPPDATA 'Memmy\data-migration\state.json')).TrimEnd('\')
+}
+$resolvedDirectMigrationStatePath = if ($DirectMigrationStatePath) {
+  [System.IO.Path]::GetFullPath($DirectMigrationStatePath).TrimEnd('\')
+} else {
+  $expectedMigrationStatePath
+}
+$resolvedDirectMigrationScriptPath = if ($DirectMigrationScriptPath) {
+  $DirectMigrationScriptPath
+} else {
+  Join-Path $PSScriptRoot 'MemmyWindowsDataMigration.ps1'
+}
+$resolvedDirectMigrationLogPath = if ($DirectMigrationLogPath) {
+  $DirectMigrationLogPath
+} else {
+  Join-Path $env:LOCALAPPDATA 'Memmy\upgrade-logs\data-migration.log'
+}
 
 function Write-MemmyUpgradeRecoveryLog([string]$Message) {
   $logDirectory = Split-Path -Parent $LogPath
@@ -22,6 +69,17 @@ function Write-MemmyUpgradeRecoveryLog([string]$Message) {
 
 function Resolve-MemmyNormalizedPath([string]$Path) {
   return [System.IO.Path]::GetFullPath($Path).TrimEnd('\')
+}
+
+function Assert-MemmySamePath([string]$Actual, [string]$Expected, [string]$Description) {
+  if (-not $Actual -or
+      -not [string]::Equals(
+        (Resolve-MemmyNormalizedPath $Actual),
+        (Resolve-MemmyNormalizedPath $Expected),
+        [System.StringComparison]::OrdinalIgnoreCase
+      )) {
+    throw "$Description does not match the trusted recovery path"
+  }
 }
 
 function Test-MemmyUpgradeProcessRunning($ProcessId, $StartedAtUtc, [string]$ExpectedPath = '') {
@@ -104,11 +162,121 @@ function Move-MemmyRecoveryDirectory([string]$Source, [string]$Destination) {
 }
 
 function Clear-MemmyRecoveryTransientMarkers {
-  $markerPath = Join-Path $dataPath 'Memmy\prepared-required-update.json'
-  foreach ($path in @("$markerPath.lock", "$markerPath.prompt")) {
-    Remove-Item -LiteralPath $path -Recurse -Force -ErrorAction SilentlyContinue
+  $markerPaths = @(
+    (Join-Path $dataPath 'Memmy\prepared-required-update.json'),
+    (Join-Path $expectedTargetUserDataPath 'prepared-required-update.json')
+  )
+  foreach ($markerPath in $markerPaths) {
+    foreach ($path in @("$markerPath.lock", "$markerPath.prompt")) {
+      Remove-Item -LiteralPath $path -Recurse -Force -ErrorAction SilentlyContinue
+    }
   }
   Write-MemmyUpgradeRecoveryLog "cleared transient prepared-update lock and prompt markers"
+}
+
+function Read-MemmyMigrationState([string]$MigrationStatePath) {
+  if (-not $MigrationStatePath -or -not (Test-Path -LiteralPath $MigrationStatePath -PathType Leaf)) {
+    return $null
+  }
+  return Get-Content -LiteralPath $MigrationStatePath -Raw -Encoding UTF8 | ConvertFrom-Json
+}
+
+function Invoke-MemmyMigrationRecovery(
+  [ValidateSet('Rollback', 'Recover')][string]$Mode,
+  [string]$MigrationStatePath,
+  [string]$MigrationScriptPath,
+  [string]$MigrationLogPath,
+  [ValidateSet('relay', 'installer')][string]$ExpectedOwner,
+  [string]$ExpectedSourceDataPath = ''
+) {
+  $migrationState = Read-MemmyMigrationState -MigrationStatePath $MigrationStatePath
+  if ($null -eq $migrationState) {
+    throw "migration state is unavailable: $MigrationStatePath"
+  }
+  if ([string]$migrationState.owner -ne $ExpectedOwner) {
+    throw "migration state owner does not match recovery owner $ExpectedOwner"
+  }
+  if (-not (Test-Path -LiteralPath $MigrationScriptPath -PathType Leaf)) {
+    throw "migration recovery helper is unavailable: $MigrationScriptPath"
+  }
+
+  $migrationSourcePath = [string]$migrationState.sourceDataPath
+  if (-not $migrationSourcePath -or -not $migrationState.targetUserDataPath -or
+      -not $migrationState.targetRuntimeHomePath -or -not $migrationState.pointerPath) {
+    throw "migration state is missing required recovery paths"
+  }
+  Assert-MemmySamePath -Actual ([string]$migrationState.targetUserDataPath) -Expected $expectedTargetUserDataPath -Description 'migration user-data target'
+  Assert-MemmySamePath -Actual ([string]$migrationState.targetRuntimeHomePath) -Expected $expectedTargetRuntimeHomePath -Description 'migration runtime target'
+  Assert-MemmySamePath -Actual ([string]$migrationState.pointerPath) -Expected $expectedPointerPath -Description 'migration data-root pointer'
+  if ($ExpectedSourceDataPath) {
+    Assert-MemmySamePath -Actual $migrationSourcePath -Expected $ExpectedSourceDataPath -Description 'migration source'
+  }
+
+  $migrationSourceAuthority = if ($migrationState.sourceAuthority) {
+    [string]$migrationState.sourceAuthority
+  } elseif ($ExpectedOwner -eq 'relay') {
+    'relay-backup-authority'
+  } else {
+    'current-install-authority'
+  }
+  $migrationSourceInstallDir = if ($migrationState.sourceInstallDir) {
+    [string]$migrationState.sourceInstallDir
+  } elseif ($ExpectedOwner -eq 'relay') {
+    $normalizedInstallDir
+  } else {
+    Split-Path -Parent $migrationSourcePath
+  }
+
+  $powershellPath = Join-Path $PSHOME 'powershell.exe'
+  & $powershellPath @(
+    '-NoProfile',
+    '-NonInteractive',
+    '-ExecutionPolicy', 'Bypass',
+    '-File', $MigrationScriptPath,
+    '-Mode', $Mode,
+    '-SourceDataPath', $migrationSourcePath,
+    '-SourceAuthority', $migrationSourceAuthority,
+    '-SourceInstallDir', $migrationSourceInstallDir,
+    '-LegacyRuntimeHomePath', $expectedLegacyRuntimeHomePath,
+    '-TargetUserDataPath', $expectedTargetUserDataPath,
+    '-TargetRuntimeHomePath', $expectedTargetRuntimeHomePath,
+    '-PointerPath', $expectedPointerPath,
+    '-StatePath', $MigrationStatePath,
+    '-LockPath', $LockPath,
+    '-LogPath', $MigrationLogPath,
+    '-Owner', $ExpectedOwner
+  )
+  if ($LASTEXITCODE -ne 0) {
+    throw "migration $Mode recovery failed with exit code $LASTEXITCODE"
+  }
+  Write-MemmyUpgradeRecoveryLog "migration $Mode recovery completed for $ExpectedOwner"
+}
+
+function Recover-MemmyDirectMigration {
+  Assert-MemmySamePath -Actual $resolvedDirectMigrationStatePath -Expected $expectedMigrationStatePath -Description 'direct migration state'
+  $migrationState = Read-MemmyMigrationState -MigrationStatePath $resolvedDirectMigrationStatePath
+  if ($null -eq $migrationState) {
+    return $false
+  }
+  if ([string]$migrationState.owner -ne 'installer') {
+    return $false
+  }
+
+  $migrationPhase = [string]$migrationState.phase
+  if (@('prepared', 'recovery-required') -contains $migrationPhase) {
+    Invoke-MemmyMigrationRecovery `
+      -Mode Recover `
+      -MigrationStatePath $resolvedDirectMigrationStatePath `
+      -MigrationScriptPath $resolvedDirectMigrationScriptPath `
+      -MigrationLogPath $resolvedDirectMigrationLogPath `
+      -ExpectedOwner installer
+  }
+  elseif (@('prepared-for-retry', 'awaiting-app-verification', 'app-verified') -notcontains $migrationPhase) {
+    throw "direct migration state has an unsupported phase: $migrationPhase"
+  }
+
+  Write-MemmyUpgradeRecoveryLog "stale direct-install migration recovered in phase $migrationPhase"
+  return $true
 }
 
 if (-not (Test-Path -LiteralPath $LockPath -PathType Container)) {
@@ -118,9 +286,20 @@ if (-not (Test-Path -LiteralPath $LockPath -PathType Container)) {
 try {
   if (-not (Test-Path -LiteralPath $statePath -PathType Leaf)) {
     $lockAge = (Get-Date) - (Get-Item -LiteralPath $LockPath).LastWriteTime
-    if ($lockAge.TotalMinutes -lt 2 -or -not (Test-Path -LiteralPath $dataPath -PathType Container)) {
+    if ($lockAge.TotalMinutes -lt 2) {
       Write-MemmyUpgradeRecoveryLog "active lock has no recovery state; leaving it in place"
       exit 2
+    }
+    if (Recover-MemmyDirectMigration) {
+      Clear-MemmyRecoveryTransientMarkers
+      Remove-Item -LiteralPath $LockPath -Recurse -Force
+      Write-MemmyUpgradeRecoveryLog "cleared stale direct-install lock after migration recovery"
+      exit 0
+    }
+    if (-not (Test-Path -LiteralPath $dataPath -PathType Container)) {
+      Remove-Item -LiteralPath $LockPath -Recurse -Force
+      Write-MemmyUpgradeRecoveryLog "cleared stale state-less lock without installed data so installation can be retried"
+      exit 0
     }
     Clear-MemmyRecoveryTransientMarkers
     Remove-Item -LiteralPath $LockPath -Recurse -Force
@@ -130,7 +309,49 @@ try {
 
   $state = Get-Content -LiteralPath $statePath -Raw | ConvertFrom-Json
   $phase = [string]$state.phase
-  if (@('relay-ready', 'data-moved', 'installer-starting', 'installer-running', 'installer-exited') -notcontains $phase) {
+  if ([string]$state.owner -eq 'installer') {
+    if ($phase -ne 'direct-migration-running') {
+      throw "direct installer recovery state has an unsupported phase: $phase"
+    }
+    if (-not $state.installDir -or -not $state.installerPath -or -not $state.installerPid) {
+      throw "direct installer recovery state is missing process identity"
+    }
+    if (Test-MemmyUpgradeProcessRunning $state.installerPid $null ([string]$state.installerPath)) {
+      Write-MemmyUpgradeRecoveryLog "direct installer is still running; leaving active lock in place"
+      exit 2
+    }
+
+    $directInstallDir = Resolve-MemmyNormalizedPath ([string]$state.installDir)
+    $directInstallRoot = [System.IO.Path]::GetPathRoot($directInstallDir)
+    $directExpectedRuntimeHomePath = if ($TargetRuntimeHomePathOverride) {
+      $expectedTargetRuntimeHomePath
+    } elseif ([string]::Equals($directInstallRoot, 'C:\', [System.StringComparison]::OrdinalIgnoreCase)) {
+      $expectedLegacyRuntimeHomePath
+    } else {
+      Resolve-MemmyNormalizedPath (Join-Path $directInstallRoot 'MemmyData\.memmy')
+    }
+    Assert-MemmySamePath -Actual ([string]$state.targetUserDataPath) -Expected $expectedTargetUserDataPath -Description 'direct-lock user-data target'
+    Assert-MemmySamePath -Actual ([string]$state.targetRuntimeHomePath) -Expected $directExpectedRuntimeHomePath -Description 'direct-lock runtime target'
+    $expectedTargetRuntimeHomePath = $directExpectedRuntimeHomePath
+    $dataPath = Join-Path $directInstallDir 'data'
+
+    if (Recover-MemmyDirectMigration) {
+      Clear-MemmyRecoveryTransientMarkers
+      Remove-Item -LiteralPath $LockPath -Recurse -Force
+      Write-MemmyUpgradeRecoveryLog "cleared direct-install lock after the installer exited and migration recovery completed"
+      exit 0
+    }
+    if (-not (Test-Path -LiteralPath $dataPath -PathType Container)) {
+      Remove-Item -LiteralPath $LockPath -Recurse -Force
+      Write-MemmyUpgradeRecoveryLog "cleared direct-install lock after the installer exited without migrated data"
+      exit 0
+    }
+    Clear-MemmyRecoveryTransientMarkers
+    Remove-Item -LiteralPath $LockPath -Recurse -Force
+    Write-MemmyUpgradeRecoveryLog "cleared direct-install lock after the installer exited with installed data present"
+    exit 0
+  }
+  if (@('relay-ready', 'data-moved', 'migration-prepared', 'migration-skipped', 'installer-starting', 'installer-running', 'installer-exited', 'migration-completed', 'migration-recovery-required') -notcontains $phase) {
     throw "recovery state has an unsupported phase: $phase"
   }
   $stateInstallDir = Resolve-MemmyNormalizedPath ([string]$state.installDir)
@@ -139,6 +360,12 @@ try {
   $backupRoot = Resolve-MemmyNormalizedPath ([string]$state.backupRoot)
   if (-not [string]::Equals($stateInstallDir, $normalizedInstallDir, [System.StringComparison]::OrdinalIgnoreCase)) {
     throw "recovery state install directory does not match launcher install directory"
+  }
+  if ([int]$state.schemaVersion -ge 3) {
+    Assert-MemmySamePath -Actual ([string]$state.migrationStatePath) -Expected $expectedMigrationStatePath -Description 'relay migration state'
+    Assert-MemmySamePath -Actual ([string]$state.targetUserDataPath) -Expected $expectedTargetUserDataPath -Description 'relay user-data target'
+    Assert-MemmySamePath -Actual ([string]$state.targetRuntimeHomePath) -Expected $expectedTargetRuntimeHomePath -Description 'relay runtime target'
+    Assert-MemmySamePath -Actual ([string]$state.legacyRuntimeHomePath) -Expected $expectedLegacyRuntimeHomePath -Description 'relay legacy runtime root'
   }
   if (-not [string]::Equals((Split-Path -Parent $stateWorkDir), $expectedStagingRoot, [System.StringComparison]::OrdinalIgnoreCase)) {
     throw "recovery state work directory is outside the expected staging directory"
@@ -159,6 +386,19 @@ try {
       ($phase -eq 'installer-starting' -and (Test-MemmyInstallerPathRunning $stateInstallerPath))) {
     Write-MemmyUpgradeRecoveryLog "upgrade process is still running; leaving active lock in place"
     exit 2
+  }
+
+  $relayMigrationStatePath = if ([int]$state.schemaVersion -ge 3) { $expectedMigrationStatePath } else { '' }
+  $relayMigrationState = Read-MemmyMigrationState -MigrationStatePath $relayMigrationStatePath
+  $relayMigrationPhase = if ($null -ne $relayMigrationState) { [string]$relayMigrationState.phase } else { '' }
+  if ($phase -eq 'migration-completed' -or
+      @('awaiting-app-verification', 'app-verified') -contains $relayMigrationPhase) {
+    Remove-Item -LiteralPath $LockPath -Recurse -Force
+    Write-MemmyUpgradeRecoveryLog "completed migration lock cleared without restoring install-local data"
+    if (Test-Path -LiteralPath $stateWorkDir -PathType Container) {
+      Remove-Item -LiteralPath $stateWorkDir -Recurse -Force -ErrorAction SilentlyContinue
+    }
+    exit 0
   }
 
   $backupPath = Join-Path $backupRoot 'data-backup'
@@ -182,6 +422,31 @@ try {
     throw "both installed data and upgrade backup are missing"
   }
 
+  if (@('prepared', 'recovery-required') -contains $relayMigrationPhase) {
+    $relayMigrationLogPath = if ($state.migrationLogPath) {
+      [string]$state.migrationLogPath
+    } else {
+      $resolvedDirectMigrationLogPath
+    }
+    Invoke-MemmyMigrationRecovery `
+      -Mode Rollback `
+      -MigrationStatePath $relayMigrationStatePath `
+      -MigrationScriptPath (Join-Path $stateWorkDir 'MemmyWindowsDataMigration.ps1') `
+      -MigrationLogPath $relayMigrationLogPath `
+      -ExpectedOwner relay `
+      -ExpectedSourceDataPath $backupPath
+  }
+  elseif ([int]$state.schemaVersion -ge 3 -and
+      @('migration-prepared', 'installer-starting', 'installer-running', 'installer-exited', 'migration-recovery-required') -contains $phase -and
+      -not $relayMigrationPhase) {
+    if ((Test-Path -LiteralPath $dataPath -PathType Container) -and
+        -not (Test-Path -LiteralPath $backupPath)) {
+      Write-MemmyUpgradeRecoveryLog "prepared relay migration rollback was already completed before lock cleanup"
+    } else {
+      throw "prepared relay migration state is unavailable"
+    }
+  }
+
   Clear-MemmyRecoveryTransientMarkers
   Remove-Item -LiteralPath $LockPath -Recurse -Force
   Write-MemmyUpgradeRecoveryLog "stale active lock cleared"
@@ -196,5 +461,20 @@ try {
   exit 0
 } catch {
   Write-MemmyUpgradeRecoveryLog ('automatic recovery failed: ' + ($_ | Out-String))
+  $lockAge = if (Test-Path -LiteralPath $LockPath -PathType Container) {
+    (Get-Date) - (Get-Item -LiteralPath $LockPath).LastWriteTime
+  } else {
+    [TimeSpan]::Zero
+  }
+  if ($lockAge.TotalMinutes -ge 2) {
+    $quarantinePath = "$LockPath.recovery-failed-$([DateTime]::UtcNow.ToString('yyyyMMddHHmmss'))"
+    try {
+      Move-Item -LiteralPath $LockPath -Destination $quarantinePath -Force -ErrorAction Stop
+      Write-MemmyUpgradeRecoveryLog "quarantined unrecoverable stale lock at $quarantinePath; application launch is no longer blocked"
+      exit 0
+    } catch {
+      Write-MemmyUpgradeRecoveryLog "unable to quarantine stale lock: $($_.Exception.Message)"
+    }
+  }
   exit 3
 }

--- a/App/shell/desktop/build/MemmyWindowsUpgradeRelay.ps1
+++ b/App/shell/desktop/build/MemmyWindowsUpgradeRelay.ps1
@@ -4,10 +4,17 @@ param(
   [Parameter(Mandatory = $true)][int]$OriginalInstallerPid,
   [Parameter(Mandatory = $true)][int]$LegacyHelperPid,
   [Parameter(Mandatory = $true)][string]$ExpectedVersion,
+  [string]$InstalledVersion = '',
   [Parameter(Mandatory = $true)][ValidateSet('0', '1')][string]$ReopenAfterInstall,
   [Parameter(Mandatory = $true)][string]$ReadyPath,
   [Parameter(Mandatory = $true)][string]$WorkDir,
-  [Parameter(Mandatory = $true)][string]$LogPath
+  [Parameter(Mandatory = $true)][string]$LogPath,
+  [string]$TargetUserDataPathOverride = '',
+  [string]$TargetRuntimeHomePathOverride = '',
+  [string]$LegacyRuntimeHomePathOverride = '',
+  [string]$MigrationStatePathOverride = '',
+  [string]$MigrationLogPathOverride = '',
+  [string]$InstallationRecordPathOverride = ''
 )
 
 $ErrorActionPreference = 'Stop'
@@ -21,15 +28,37 @@ $stagingRoot = Split-Path -Parent $WorkDir
 $lockPath = Join-Path $stagingRoot 'active.lock'
 $lockStatePath = Join-Path $stagingRoot 'active.lock\state.json'
 $appExe = Join-Path $normalizedInstallDir 'Memmy.exe'
+$migrationScriptPath = Join-Path $WorkDir 'MemmyWindowsDataMigration.ps1'
+$targetUserDataPath = if ($TargetUserDataPathOverride) { $TargetUserDataPathOverride } else { Join-Path $env:APPDATA 'Memmy' }
+$dataPointerPath = Join-Path $targetUserDataPath 'data-root.txt'
+$migrationStatePath = if ($MigrationStatePathOverride) { $MigrationStatePathOverride } else { Join-Path $env:LOCALAPPDATA 'Memmy\data-migration\state.json' }
+$migrationLogPath = if ($MigrationLogPathOverride) { $MigrationLogPathOverride } else { Join-Path $env:LOCALAPPDATA 'Memmy\upgrade-logs\data-migration.log' }
+$installationRecordPath = if ($InstallationRecordPathOverride) { $InstallationRecordPathOverride } else { Join-Path $env:LOCALAPPDATA 'Memmy\data-layout\last-install.json' }
+$legacyRuntimeHomePath = if ($LegacyRuntimeHomePathOverride) { $LegacyRuntimeHomePathOverride } else { Join-Path $env:USERPROFILE '.memmy' }
+$installDriveRoot = [System.IO.Path]::GetPathRoot($normalizedInstallDir)
+$targetRuntimeHomePath = if ($TargetRuntimeHomePathOverride) {
+  $TargetRuntimeHomePathOverride
+} elseif ([string]::Equals($installDriveRoot, 'C:\', [System.StringComparison]::OrdinalIgnoreCase)) {
+  $legacyRuntimeHomePath
+} else {
+  Join-Path $installDriveRoot 'MemmyData\.memmy'
+}
 $normalizedInstallerPath = [System.IO.Path]::GetFullPath($InstallerPath)
 $installerExit = 1
 $installerProcess = $null
 $dataMoved = $false
 $dataRestored = $false
 $lockAcquired = $false
+$migrationPrepared = $false
+$migrationCompleted = $false
+$migrationRolledBack = $false
+$migrationSkipped = $false
+$migrationFailure = ''
+$upgradeVerified = $false
 $relayPhase = 'relay-ready'
 $resolvedReopenAfterInstall = $ReopenAfterInstall
 $relayStartedAtUtc = (Get-Process -Id $PID -ErrorAction Stop).StartTime.ToUniversalTime().ToString('O')
+$verifiedInstalledVersion = ''
 
 function Write-MemmyUpgradeLog([string]$Message) {
   $logDirectory = Split-Path -Parent $LogPath
@@ -37,6 +66,45 @@ function Write-MemmyUpgradeLog([string]$Message) {
     New-Item -ItemType Directory -Force -Path $logDirectory | Out-Null
   }
   Add-Content -LiteralPath $LogPath -Value ('[{0:O}] {1}' -f (Get-Date), $Message)
+}
+
+function Invoke-MemmyDataMigration([ValidateSet('Prepare', 'Complete', 'Rollback', 'RequireRecovery')][string]$Mode) {
+  if (-not (Test-Path -LiteralPath $migrationScriptPath -PathType Leaf)) {
+    throw "data migration helper is missing: $migrationScriptPath"
+  }
+  $powershellPath = Join-Path $PSHOME 'powershell.exe'
+  $arguments = @(
+    '-NoProfile',
+    '-NonInteractive',
+    '-ExecutionPolicy', 'Bypass',
+    '-File', $migrationScriptPath,
+    '-Mode', $Mode,
+    '-SourceDataPath', $backupPath,
+    '-SourceAuthority', 'relay-backup-authority',
+    '-SourceInstallDir', $normalizedInstallDir,
+    '-InstallationRecordPath', $installationRecordPath,
+    '-LegacyRuntimeHomePath', $legacyRuntimeHomePath,
+    '-TargetUserDataPath', $targetUserDataPath,
+    '-TargetRuntimeHomePath', $targetRuntimeHomePath,
+    '-PointerPath', $dataPointerPath,
+    '-StatePath', $migrationStatePath,
+    '-LockPath', $lockPath,
+    '-LogPath', $migrationLogPath,
+    '-Owner', 'relay'
+  )
+  if ($InstalledVersion) {
+    $arguments += @('-SourceInstalledVersion', $InstalledVersion)
+  }
+  $migrationOutput = @(& $powershellPath @arguments 2>&1)
+  $migrationExitCode = $LASTEXITCODE
+  if ($migrationExitCode -ne 0) {
+    $migrationDetail = @($migrationOutput | ForEach-Object { [string]$_ } | Where-Object { $_ }) -join ' | '
+    if ($migrationDetail) {
+      Write-MemmyUpgradeLog "data migration $Mode output: $migrationDetail"
+    }
+    throw "data migration $Mode failed with exit code $migrationExitCode"
+  }
+  Write-MemmyUpgradeLog "data migration $Mode completed targetRuntimeHome=$targetRuntimeHomePath"
 }
 
 function Resolve-MemmyLegacyHelperReopenIntent([int]$HelperPid, [string]$MarkerPath, [string]$Fallback) {
@@ -49,7 +117,7 @@ function Resolve-MemmyLegacyHelperReopenIntent([int]$HelperPid, [string]$MarkerP
     $pattern = '(?:^|\s)"?(?<intent>[01])"?\s+"?' + [Regex]::Escape($MarkerPath) + '"?(?:\s|$)'
     $match = [Regex]::Match($commandLine, $pattern, [Text.RegularExpressions.RegexOptions]::IgnoreCase)
     if (-not $match.Success) {
-      throw "legacy helper reopen argument is unavailable"
+      throw "legacy helper reopen argument is unavailable for marker $MarkerPath"
     }
     $intent = $match.Groups['intent'].Value
     Write-MemmyUpgradeLog "reopen intent resolved from legacy helper pid ${HelperPid}: $intent"
@@ -68,6 +136,49 @@ function Wait-MemmyProcessExit([int]$ProcessId, [int]$TimeoutSeconds) {
   Write-MemmyUpgradeLog "waiting for original installer pid $ProcessId"
   if (-not $process.WaitForExit($TimeoutSeconds * 1000)) {
     throw "original installer pid $ProcessId did not exit"
+  }
+}
+
+function Get-MemmyInstallProcesses {
+  $expectedPath = [System.IO.Path]::GetFullPath($appExe)
+  foreach ($process in @(Get-Process -Name 'Memmy' -ErrorAction SilentlyContinue)) {
+    try {
+      if ([string]::Equals(
+          [System.IO.Path]::GetFullPath($process.Path),
+          $expectedPath,
+          [System.StringComparison]::OrdinalIgnoreCase
+        )) {
+        $process
+      }
+    } catch {
+      continue
+    }
+  }
+}
+
+function Wait-MemmyInstallProcessesExit([int]$TimeoutSeconds) {
+  $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
+  $remaining = @(Get-MemmyInstallProcesses)
+  while ($remaining.Count -gt 0 -and [DateTime]::UtcNow -lt $deadline) {
+    Start-Sleep -Milliseconds 250
+    $remaining = @(Get-MemmyInstallProcesses)
+  }
+  if ($remaining.Count -eq 0) {
+    return
+  }
+
+  $remainingIds = @($remaining | ForEach-Object { $_.Id })
+  Write-MemmyUpgradeLog "forcing remaining installed app processes to exit after timeout: $($remainingIds -join ',')"
+  foreach ($process in $remaining) {
+    Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue
+  }
+  $forceDeadline = [DateTime]::UtcNow.AddSeconds(10)
+  do {
+    Start-Sleep -Milliseconds 250
+    $remaining = @(Get-MemmyInstallProcesses)
+  } while ($remaining.Count -gt 0 -and [DateTime]::UtcNow -lt $forceDeadline)
+  if ($remaining.Count -gt 0) {
+    throw "installed Memmy processes did not exit: $(@($remaining | ForEach-Object { $_.Id }) -join ',')"
   }
 }
 
@@ -107,7 +218,7 @@ function Write-MemmyRelayState {
     }
   }
   $state = [ordered]@{
-    schemaVersion = 2
+    schemaVersion = 3
     phase = $relayPhase
     stateUpdatedAtUtc = [DateTime]::UtcNow.ToString('O')
     relayPid = $PID
@@ -118,6 +229,13 @@ function Write-MemmyRelayState {
     installDir = $normalizedInstallDir
     workDir = [System.IO.Path]::GetFullPath($WorkDir).TrimEnd('\')
     backupRoot = $backupRoot
+    migrationStatePath = $migrationStatePath
+    migrationLogPath = $migrationLogPath
+    legacyRuntimeHomePath = $legacyRuntimeHomePath
+    targetUserDataPath = $targetUserDataPath
+    targetRuntimeHomePath = $targetRuntimeHomePath
+    migrationSkipped = $migrationSkipped
+    migrationFailure = $migrationFailure
   }
   $temporaryStatePath = "$lockStatePath.tmp"
   [System.IO.File]::WriteAllText($temporaryStatePath, ($state | ConvertTo-Json -Compress))
@@ -167,7 +285,9 @@ function Get-MemmyInstalledVersion {
 }
 
 function Clear-MemmyUpdateMarkers {
-  $markerPath = Join-Path $dataPath 'Memmy\prepared-required-update.json'
+  $roamingMarkerPath = Join-Path $targetUserDataPath 'prepared-required-update.json'
+  $legacyMarkerPath = Join-Path $dataPath 'Memmy\prepared-required-update.json'
+  $markerPath = if (Test-Path -LiteralPath $roamingMarkerPath -PathType Leaf) { $roamingMarkerPath } else { $legacyMarkerPath }
   foreach ($path in @($markerPath, "$markerPath.lock", "$markerPath.prompt", "$markerPath.attempt")) {
     Remove-Item -LiteralPath $path -Recurse -Force -ErrorAction SilentlyContinue
   }
@@ -215,14 +335,16 @@ function Schedule-MemmyStagingCleanup {
     return
   }
   $powershellPath = Join-Path $PSHOME 'powershell.exe'
-  $cleanupArguments = "-NoProfile -NonInteractive -ExecutionPolicy Bypass -WindowStyle Hidden -File `"$cleanupScriptPath`" -WorkDir `"$WorkDir`" -BackupRoot `"$backupRoot`""
+  $cleanupArguments = "-NoProfile -NonInteractive -ExecutionPolicy Bypass -WindowStyle Hidden -File `"$cleanupScriptPath`" -WorkDir `"$WorkDir`""
   Start-Process -FilePath $powershellPath -ArgumentList $cleanupArguments -WorkingDirectory $stagingRoot -WindowStyle Hidden
 }
 
 try {
   New-Item -ItemType Directory -Force -Path $WorkDir | Out-Null
   Write-MemmyUpgradeLog "relay starting installer=$InstallerPath installDir=$InstallDir expected=$ExpectedVersion reopenFallback=$ReopenAfterInstall"
-  $markerPath = Join-Path $dataPath 'Memmy\prepared-required-update.json'
+  $roamingMarkerPath = Join-Path $targetUserDataPath 'prepared-required-update.json'
+  $legacyMarkerPath = Join-Path $dataPath 'Memmy\prepared-required-update.json'
+  $markerPath = if (Test-Path -LiteralPath $roamingMarkerPath -PathType Leaf) { $roamingMarkerPath } else { $legacyMarkerPath }
   $resolvedReopenAfterInstall = Resolve-MemmyLegacyHelperReopenIntent -HelperPid $LegacyHelperPid -MarkerPath $markerPath -Fallback $ReopenAfterInstall
   New-Item -ItemType Directory -Path $lockPath -ErrorAction Stop | Out-Null
   $lockAcquired = $true
@@ -230,6 +352,7 @@ try {
   [System.IO.File]::WriteAllText($ReadyPath, $resolvedReopenAfterInstall)
   Write-MemmyUpgradeLog "relay ready reopen=$resolvedReopenAfterInstall"
   Wait-MemmyProcessExit -ProcessId $OriginalInstallerPid -TimeoutSeconds 120
+  Wait-MemmyInstallProcessesExit -TimeoutSeconds 20
 
   if (Test-Path -LiteralPath $dataPath -PathType Container) {
     if (Test-Path -LiteralPath $backupRoot) {
@@ -240,6 +363,19 @@ try {
     $relayPhase = 'data-moved'
     Write-MemmyRelayState
     Write-MemmyUpgradeLog "data moved to $backupPath"
+  }
+
+  try {
+    Invoke-MemmyDataMigration -Mode Prepare
+    $migrationPrepared = $true
+    $relayPhase = 'migration-prepared'
+    Write-MemmyRelayState
+  } catch {
+    $migrationSkipped = $true
+    $migrationFailure = $_.Exception.Message
+    $relayPhase = 'migration-skipped'
+    Write-MemmyRelayState
+    Write-MemmyUpgradeLog "data migration Prepare failed safely; continuing installation without migration: $migrationFailure"
   }
 
   $arguments = @('/S', '--updated', '--memmy-upgrade-relayed', '/currentuser', ('/D=' + $InstallDir))
@@ -253,35 +389,87 @@ try {
   $installerProcess.WaitForExit()
   $installerExit = if ($null -eq $installerProcess.ExitCode) { 1 } else { $installerProcess.ExitCode }
   Write-MemmyUpgradeLog "installer exit $installerExit"
+  $verifiedInstalledVersion = Get-MemmyInstalledVersion
+  $upgradeVerified = $installerExit -eq 0 -and $verifiedInstalledVersion.StartsWith($ExpectedVersion, [System.StringComparison]::OrdinalIgnoreCase)
+  if (-not $upgradeVerified) {
+    throw "upgrade verification failed installedVersion=$verifiedInstalledVersion installerExit=$installerExit"
+  }
+
+  if ($migrationPrepared) {
+    try {
+      Invoke-MemmyDataMigration -Mode Complete
+      $migrationCompleted = $true
+      $relayPhase = 'migration-completed'
+      Write-MemmyRelayState
+    } catch {
+      $migrationFailure = $_.Exception.Message
+      Write-MemmyUpgradeLog "data migration Complete failed; rolling back migration while retaining the installed app: $migrationFailure"
+      for ($rollbackAttempt = 1; $rollbackAttempt -le 2 -and -not $migrationRolledBack; $rollbackAttempt++) {
+        try {
+          Invoke-MemmyDataMigration -Mode Rollback
+          $migrationRolledBack = $true
+        } catch {
+          Write-MemmyUpgradeLog "data migration rollback attempt $rollbackAttempt after completion failure failed: $($_.Exception.Message)"
+        }
+      }
+      $migrationSkipped = $true
+      if ($migrationRolledBack) {
+        $relayPhase = 'migration-skipped'
+        Write-MemmyRelayState
+      } else {
+        # Keep the installed application usable and leave the prepared transaction for startup
+        # recovery. The lock is released below so a helper failure never permanently blocks launch.
+        $migrationCompleted = $false
+        try {
+          Invoke-MemmyDataMigration -Mode RequireRecovery
+        } catch {
+          # Startup also treats any state left in `prepared` as recovery-required, so a failure
+          # to update the explicit phase still fails open without accepting the mixed target.
+          Write-MemmyUpgradeLog "unable to mark explicit migration recovery phase; prepared state remains recoverable: $($_.Exception.Message)"
+        }
+        $relayPhase = 'migration-recovery-required'
+        Write-MemmyRelayState
+        Write-MemmyUpgradeLog "retaining prepared migration state for startup recovery"
+      }
+    }
+  }
 } catch {
   Write-MemmyUpgradeLog ('relay error: ' + ($_ | Out-String))
   if ($installerExit -eq 0) {
     $installerExit = 1
   }
 } finally {
-  try {
-    Restore-MemmyData
-  } catch {
-    Write-MemmyUpgradeLog ('data restore failed: ' + ($_ | Out-String))
-    $dataRestored = $false
+  if (-not $upgradeVerified) {
+    if ($migrationPrepared -and -not $migrationCompleted) {
+      try {
+        Invoke-MemmyDataMigration -Mode Rollback
+        $migrationRolledBack = $true
+      } catch {
+        Write-MemmyUpgradeLog ('data migration rollback failed: ' + ($_ | Out-String))
+        $migrationRolledBack = $false
+      }
+    }
+    try {
+      Restore-MemmyData
+    } catch {
+      Write-MemmyUpgradeLog ('data restore failed: ' + ($_ | Out-String))
+      $dataRestored = $false
+    }
   }
-  if ($lockAcquired -and $dataRestored) {
+  $migrationSafe = (-not $migrationPrepared) -or $migrationCompleted -or $migrationRolledBack
+  if ($lockAcquired -and (($upgradeVerified -and ($migrationCompleted -or $migrationSkipped)) -or ($dataRestored -and $migrationSafe))) {
     Remove-Item -LiteralPath $lockPath -Recurse -Force -ErrorAction SilentlyContinue
   } elseif ($lockAcquired) {
     Write-MemmyUpgradeLog "active lock retained for automatic recovery $lockPath"
   }
 }
 
-if (-not $dataRestored) {
-  Write-MemmyUpgradeLog "upgrade stopped with recoverable data backup $backupPath"
-  exit 3
-}
-
-$installedVersion = Get-MemmyInstalledVersion
-$upgradeVerified = $installerExit -eq 0 -and $installedVersion.StartsWith($ExpectedVersion, [System.StringComparison]::OrdinalIgnoreCase)
-if ($upgradeVerified) {
-  Clear-MemmyUpdateMarkers
-  Write-MemmyUpgradeLog "upgrade verified installedVersion=$installedVersion"
+if ($upgradeVerified -and ($migrationCompleted -or $migrationSkipped)) {
+  if ($migrationSkipped -and $dataMoved) {
+    Write-MemmyUpgradeLog "upgrade verified without migration; original data retained for manual recovery at $backupPath"
+  } else {
+    Write-MemmyUpgradeLog "upgrade verified installedVersion=$verifiedInstalledVersion"
+  }
   if ($resolvedReopenAfterInstall -eq '1') {
     Ensure-MemmyInstalledAppStarted
   }
@@ -289,7 +477,11 @@ if ($upgradeVerified) {
   exit 0
 }
 
-Write-MemmyUpgradeLog "upgrade not verified installedVersion=$installedVersion installerExit=$installerExit"
+Write-MemmyUpgradeLog "upgrade not verified installedVersion=$verifiedInstalledVersion installerExit=$installerExit"
+if (-not $dataRestored) {
+  Write-MemmyUpgradeLog "upgrade stopped with recoverable data backup $backupPath"
+  exit 3
+}
 if ($resolvedReopenAfterInstall -eq '1') {
   Start-MemmyInstalledApp
 }

--- a/App/shell/desktop/build/installer-win-unsigned.nsh
+++ b/App/shell/desktop/build/installer-win-unsigned.nsh
@@ -1,8 +1,14 @@
 !include "FileFunc.nsh"
 !include "getProcessInfo.nsh"
+!include "LogicLib.nsh"
+!include "nsDialogs.nsh"
 
 !ifndef MEMMY_WM_SETTINGCHANGE
   !define MEMMY_WM_SETTINGCHANGE 0x001A
+!endif
+
+!ifndef MEMMY_LANG_SIMPCHINESE
+  !define MEMMY_LANG_SIMPCHINESE 2052
 !endif
 
 !macro customHeader
@@ -21,11 +27,59 @@
   StrCpy $isForceCurrentInstall "1"
 !macroend
 
+; electron-builder omits its own $pid declaration whenever customCheckAppRunning exists, so this
+; declaration must be visible while compiling both the installer and the generated uninstaller.
+Var pid
+
+; Keep electron-builder's localized running-app prompt and its normal-then-forced termination
+; retries. Force the exact-image/current-user cmd fallback instead of the default $INSTDIR prefix
+; check: a custom-drive uninstaller can otherwise resolve a stale/default install directory, miss
+; the live Memmy process, and delete resources underneath the tray process. _CHECK_APP_RUNNING
+; aborts before file or shortcut cleanup if the process still exists after the forced retry.
+!macro customCheckAppRunning
+  !insertmacro IS_POWERSHELL_AVAILABLE
+  StrCpy $IsPowerShellAvailable "1"
+  !insertmacro _CHECK_APP_RUNNING
+
+  ; Data migration is an installer transaction. The uninstaller only performs the shared
+  ; close-and-verify flow above and must never prepare or mutate migration state.
+  !ifndef BUILD_UNINSTALLER
+    StrCmp $MemmyIsRelayedUpgrade "1" memmy_check_app_running_done
+    Call MemmyPrepareDirectDataMigration
+    Pop $0
+    StrCmp $0 "1" memmy_check_app_running_done
+    ${IfNot} ${Silent}
+      MessageBox MB_OK|MB_ICONSTOP "$R8"
+    ${EndIf}
+    SetErrorLevel 5
+    Quit
+
+    memmy_check_app_running_done:
+  !endif
+!macroend
+
 !ifndef BUILD_UNINSTALLER
+  !define MUI_CUSTOMFUNCTION_ABORT MemmyOnUserAbort
   Var MemmyIsRelayedUpgrade
   Var MemmyUpgradeWorkDir
   Var MemmyUpgradeBackupRoot
   Var MemmyUpgradeReopenAfterInstall
+  Var MemmyPreviousInstallDir
+  Var MemmyPreviousInstalledVersion
+  Var MemmyDirectMigrationPrepared
+  Var MemmyPreparedInstallDir
+  Var MemmyDirectSourceDataPath
+  Var MemmyDirectSourceInstallDir
+  Var MemmyDirectSourceAuthority
+  Var MemmyTargetUserDataPath
+  Var MemmyTargetRuntimeHomePath
+  Var MemmyDataPointerPath
+  Var MemmyMigrationStatePath
+  Var MemmyInstallationRecordPath
+  Var MemmyMigrationScriptPath
+  Var MemmyMigrationLockPath
+  Var MemmyMigrationLogPath
+  Var MemmyInstallerPid
 
   ; The 1.0.8 updater starts the downloaded installer from $INSTDIR\data. electron-builder's
   ; normal upgrade path asks the old uninstaller to move all of $INSTDIR, so that running
@@ -33,17 +87,59 @@
   ; this legacy --updated invocation through a copy outside $INSTDIR. The relayed child carries
   ; an explicit marker so normal installs and future upgrades continue through electron-builder.
   !macro customInit
+    StrCpy $MemmyDirectMigrationPrepared "0"
+    StrCpy $MemmyPreparedInstallDir ""
+    System::Call 'kernel32::GetCurrentProcessId() i.r0'
+    StrCpy $MemmyInstallerPid $0
+    ReadRegStr $MemmyPreviousInstallDir HKCU "${INSTALL_REGISTRY_KEY}" "InstallLocation"
+    ; electron-builder stores DisplayVersion under the uninstall key, while
+    ; InstallLocation lives under the product key.
+    ReadRegStr $MemmyPreviousInstalledVersion HKCU "${UNINSTALL_REGISTRY_KEY}" "DisplayVersion"
     Call MemmyRelayLegacyUpgrade
+    StrCmp $MemmyIsRelayedUpgrade "1" memmy_custom_init_done
+    ${If} ${Silent}
+      Call MemmyValidateSelectedDirectories
+      Pop $0
+      StrCmp $0 "1" memmy_custom_init_done memmy_custom_init_failed
+
+      memmy_custom_init_failed:
+        SetErrorLevel 5
+        Quit
+    ${EndIf}
+
+    memmy_custom_init_done:
+  !macroend
+
+  !macro customPageAfterChangeDir
+    Page custom MemmyValidateInstallPage
+  !macroend
+
+  ; electron-builder quits directly when the old uninstaller returns a failure code,
+  ; so recover the prepared migration before preserving its existing error behavior.
+  !macro customUnInstallCheck
+    IfErrors memmy_uninstall_check_exec_failed memmy_uninstall_check_result
+
+    memmy_uninstall_check_exec_failed:
+      DetailPrint `Uninstall was not successful. Not able to launch uninstaller!`
+      Return
+
+    memmy_uninstall_check_result:
+      ${If} $R0 != 0
+        Call MemmyRecoverDirectDataMigration
+        MessageBox MB_OK|MB_ICONEXCLAMATION "$(uninstallFailed): $R0"
+        DetailPrint `Uninstall was not successful. Uninstaller error code: $R0.`
+        SetErrorLevel 2
+        Quit
+      ${EndIf}
   !macroend
 
   !macro customInstall
-    Call MemmyRestoreRelayedUpgradeData
     Call MemmyAddCliToUserPath
     Call MemmyInstallLaunchProxy
     !insertmacro MemmyPointShortcutsToLaunchProxy
     Call MemmyClearRelayedUpgradeMarkers
-    Call MemmyLaunchRelayedUpgrade
-    Call MemmyScheduleRelayedUpgradeCleanup
+    ; Release the direct-install barrier only after every install-time mutation is complete.
+    Call MemmyCompleteDirectDataMigration
   !macroend
 !endif
 
@@ -55,6 +151,305 @@
 !endif
 
 !ifndef BUILD_UNINSTALLER
+Function MemmyNormalizeInstallDirectory
+  ${GetFileName} "$INSTDIR" $R4
+  StrCmp $R4 "${APP_FILENAME}" memmy_normalize_install_done
+  StrCpy $INSTDIR "$INSTDIR\${APP_FILENAME}"
+
+  memmy_normalize_install_done:
+FunctionEnd
+
+Function MemmyResolveMigrationPaths
+  ${GetRoot} "$INSTDIR" $0
+  StrCmp $0 "" memmy_resolve_use_profile
+  StrCpy $1 $0 1
+  StrCmp $1 "C" memmy_resolve_use_profile
+  StrCmp $1 "c" memmy_resolve_use_profile
+  StrCpy $MemmyTargetRuntimeHomePath "$0\MemmyData\.memmy"
+  Goto memmy_resolve_runtime_done
+
+  memmy_resolve_use_profile:
+    StrCpy $MemmyTargetRuntimeHomePath "$PROFILE\.memmy"
+
+  memmy_resolve_runtime_done:
+    StrCpy $MemmyTargetUserDataPath "$APPDATA\Memmy"
+    StrCpy $MemmyDataPointerPath "$MemmyTargetUserDataPath\data-root.txt"
+    StrCpy $MemmyMigrationStatePath "$LOCALAPPDATA\Memmy\data-migration\state.json"
+    StrCpy $MemmyInstallationRecordPath "$LOCALAPPDATA\Memmy\data-layout\last-install.json"
+    StrCpy $MemmyMigrationLockPath "$LOCALAPPDATA\Memmy\upgrade-staging\active.lock"
+    StrCpy $MemmyMigrationLogPath "$LOCALAPPDATA\Memmy\upgrade-logs\data-migration.log"
+    StrCmp $MemmyPreviousInstallDir "" 0 memmy_resolve_previous_source
+    StrCpy $MemmyDirectSourceDataPath "$INSTDIR\data"
+    StrCpy $MemmyDirectSourceInstallDir "$INSTDIR"
+    ; The exact directory explicitly selected by the user is the only discoverable old
+    ; install after a legacy uninstaller removed its registry entry. The migration helper
+    ; still requires complete category anchors and blocks it when an external-v1 record
+    ; proves the directory belongs to the new layout.
+    StrCpy $MemmyDirectSourceAuthority "selected-install-authority"
+    Return
+
+  memmy_resolve_previous_source:
+    StrCpy $MemmyDirectSourceDataPath "$MemmyPreviousInstallDir\data"
+    StrCpy $MemmyDirectSourceInstallDir "$MemmyPreviousInstallDir"
+    StrCpy $MemmyDirectSourceAuthority "current-install-authority"
+FunctionEnd
+
+; Input: $R0 is the exact directory to validate. Output: pushes "1" when
+; that directory supports create/write/delete operations, else "0".
+Function MemmyProbeWritableDirectory
+  StrCpy $R1 ""
+  StrCpy $R2 ""
+  StrCpy $R3 ""
+  StrCpy $R5 "0"
+
+  IfFileExists "$R0\*.*" memmy_writable_probe_target_ready
+  ClearErrors
+  CreateDirectory "$R0"
+  IfErrors memmy_writable_probe_failed
+  StrCpy $R5 "1"
+
+  memmy_writable_probe_target_ready:
+    ClearErrors
+    GetTempFileName $R1 "$R0"
+    IfErrors memmy_writable_probe_failed
+    Delete "$R1"
+    IfErrors memmy_writable_probe_cleanup_failed
+    CreateDirectory "$R1"
+    IfErrors memmy_writable_probe_cleanup_failed
+    StrCpy $R2 "$R1\write-test.tmp"
+    FileOpen $R3 "$R2" w
+    IfErrors memmy_writable_probe_cleanup_failed
+    FileWrite $R3 "Memmy"
+    IfErrors memmy_writable_probe_close_failed
+    FileClose $R3
+    StrCpy $R3 ""
+    ClearErrors
+    Delete "$R2"
+    IfErrors memmy_writable_probe_cleanup_failed
+    StrCpy $R2 ""
+    ClearErrors
+    RMDir "$R1"
+    IfErrors memmy_writable_probe_cleanup_failed
+    StrCpy $R1 ""
+    ${If} $R5 == "1"
+      ClearErrors
+      RMDir "$R0"
+      IfErrors memmy_writable_probe_failed
+      StrCpy $R5 "0"
+    ${EndIf}
+    Push "1"
+    Return
+
+  memmy_writable_probe_close_failed:
+    FileClose $R3
+    StrCpy $R3 ""
+
+  memmy_writable_probe_cleanup_failed:
+    ClearErrors
+    ${If} $R2 != ""
+      Delete "$R2"
+    ${EndIf}
+    ${If} $R1 != ""
+      Delete "$R1"
+      RMDir "$R1"
+    ${EndIf}
+    ClearErrors
+
+  memmy_writable_probe_failed:
+    ${If} $R5 == "1"
+      ClearErrors
+      RMDir "$R0"
+    ${EndIf}
+    Push "0"
+FunctionEnd
+
+; Resolves and probes the selected install folder, roaming user-data folder, and
+; installation-drive runtime folder. Output: pushes "1" on success, else "0".
+Function MemmyValidateSelectedDirectories
+  Call MemmyNormalizeInstallDirectory
+  Call MemmyResolveMigrationPaths
+
+  StrCpy $R0 "$INSTDIR"
+  Call MemmyProbeWritableDirectory
+  Pop $0
+  StrCmp $0 "1" memmy_validate_user_data
+  StrCpy $R8 "The selected installation folder $\"$INSTDIR$\" does not have permission. Choose another folder."
+  StrCmp $LANGUAGE ${MEMMY_LANG_SIMPCHINESE} 0 memmy_validate_failed
+  StrCpy $R8 "当前选择的安装文件夹“$INSTDIR”没有权限，请选择其它目录。"
+  Goto memmy_validate_failed
+
+  memmy_validate_user_data:
+    StrCpy $R0 "$MemmyTargetUserDataPath"
+    Call MemmyProbeWritableDirectory
+    Pop $0
+    StrCmp $0 "1" memmy_validate_runtime
+    StrCpy $R8 "The Memmy account data folder $\"$MemmyTargetUserDataPath$\" is not writable."
+    StrCmp $LANGUAGE ${MEMMY_LANG_SIMPCHINESE} 0 memmy_validate_failed
+    StrCpy $R8 "Memmy 登录数据目录“$MemmyTargetUserDataPath”没有写入权限，无法继续安装。"
+    Goto memmy_validate_failed
+
+  memmy_validate_runtime:
+    StrCpy $R0 "$MemmyTargetRuntimeHomePath"
+    Call MemmyProbeWritableDirectory
+    Pop $0
+    StrCmp $0 "1" memmy_validate_succeeded
+    StrCpy $R8 "The Memmy data folder $\"$MemmyTargetRuntimeHomePath$\" does not have permission. Choose another installation folder."
+    StrCmp $LANGUAGE ${MEMMY_LANG_SIMPCHINESE} 0 memmy_validate_failed
+    StrCpy $R8 "当前安装位置对应的数据文件夹“$MemmyTargetRuntimeHomePath”没有权限，请选择其它安装目录。"
+    Goto memmy_validate_failed
+
+  memmy_validate_succeeded:
+    Push "1"
+    Return
+
+  memmy_validate_failed:
+    Push "0"
+FunctionEnd
+
+Function MemmyExtractDataMigrationScript
+  InitPluginsDir
+  CreateDirectory "$PLUGINSDIR\MemmyDataMigration"
+  SetOutPath "$PLUGINSDIR\MemmyDataMigration"
+  File /oname=MemmyWindowsDataMigration.ps1 "${BUILD_RESOURCES_DIR}\MemmyWindowsDataMigration.ps1"
+  StrCpy $MemmyMigrationScriptPath "$PLUGINSDIR\MemmyDataMigration\MemmyWindowsDataMigration.ps1"
+FunctionEnd
+
+; Performs the migration while the old installation and its registered location still exist.
+; Output: pushes "1" on success, else "0" and leaves a user-facing message in $R8.
+Function MemmyPrepareDirectDataMigration
+  StrCmp $MemmyDirectMigrationPrepared "1" memmy_direct_prepare_already
+  Call MemmyResolveMigrationPaths
+  Call MemmyExtractDataMigrationScript
+  IfFileExists "$MemmyMigrationScriptPath" 0 memmy_direct_prepare_failed
+
+  ; Refresh the previous installation's shortcut proxy before copying. If the
+  ; installer later fails, it still points to the old app and becomes usable as
+  ; soon as this function releases the lock.
+  StrCmp $MemmyPreviousInstallDir "" memmy_direct_prepare_run
+  StrCpy $R7 "$INSTDIR"
+  StrCpy $INSTDIR "$MemmyPreviousInstallDir"
+  Call MemmyInstallLaunchProxy
+  StrCpy $INSTDIR "$R7"
+
+  memmy_direct_prepare_run:
+    StrCpy $R5 "$SYSDIR\WindowsPowerShell\v1.0\powershell.exe"
+    nsExec::ExecToStack '$\"$R5$\" -NoProfile -NonInteractive -ExecutionPolicy Bypass -File $\"$MemmyMigrationScriptPath$\" -Mode Prepare -SourceDataPath $\"$MemmyDirectSourceDataPath$\" -SourceAuthority $MemmyDirectSourceAuthority -SourceInstallDir $\"$MemmyDirectSourceInstallDir$\" -SourceInstalledVersion $\"$MemmyPreviousInstalledVersion$\" -InstallationRecordPath $\"$MemmyInstallationRecordPath$\" -LegacyRuntimeHomePath $\"$PROFILE\.memmy$\" -TargetUserDataPath $\"$MemmyTargetUserDataPath$\" -TargetRuntimeHomePath $\"$MemmyTargetRuntimeHomePath$\" -PointerPath $\"$MemmyDataPointerPath$\" -StatePath $\"$MemmyMigrationStatePath$\" -LockPath $\"$MemmyMigrationLockPath$\" -LogPath $\"$MemmyMigrationLogPath$\" -Owner installer -InstallerPid $MemmyInstallerPid -InstallerPath $\"$EXEPATH$\" -InstallerInstallDir $\"$INSTDIR$\" -AcquireLock'
+    Pop $0
+    Pop $1
+    StrCmp $0 "0" memmy_direct_prepare_succeeded
+    DetailPrint "Memmy data migration was skipped after a safe rollback; installation will continue."
+    RMDir /r "$MemmyMigrationLockPath"
+    Goto memmy_direct_prepare_skipped
+
+  memmy_direct_prepare_failed:
+    DetailPrint "Memmy data migration helper is unavailable; installation will continue without automatic migration."
+
+  memmy_direct_prepare_skipped:
+    StrCpy $MemmyDirectMigrationPrepared "0"
+    Push "1"
+    Return
+
+  memmy_direct_prepare_succeeded:
+    StrCpy $MemmyDirectMigrationPrepared "1"
+    StrCpy $MemmyPreparedInstallDir "$INSTDIR"
+    Push "1"
+    Return
+
+  memmy_direct_prepare_already:
+    StrCmp $MemmyPreparedInstallDir $INSTDIR memmy_direct_prepare_already_valid
+    DetailPrint "The installation folder changed after data migration started; rolling back and preparing the final folder."
+    Call MemmyRecoverDirectDataMigration
+    StrCpy $MemmyDirectMigrationPrepared "0"
+    Call MemmyResolveMigrationPaths
+    Goto memmy_direct_prepare_run
+
+  memmy_direct_prepare_already_valid:
+    Push "1"
+FunctionEnd
+
+Function MemmyCompleteDirectDataMigration
+  StrCmp $MemmyDirectMigrationPrepared "1" 0 memmy_direct_complete_done
+  StrCpy $R5 "$SYSDIR\WindowsPowerShell\v1.0\powershell.exe"
+  nsExec::ExecToStack '$\"$R5$\" -NoProfile -NonInteractive -ExecutionPolicy Bypass -File $\"$MemmyMigrationScriptPath$\" -Mode Complete -SourceDataPath $\"$MemmyDirectSourceDataPath$\" -SourceAuthority $MemmyDirectSourceAuthority -SourceInstallDir $\"$MemmyDirectSourceInstallDir$\" -SourceInstalledVersion $\"$MemmyPreviousInstalledVersion$\" -InstallationRecordPath $\"$MemmyInstallationRecordPath$\" -LegacyRuntimeHomePath $\"$PROFILE\.memmy$\" -TargetUserDataPath $\"$MemmyTargetUserDataPath$\" -TargetRuntimeHomePath $\"$MemmyTargetRuntimeHomePath$\" -PointerPath $\"$MemmyDataPointerPath$\" -StatePath $\"$MemmyMigrationStatePath$\" -LockPath $\"$MemmyMigrationLockPath$\" -LogPath $\"$MemmyMigrationLogPath$\" -Owner installer'
+  Pop $0
+  Pop $1
+  StrCmp $0 "0" memmy_direct_complete_succeeded
+  DetailPrint "Memmy data migration completion failed; the migration will be rolled back and installation will continue."
+  Call MemmyRecoverDirectDataMigration
+  Goto memmy_direct_complete_done
+
+  memmy_direct_complete_succeeded:
+    RMDir /r "$MemmyMigrationLockPath"
+    StrCpy $MemmyDirectMigrationPrepared "0"
+
+  memmy_direct_complete_done:
+FunctionEnd
+
+Function MemmyRecoverDirectDataMigration
+  StrCmp $MemmyDirectMigrationPrepared "1" 0 memmy_direct_recover_done
+  StrCpy $R5 "$SYSDIR\WindowsPowerShell\v1.0\powershell.exe"
+  nsExec::ExecToStack '$\"$R5$\" -NoProfile -NonInteractive -ExecutionPolicy Bypass -File $\"$MemmyMigrationScriptPath$\" -Mode Recover -SourceDataPath $\"$MemmyDirectSourceDataPath$\" -SourceAuthority $MemmyDirectSourceAuthority -SourceInstallDir $\"$MemmyDirectSourceInstallDir$\" -SourceInstalledVersion $\"$MemmyPreviousInstalledVersion$\" -InstallationRecordPath $\"$MemmyInstallationRecordPath$\" -LegacyRuntimeHomePath $\"$PROFILE\.memmy$\" -TargetUserDataPath $\"$MemmyTargetUserDataPath$\" -TargetRuntimeHomePath $\"$MemmyTargetRuntimeHomePath$\" -PointerPath $\"$MemmyDataPointerPath$\" -StatePath $\"$MemmyMigrationStatePath$\" -LockPath $\"$MemmyMigrationLockPath$\" -LogPath $\"$MemmyMigrationLogPath$\" -Owner installer'
+  Pop $0
+  Pop $1
+  StrCmp $0 "0" 0 memmy_direct_recover_failed
+  RMDir /r "$MemmyMigrationLockPath"
+  StrCpy $MemmyDirectMigrationPrepared "0"
+  Goto memmy_direct_recover_done
+
+  memmy_direct_recover_failed:
+    DetailPrint "Memmy data migration recovery failed with exit code $0; handing the prepared transaction to startup recovery."
+    nsExec::ExecToStack '$\"$R5$\" -NoProfile -NonInteractive -ExecutionPolicy Bypass -File $\"$MemmyMigrationScriptPath$\" -Mode RequireRecovery -SourceDataPath $\"$MemmyDirectSourceDataPath$\" -SourceAuthority $MemmyDirectSourceAuthority -SourceInstallDir $\"$MemmyDirectSourceInstallDir$\" -SourceInstalledVersion $\"$MemmyPreviousInstalledVersion$\" -InstallationRecordPath $\"$MemmyInstallationRecordPath$\" -LegacyRuntimeHomePath $\"$PROFILE\.memmy$\" -TargetUserDataPath $\"$MemmyTargetUserDataPath$\" -TargetRuntimeHomePath $\"$MemmyTargetRuntimeHomePath$\" -PointerPath $\"$MemmyDataPointerPath$\" -StatePath $\"$MemmyMigrationStatePath$\" -LockPath $\"$MemmyMigrationLockPath$\" -LogPath $\"$MemmyMigrationLogPath$\" -Owner installer'
+    Pop $2
+    Pop $3
+    StrCmp $2 "0" memmy_direct_recover_handoff_done
+    DetailPrint "Memmy startup recovery marker could not be updated; startup will conservatively recover the remaining prepared state."
+
+  memmy_direct_recover_handoff_done:
+    ; Never leave an installer-owned lock permanently after installation. Both `prepared`
+    ; and `recovery-required` are mandatory rollback phases in the new app startup path.
+    RMDir /r "$MemmyMigrationLockPath"
+    StrCpy $MemmyDirectMigrationPrepared "0"
+
+  memmy_direct_recover_done:
+FunctionEnd
+
+Function .onInstFailed
+  Call MemmyRecoverDirectDataMigration
+FunctionEnd
+
+Function MemmyOnUserAbort
+  Call MemmyRecoverDirectDataMigration
+FunctionEnd
+
+Function MemmyValidateInstallPage
+  GetDlgItem $0 $HWNDPARENT 1
+  EnableWindow $0 1
+  ${If} ${Silent}
+    Abort
+  ${EndIf}
+  StrCmp $MemmyIsRelayedUpgrade "1" 0 memmy_validate_page_direct
+  Abort
+
+  memmy_validate_page_direct:
+    Call MemmyValidateSelectedDirectories
+    Pop $0
+    StrCmp $0 "1" 0 memmy_validate_page_show_error
+    Abort
+
+  memmy_validate_page_show_error:
+    nsDialogs::Create 1018
+    Pop $2
+    StrCmp $2 error 0 memmy_validate_page_show
+    Abort
+
+  memmy_validate_page_show:
+    ${NSD_CreateLabel} 0 0 100% 75u "$R8"
+    Pop $4
+    GetDlgItem $0 $HWNDPARENT 1
+    EnableWindow $0 0
+    nsDialogs::Show
+FunctionEnd
+
 Function MemmyRelayLegacyUpgrade
   ${GetParameters} $R0
 
@@ -85,6 +480,14 @@ Function MemmyRelayLegacyUpgrade
     ; Direct/manual updates reopen Memmy. A prepared update without the boot-attempt marker was
     ; launched during normal app shutdown and must remain closed. Boot fallback writes .attempt.
     StrCpy $R6 "1"
+    IfFileExists "$APPDATA\Memmy\prepared-required-update.json" memmy_relay_resolve_roaming_reopen memmy_relay_check_legacy_reopen
+
+  memmy_relay_resolve_roaming_reopen:
+    IfFileExists "$APPDATA\Memmy\prepared-required-update.json.attempt" memmy_relay_stage
+    StrCpy $R6 "0"
+    Goto memmy_relay_stage
+
+  memmy_relay_check_legacy_reopen:
     IfFileExists "$INSTDIR\data\Memmy\prepared-required-update.json" 0 memmy_relay_stage
     IfFileExists "$INSTDIR\data\Memmy\prepared-required-update.json.attempt" memmy_relay_stage
     StrCpy $R6 "0"
@@ -103,6 +506,9 @@ Function MemmyRelayLegacyUpgrade
     File /oname=MemmyWindowsUpgradeCleanup.ps1 "${BUILD_RESOURCES_DIR}\MemmyWindowsUpgradeCleanup.ps1"
     IfErrors memmy_relay_failed
     IfFileExists "$R1\MemmyWindowsUpgradeCleanup.ps1" 0 memmy_relay_failed
+    File /oname=MemmyWindowsDataMigration.ps1 "${BUILD_RESOURCES_DIR}\MemmyWindowsDataMigration.ps1"
+    IfErrors memmy_relay_failed
+    IfFileExists "$R1\MemmyWindowsDataMigration.ps1" 0 memmy_relay_failed
 
     ClearErrors
     FileOpen $0 "$R4" w
@@ -115,7 +521,7 @@ Function MemmyRelayLegacyUpgrade
     Delete "$R8"
 
     ClearErrors
-    ExecShell "open" "$R5" '-NoProfile -NonInteractive -ExecutionPolicy Bypass -WindowStyle Hidden -File $\"$R3$\" -InstallerPath $\"$R4$\" -InstallDir $\"$INSTDIR$\" -OriginalInstallerPid $2 -LegacyHelperPid $3 -ExpectedVersion $\"${VERSION}$\" -ReopenAfterInstall $R6 -ReadyPath $\"$R8$\" -WorkDir $\"$R1$\" -LogPath $\"$R7$\"' SW_HIDE
+    ExecShell "open" "$R5" '-NoProfile -NonInteractive -ExecutionPolicy Bypass -WindowStyle Hidden -File $\"$R3$\" -InstallerPath $\"$R4$\" -InstallDir $\"$INSTDIR$\" -OriginalInstallerPid $2 -LegacyHelperPid $3 -ExpectedVersion $\"${VERSION}$\" -InstalledVersion $\"$MemmyPreviousInstalledVersion$\" -ReopenAfterInstall $R6 -ReadyPath $\"$R8$\" -WorkDir $\"$R1$\" -LogPath $\"$R7$\"' SW_HIDE
     IfErrors memmy_relay_failed
     StrCpy $R9 "0"
 
@@ -152,8 +558,8 @@ Function MemmyReadRelayedUpgradeContext
   memmy_relay_context_validate_path:
     GetFullPathName $4 "$MemmyUpgradeWorkDir"
     StrCmp $4 $MemmyUpgradeWorkDir 0 memmy_relay_context_failed
-    GetFullPathName $5 "$MemmyUpgradeBackupRoot"
-    StrCmp $5 $MemmyUpgradeBackupRoot 0 memmy_relay_context_failed
+    ; The backup root is optional when the previous installation has no data directory.
+    ; Validate its exact deterministic path below without requiring it to exist yet.
     StrCpy $0 "$LOCALAPPDATA\Memmy\upgrade-staging\"
     StrLen $1 $0
     StrLen $2 $MemmyUpgradeWorkDir
@@ -176,31 +582,6 @@ Function MemmyReadRelayedUpgradeContext
     Quit
 FunctionEnd
 
-Function MemmyRestoreRelayedUpgradeData
-  StrCmp $MemmyIsRelayedUpgrade "1" 0 memmy_restore_relayed_data_done
-  StrCpy $0 "$MemmyUpgradeBackupRoot\data-backup"
-  StrCpy $1 "$INSTDIR\data"
-  StrCpy $2 "$MemmyUpgradeBackupRoot\installer-created-data"
-  IfFileExists "$0\*" 0 memmy_restore_relayed_data_failed
-  IfFileExists "$2\*" memmy_restore_relayed_data_failed
-  IfFileExists "$1\*" 0 memmy_restore_relayed_data_backup
-  ClearErrors
-  Rename "$1" "$2"
-  IfErrors memmy_restore_relayed_data_failed
-
-  memmy_restore_relayed_data_backup:
-    ClearErrors
-    Rename "$0" "$1"
-    IfErrors memmy_restore_relayed_data_failed
-    IfFileExists "$1\*" memmy_restore_relayed_data_done memmy_restore_relayed_data_failed
-
-  memmy_restore_relayed_data_failed:
-    SetErrorLevel 3
-    Quit
-
-  memmy_restore_relayed_data_done:
-FunctionEnd
-
 Function MemmyClearRelayedUpgradeMarkers
   StrCmp $MemmyIsRelayedUpgrade "1" 0 memmy_clear_relayed_markers_done
   StrCpy $0 "$INSTDIR\data\Memmy\prepared-required-update.json"
@@ -208,28 +589,8 @@ Function MemmyClearRelayedUpgradeMarkers
   RMDir /r "$0.lock"
   Delete "$0.prompt"
   Delete "$0.attempt"
-  RMDir /r "$LOCALAPPDATA\Memmy\upgrade-staging\active.lock"
 
   memmy_clear_relayed_markers_done:
-FunctionEnd
-
-Function MemmyLaunchRelayedUpgrade
-  StrCmp $MemmyIsRelayedUpgrade "1" 0 memmy_launch_relayed_upgrade_done
-  StrCmp $MemmyUpgradeReopenAfterInstall "1" 0 memmy_launch_relayed_upgrade_done
-  Exec '$\"$INSTDIR\${PRODUCT_FILENAME}.exe$\" --updated'
-
-  memmy_launch_relayed_upgrade_done:
-FunctionEnd
-
-Function MemmyScheduleRelayedUpgradeCleanup
-  StrCmp $MemmyIsRelayedUpgrade "1" 0 memmy_schedule_relayed_cleanup_done
-  StrCpy $0 "$MemmyUpgradeWorkDir\MemmyWindowsUpgradeCleanup.ps1"
-  StrCpy $1 "$SYSDIR\WindowsPowerShell\v1.0\powershell.exe"
-  IfFileExists "$0" 0 memmy_schedule_relayed_cleanup_done
-  IfFileExists "$1" 0 memmy_schedule_relayed_cleanup_done
-  ExecShell "open" "$1" '-NoProfile -NonInteractive -ExecutionPolicy Bypass -WindowStyle Hidden -File $\"$0$\" -WorkDir $\"$MemmyUpgradeWorkDir$\" -BackupRoot $\"$MemmyUpgradeBackupRoot$\"' SW_HIDE
-
-  memmy_schedule_relayed_cleanup_done:
 FunctionEnd
 
 Function MemmyPathContains
@@ -291,22 +652,32 @@ Function MemmyInstallLaunchProxy
   File /oname=Memmy.ico "${BUILD_RESOURCES_DIR}\icon.ico"
   File /oname=MemmyUpdatePrompt.ps1 "${BUILD_RESOURCES_DIR}\MemmyUpdatePrompt.ps1"
   File /oname=MemmyWindowsUpgradeRecovery.ps1 "${BUILD_RESOURCES_DIR}\MemmyWindowsUpgradeRecovery.ps1"
+  File /oname=MemmyWindowsDataMigration.ps1 "${BUILD_RESOURCES_DIR}\MemmyWindowsDataMigration.ps1"
 
   FileOpen $1 "$0\MemmyLauncher.vbs" w
   FileWrite $1 "Set shell = CreateObject($\"WScript.Shell$\")$\r$\n"
   FileWrite $1 "Set fso = CreateObject($\"Scripting.FileSystemObject$\")$\r$\n"
   FileWrite $1 "appExe = $\"$INSTDIR\${PRODUCT_FILENAME}.exe$\"$\r$\n"
-  FileWrite $1 "dataRoot = $\"$INSTDIR\data$\"$\r$\n"
+  FileWrite $1 "userDataRoot = shell.ExpandEnvironmentStrings($\"%APPDATA%$\") & $\"\Memmy$\"$\r$\n"
+  FileWrite $1 "legacyUserDataRoot = $\"$INSTDIR\data\Memmy$\"$\r$\n"
   FileWrite $1 "powerShellPath = shell.ExpandEnvironmentStrings($\"%SystemRoot%$\") & $\"\System32\WindowsPowerShell\v1.0\powershell.exe$\"$\r$\n"
   FileWrite $1 "promptPath = $\"$0\MemmyUpdatePrompt.ps1$\"$\r$\n"
   FileWrite $1 "recoveryPath = $\"$0\MemmyWindowsUpgradeRecovery.ps1$\"$\r$\n"
+  FileWrite $1 "migrationRecoveryPath = $\"$0\MemmyWindowsDataMigration.ps1$\"$\r$\n"
+  FileWrite $1 "migrationStatePath = shell.ExpandEnvironmentStrings($\"%LOCALAPPDATA%$\") & $\"\Memmy\data-migration\state.json$\"$\r$\n"
+  FileWrite $1 "migrationLogPath = shell.ExpandEnvironmentStrings($\"%LOCALAPPDATA%$\") & $\"\Memmy\upgrade-logs\data-migration.log$\"$\r$\n"
   FileWrite $1 "upgradeLogPath = shell.ExpandEnvironmentStrings($\"%LOCALAPPDATA%$\") & $\"\Memmy\upgrade-logs\windows-upgrade.log$\"$\r$\n"
-  FileWrite $1 "languagePath = dataRoot & $\"\Memmy\update-prompt-language.txt$\"$\r$\n"
-  FileWrite $1 "markerPath = dataRoot & $\"\Memmy\prepared-required-update.json$\"$\r$\n"
+  FileWrite $1 "languagePath = userDataRoot & $\"\update-prompt-language.txt$\"$\r$\n"
+  FileWrite $1 "markerPath = userDataRoot & $\"\prepared-required-update.json$\"$\r$\n"
+  FileWrite $1 "legacyMarkerPath = legacyUserDataRoot & $\"\prepared-required-update.json$\"$\r$\n"
+  FileWrite $1 "If (Not fso.FileExists(markerPath)) And (fso.FileExists(legacyMarkerPath) Or fso.FolderExists(legacyMarkerPath & $\".lock$\")) Then$\r$\n"
+  FileWrite $1 "  markerPath = legacyMarkerPath$\r$\n"
+  FileWrite $1 "  languagePath = legacyUserDataRoot & $\"\update-prompt-language.txt$\"$\r$\n"
+  FileWrite $1 "End If$\r$\n"
   FileWrite $1 "lockPath = markerPath & $\".lock$\"$\r$\n"
   FileWrite $1 "relayLockPath = shell.ExpandEnvironmentStrings($\"%LOCALAPPDATA%$\") & $\"\Memmy\upgrade-staging\active.lock$\"$\r$\n"
   FileWrite $1 "If fso.FolderExists(relayLockPath) And fso.FileExists(recoveryPath) Then$\r$\n"
-  FileWrite $1 "  shell.Run Chr(34) & powerShellPath & Chr(34) & $\" -NoProfile -NonInteractive -ExecutionPolicy Bypass -WindowStyle Hidden -File $\" & Chr(34) & recoveryPath & Chr(34) & $\" -InstallDir $\" & Chr(34) & fso.GetParentFolderName(appExe) & Chr(34) & $\" -LockPath $\" & Chr(34) & relayLockPath & Chr(34) & $\" -LogPath $\" & Chr(34) & upgradeLogPath & Chr(34), 0, True$\r$\n"
+  FileWrite $1 "  shell.Run Chr(34) & powerShellPath & Chr(34) & $\" -NoProfile -NonInteractive -ExecutionPolicy Bypass -WindowStyle Hidden -File $\" & Chr(34) & recoveryPath & Chr(34) & $\" -InstallDir $\" & Chr(34) & fso.GetParentFolderName(appExe) & Chr(34) & $\" -LockPath $\" & Chr(34) & relayLockPath & Chr(34) & $\" -LogPath $\" & Chr(34) & upgradeLogPath & Chr(34) & $\" -DirectMigrationStatePath $\" & Chr(34) & migrationStatePath & Chr(34) & $\" -DirectMigrationScriptPath $\" & Chr(34) & migrationRecoveryPath & Chr(34) & $\" -DirectMigrationLogPath $\" & Chr(34) & migrationLogPath & Chr(34), 0, True$\r$\n"
   FileWrite $1 "End If$\r$\n"
   FileWrite $1 "If fso.FolderExists(relayLockPath) Then$\r$\n"
   FileWrite $1 "  lockPath = relayLockPath$\r$\n"

--- a/App/shell/desktop/src/main/main.ts
+++ b/App/shell/desktop/src/main/main.ts
@@ -16,7 +16,7 @@ import type {
 } from "@memmy/desktop-interface";
 import { app, BrowserWindow, clipboard, dialog, ipcMain, Menu, nativeImage, nativeTheme, Notification, screen, shell, systemPreferences, Tray, type Event as ElectronEvent, type FileFilter, type IpcMainEvent, type MenuItemConstructorOptions, type Rectangle, type WebContents } from "electron";
 import { spawn } from "node:child_process";
-import { constants as fsConstants, cpSync, existsSync, mkdirSync, readFileSync } from "node:fs";
+import { constants as fsConstants, existsSync, readFileSync } from "node:fs";
 import { access, appendFile, chmod, copyFile, lstat, mkdir, open, readFile, readdir, rename, rm, stat, symlink, unlink, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { basename, dirname, extname, join, relative, resolve, sep } from "node:path";
@@ -98,6 +98,15 @@ import {
   resolveUpdateSplashHtml,
   type StartupSplashLanguage
 } from "./startup-splash.js";
+import {
+  advanceWindowsDataMigrationAfterBoot,
+  readWindowsDataMigrationConsistency,
+  recoverWindowsDataMigrationForStartup,
+  recordWindowsDataLayoutAfterBoot,
+  resolveWindowsDataLayout,
+  type WindowsDataMigrationConsistency,
+  type WindowsDataLayout
+} from "./windows-data-layout.js";
 
 let mainWindow: BrowserWindow | null = null;
 let petWindow: BrowserWindow | null = null;
@@ -110,6 +119,9 @@ let memoryServiceControl: { baseUrl: string; token: string } | null = null;
 let memoryServiceRestart: Promise<DesktopMemoryServiceRestartResult> | null = null;
 let packagedRendererServer: PackagedRendererStaticServer | null = null;
 let packagedRendererBaseUrl: string | null = null;
+let windowsDataLayout: WindowsDataLayout | null = null;
+const rendererReadyWebContentsIds = new Set<number>();
+const rendererReadyWaiters = new Map<number, (verified: boolean) => void>();
 let queuedPetWindowClose: ReturnType<typeof setTimeout> | null = null;
 let petWindowCloseActivateSuppressionTimer: ReturnType<typeof setTimeout> | null = null;
 let latestPetWindowLayout: PetWindowLayout | null = null;
@@ -312,6 +324,18 @@ async function boot(): Promise<void> {
     registerIpcHandlers();
     await installBundledCliIfNeeded();
     await startPackagedRendererServerIfNeeded();
+    let windowsMigrationConsistency: WindowsDataMigrationConsistency | undefined;
+    if (windowsDataLayout) {
+      try {
+        windowsMigrationConsistency = await readWindowsDataMigrationConsistency(windowsDataLayout);
+      } catch (error) {
+        const recovery = await recoverWindowsDataMigrationForStartup(
+          windowsDataLayout,
+          `migration state could not be read: ${formatStartupError(error)}`
+        );
+        await writePackagedStartupLog(`boot:data-migration-state-failed-open:${JSON.stringify(recovery)}`);
+      }
+    }
     const appDatabaseFile = join(app.getPath("userData"), "app.sqlite");
     runtimeServices = await startManagedRuntimeServices({
       appPath: app.getAppPath(),
@@ -320,11 +344,26 @@ async function boot(): Promise<void> {
       logDirectory: app.getPath("logs"),
       logLevel: getCurrentLogLevel(),
       beforeStartServices: async ({ databasePath, configPath }) => {
-        await syncRuntimeConfigForStartup({
+        const syncOptions = {
           databasePath,
           memmyConfigPath: configPath,
           accountChannel: resolveCurrentDesktopAccountChannel()
-        });
+        };
+        try {
+          await syncRuntimeConfigForStartup({
+            ...syncOptions,
+            ...(windowsMigrationConsistency ? { migrationConsistency: windowsMigrationConsistency } : {})
+          });
+        } catch (error) {
+          if (!windowsDataLayout || !isWindowsDataMigrationConsistencyError(error)) throw error;
+          const recovery = await recoverWindowsDataMigrationForStartup(
+            windowsDataLayout,
+            formatStartupError(error)
+          );
+          windowsMigrationConsistency = undefined;
+          await writePackagedStartupLog(`boot:data-migration-consistency-failed-open:${JSON.stringify(recovery)}`);
+          await syncRuntimeConfigForStartup(syncOptions);
+        }
       },
       runtimeEntries: app.isPackaged
         ? undefined
@@ -335,17 +374,37 @@ async function boot(): Promise<void> {
     });
     runtimeConfig = await startLocalApi(runtimeServices);
     isBootReady = true;
-    createInitialWindow();
+    const initialWindow = createInitialWindow();
     triggerAgentSourceAutoInject("boot");
     if (process.platform === "darwin") {
       syncMenuBarTray(resolveMenuBarIconEnabled());
     }
     setDevelopmentDockIcon();
-    await writePackagedStartupLog("boot:ready");
+    const rendererVerified = !windowsDataLayout || await waitForInitialRendererVerification(initialWindow);
+    await writePackagedStartupLog(rendererVerified ? "boot:ready" : "boot:ready-data-migration-verification-deferred");
+    if (windowsDataLayout && rendererVerified) {
+      await recordWindowsDataLayoutAfterBoot(
+        windowsDataLayout,
+        resolveDesktopAppVersion()
+      ).catch(async (error: unknown) => {
+        console.warn("Windows data layout record deferred:", error);
+        await writePackagedStartupLog(`boot:data-layout-record-deferred\n${formatStartupError(error)}`);
+      });
+      await advanceWindowsDataMigrationAfterBoot(
+        windowsDataLayout,
+        [join(homedir(), ".memmy")]
+      ).catch(async (error: unknown) => {
+        console.warn("Windows data migration cleanup deferred:", error);
+        await writePackagedStartupLog(`boot:data-migration-cleanup-deferred\n${formatStartupError(error)}`);
+      });
+    }
     startRequiredUpdateBackgroundChecks();
     // Fallback cleanup of leftover packages in the updates directory: deferred and async, to avoid
     // the startup peak and not block the window from showing.
-    setTimeout(() => void pruneUpdatesDirectory(), UPDATES_PRUNE_STARTUP_DELAY_MS);
+    setTimeout(() => {
+      void pruneUpdatesDirectory();
+      void pruneWindowsLegacyUpdateCaches();
+    }, UPDATES_PRUNE_STARTUP_DELAY_MS);
   } catch (error) {
     await runtimeServices?.close();
     runtimeServices = null;
@@ -359,9 +418,17 @@ async function boot(): Promise<void> {
  */
 function configureAppIdentity(): void {
   const edition = resolveCurrentDesktopEdition();
-  const userDataPath = resolveDesktopUserDataPath(edition);
-  const memmyHome = resolveDesktopRuntimeHomePath(edition);
-  migratePackagedWindowsDataIfNeeded(edition, userDataPath, memmyHome);
+  windowsDataLayout = resolveWindowsDataLayout({
+    platform: process.platform,
+    isPackaged: app.isPackaged,
+    isWindowsStore: Boolean((process as NodeJS.Process & { windowsStore?: boolean }).windowsStore),
+    executablePath: process.execPath,
+    appDataPath: app.getPath("appData"),
+    localAppDataPath: process.env.LOCALAPPDATA?.trim() ?? "",
+    homeDirectory: homedir()
+  });
+  const userDataPath = windowsDataLayout?.userDataPath ?? resolveDesktopUserDataPath(edition);
+  const memmyHome = windowsDataLayout?.runtimeHomePath ?? resolveDesktopRuntimeHomePath(edition);
   app.setName("Memmy");
   if (process.platform === "win32") {
     app.setAppUserModelId(WINDOWS_APP_USER_MODEL_ID);
@@ -381,64 +448,12 @@ function configureAppIdentity(): void {
   }
 }
 
-function resolvePackagedWindowsDataRoot(): string | null {
-  if (process.platform !== "win32" || !app.isPackaged) {
-    return null;
-  }
-
-  return join(dirname(process.execPath), "data");
-}
-
 function resolveDesktopUserDataPath(edition: DesktopEdition): string {
-  return join(
-    resolvePackagedWindowsDataRoot() ?? app.getPath("appData"),
-    desktopUserDataDirectoryName(edition)
-  );
+  return join(app.getPath("appData"), desktopUserDataDirectoryName(edition));
 }
 
 function resolveDesktopRuntimeHomePath(edition: DesktopEdition): string {
-  return join(
-    resolvePackagedWindowsDataRoot() ?? homedir(),
-    desktopRuntimeHomeDirectoryName(edition)
-  );
-}
-
-function migratePackagedWindowsDataIfNeeded(
-  edition: DesktopEdition,
-  userDataPath: string,
-  memmyHome: string
-): void {
-  if (!resolvePackagedWindowsDataRoot()) {
-    return;
-  }
-
-  copyDirectoryIfMissing(join(app.getPath("appData"), desktopUserDataDirectoryName(edition)), userDataPath);
-  copyDirectoryIfMissing(join(homedir(), desktopRuntimeHomeDirectoryName(edition)), memmyHome);
-}
-
-function copyDirectoryIfMissing(sourcePath: string, targetPath: string): void {
-  if (
-    pathsEqual(sourcePath, targetPath) ||
-    !existsSync(sourcePath) ||
-    existsSync(targetPath)
-  ) {
-    return;
-  }
-
-  try {
-    mkdirSync(dirname(targetPath), { recursive: true });
-    cpSync(sourcePath, targetPath, { recursive: true });
-  } catch (error) {
-    console.warn(`Failed to migrate Memmy data from ${sourcePath} to ${targetPath}:`, error);
-  }
-}
-
-function pathsEqual(left: string, right: string): boolean {
-  const normalizedLeft = resolve(left);
-  const normalizedRight = resolve(right);
-  return process.platform === "win32"
-    ? normalizedLeft.toLowerCase() === normalizedRight.toLowerCase()
-    : normalizedLeft === normalizedRight;
+  return join(homedir(), desktopRuntimeHomeDirectoryName(edition));
 }
 
 /**
@@ -839,6 +854,12 @@ function registerIpcHandlers(): void {
   }
 
   areIpcHandlersRegistered = true;
+
+  ipcMain.on("memmy:renderer-ready", (event) => {
+    const senderId = event.sender.id;
+    rendererReadyWebContentsIds.add(senderId);
+    rendererReadyWaiters.get(senderId)?.(true);
+  });
 
   ipcMain.handle("memmy:get-runtime-config", () => {
     if (!runtimeConfig) {
@@ -2934,7 +2955,7 @@ function scheduleQuitForManualUpdateInstall(): void {
  * @returns The local update package directory.
  */
 function resolveUpdatesDirectory(): string {
-  return join(app.getPath("userData"), "updates");
+  return windowsDataLayout?.updatesPath ?? join(app.getPath("userData"), "updates");
 }
 
 /**
@@ -3024,6 +3045,33 @@ async function pruneUpdatesDirectory(): Promise<void> {
     }
   } catch (error) {
     console.warn("prune updates directory skipped:", error);
+  }
+}
+
+/**
+ * Removes obsolete Windows installer caches after a successful boot. These paths contain copied
+ * installers and relay helpers, not account or memory data. An active unified update lock always
+ * suppresses cleanup so recovery still has every file it needs.
+ */
+async function pruneWindowsLegacyUpdateCaches(): Promise<void> {
+  if (process.platform !== "win32" || !app.isPackaged || !windowsDataLayout) return;
+  const relayLockPath = resolveWindowsUpgradeRelayLockPath();
+  if (!relayLockPath || existsSync(relayLockPath)) return;
+
+  const legacyUserDataUpdatesPath = join(app.getPath("userData"), "updates");
+  if (resolve(legacyUserDataUpdatesPath).toLowerCase() !== resolve(windowsDataLayout.updatesPath).toLowerCase()) {
+    await rm(legacyUserDataUpdatesPath, { recursive: true, force: true }).catch(() => undefined);
+  }
+
+  const stagingRoot = dirname(relayLockPath);
+  const stagingEntries = await readdir(stagingRoot).catch(() => []);
+  await Promise.all(stagingEntries
+    .filter((entry) => entry.toLowerCase() !== "active.lock")
+    .map((entry) => rm(join(stagingRoot, entry), { recursive: true, force: true }).catch(() => undefined)));
+
+  const localAppData = process.env.LOCALAPPDATA?.trim();
+  if (localAppData) {
+    await rm(join(localAppData, "@memmydesktop-updater"), { recursive: true, force: true }).catch(() => undefined);
   }
 }
 
@@ -3362,14 +3410,50 @@ function closeSplashWindow(): void {
   }
 }
 
-function createInitialWindow(): void {
+function createInitialWindow(): BrowserWindow | null {
   if (resolveInitialWindowMode() === "pet") {
     setPetWindowMode(true);
     closeSplashWindow(); // Pet mode starts fast; no splash needed
-    return;
+    return petWindow;
   }
 
-  createMainWindow();
+  return createMainWindow();
+}
+
+function waitForInitialRendererVerification(targetWindow: BrowserWindow | null): Promise<boolean> {
+  if (!targetWindow || targetWindow.isDestroyed()) return Promise.resolve(false);
+  const webContentsId = targetWindow.webContents.id;
+  if (rendererReadyWebContentsIds.has(webContentsId)) return Promise.resolve(true);
+  return new Promise((resolveVerification) => {
+    let settled = false;
+    const finish = (verified: boolean) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      targetWindow.webContents.removeListener("did-fail-load", handleFailed);
+      targetWindow.removeListener("closed", handleClosed);
+      if (rendererReadyWaiters.get(webContentsId) === finish) {
+        rendererReadyWaiters.delete(webContentsId);
+      }
+      resolveVerification(verified);
+    };
+    const handleFailed = (_event: ElectronEvent, _errorCode: number, _errorDescription: string, _validatedUrl: string, isMainFrame: boolean) => {
+      if (isMainFrame) finish(false);
+    };
+    const handleClosed = () => finish(false);
+    const timeout = setTimeout(() => finish(false), 30_000);
+    timeout.unref?.();
+    rendererReadyWaiters.set(webContentsId, finish);
+    targetWindow.webContents.on("did-fail-load", handleFailed);
+    targetWindow.once("closed", handleClosed);
+    if (rendererReadyWebContentsIds.has(webContentsId)) finish(true);
+  });
+}
+
+function isWindowsDataMigrationConsistencyError(error: unknown): boolean {
+  return error instanceof Error
+    && "code" in error
+    && error.code === "windows_data_migration_inconsistent";
 }
 
 /**
@@ -4755,6 +4839,12 @@ app.whenReady().then(async () => {
     // An instance is already running: this instance exits directly, to avoid a second instance
     // contending for the fixed ports (memory 18960 / agent gateway) and causing a startup failure.
     app.quit();
+    return;
+  }
+
+  const windowsUpgradeLockPath = resolveWindowsUpgradeRelayLockPath();
+  if (windowsUpgradeLockPath && existsSync(windowsUpgradeLockPath)) {
+    app.exit(0);
     return;
   }
 

--- a/App/shell/desktop/src/main/windows-data-layout.ts
+++ b/App/shell/desktop/src/main/windows-data-layout.ts
@@ -1,0 +1,555 @@
+import { mkdir, readFile, rename, rm, rmdir, writeFile } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
+import { win32 } from "node:path";
+
+export interface WindowsDataLayout {
+  userDataPath: string;
+  runtimeHomePath: string;
+  updatesPath: string;
+  pointerPath: string;
+  migrationStatePath: string;
+  installationRecordPath: string;
+  legacyInstallDataPath: string;
+}
+
+export interface WindowsDataMigrationConsistency {
+  accountSourceIsAuthoritative: boolean;
+  runtimeSourceWasMigrated: boolean;
+  categorySourcesShareGeneration: boolean;
+}
+
+export interface ResolveWindowsDataLayoutOptions {
+  platform: NodeJS.Platform;
+  isPackaged: boolean;
+  isWindowsStore: boolean;
+  executablePath: string;
+  appDataPath: string;
+  localAppDataPath: string;
+  homeDirectory: string;
+}
+
+export const resolveWindowsDataLayout = (
+  options: ResolveWindowsDataLayoutOptions
+): WindowsDataLayout | null => {
+  if (options.platform !== "win32" || !options.isPackaged) {
+    return null;
+  }
+
+  const userDataPath = win32.join(options.appDataPath, "Memmy");
+  const legacyRuntimeHomePath = win32.join(options.homeDirectory, ".memmy");
+  const installationRoot = win32.parse(options.executablePath).root;
+  const useLegacyRuntimeHome = options.isWindowsStore
+    || !installationRoot
+    || sameWindowsRoot(installationRoot, "C:\\");
+  const dataContainerPath = useLegacyRuntimeHome
+    ? legacyRuntimeHomePath
+    : win32.join(installationRoot, "MemmyData");
+  const runtimeHomePath = useLegacyRuntimeHome
+    ? legacyRuntimeHomePath
+    : win32.join(dataContainerPath, ".memmy");
+  const localAppDataPath = options.localAppDataPath
+    || win32.join(options.homeDirectory, "AppData", "Local");
+
+  return {
+    userDataPath,
+    runtimeHomePath,
+    updatesPath: win32.join(dataContainerPath, "updates"),
+    pointerPath: win32.join(userDataPath, "data-root.txt"),
+    migrationStatePath: win32.join(localAppDataPath, "Memmy", "data-migration", "state.json"),
+    installationRecordPath: win32.join(localAppDataPath, "Memmy", "data-layout", "last-install.json"),
+    legacyInstallDataPath: win32.join(win32.dirname(options.executablePath), "data")
+  };
+};
+
+interface WindowsDataMigrationState {
+  owner?: unknown;
+  phase?: unknown;
+  sourceDataPath?: unknown;
+  sourceAuthority?: unknown;
+  sourceInstallDir?: unknown;
+  targetUserDataPath?: unknown;
+  targetRuntimeHomePath?: unknown;
+  backupPaths?: unknown;
+  runtimeSourcePath?: unknown;
+  runtimeSourcePaths?: unknown;
+  accountSourceAuthority?: unknown;
+  runtimeSourceAuthority?: unknown;
+  categorySourcesShareGeneration?: unknown;
+  preparedCopies?: unknown;
+  previousPointerExisted?: unknown;
+  previousPointerBytesBase64?: unknown;
+  deferredCleanupStates?: unknown;
+}
+
+const trustedInstallAuthorities = new Set([
+  "current-install-authority",
+  "selected-install-authority",
+  "relay-backup-authority",
+  "persisted-install-authority"
+]);
+
+export const readWindowsDataMigrationConsistency = async (
+  layout: WindowsDataLayout
+): Promise<WindowsDataMigrationConsistency | undefined> => {
+  let state: WindowsDataMigrationState;
+  try {
+    state = JSON.parse(await readFile(layout.migrationStatePath, "utf8")) as WindowsDataMigrationState;
+  } catch (error) {
+    if (isMissingFileError(error)) return undefined;
+    throw error;
+  }
+  validateMigrationTargets(state, layout);
+  const phase = String(state.phase);
+  if (phase === "prepared" || phase === "recovery-required") {
+    throw new Error(`Windows data migration requires startup rollback in phase ${phase}`);
+  }
+  if (!["prepared-for-retry", "awaiting-app-verification", "app-verified"].includes(phase)) {
+    return undefined;
+  }
+  const accountSourceIsAuthoritative = typeof state.accountSourceAuthority === "string"
+    && trustedInstallAuthorities.has(state.accountSourceAuthority);
+  const runtimeSourceWasMigrated = typeof state.runtimeSourceAuthority === "string"
+    && state.runtimeSourceAuthority !== "target-existing";
+  if (!accountSourceIsAuthoritative && !runtimeSourceWasMigrated) return undefined;
+  return {
+    accountSourceIsAuthoritative,
+    runtimeSourceWasMigrated,
+    categorySourcesShareGeneration: state.categorySourcesShareGeneration === true
+  };
+};
+
+export interface WindowsDataMigrationStartupRecoveryResult {
+  status: "none" | "rolled-back" | "quarantined";
+  reason?: string;
+  quarantinePath?: string;
+}
+
+/**
+ * Fails open when a migrated account/runtime pair cannot safely start. Valid prepared
+ * copies are rolled back idempotently; malformed or unsafe state is quarantined without
+ * deleting any data or rollback directory.
+ */
+export const recoverWindowsDataMigrationForStartup = async (
+  layout: WindowsDataLayout,
+  reason: string
+): Promise<WindowsDataMigrationStartupRecoveryResult> => {
+  let state: WindowsDataMigrationState;
+  try {
+    state = JSON.parse(await readFile(layout.migrationStatePath, "utf8")) as WindowsDataMigrationState;
+  } catch (error) {
+    if (isMissingFileError(error)) return { status: "none" };
+    const quarantinePath = await quarantineMigrationState(layout.migrationStatePath);
+    return { status: "quarantined", reason: `${reason}: ${String(error)}`, ...(quarantinePath ? { quarantinePath } : {}) };
+  }
+
+  try {
+    validateMigrationTargets(state, layout);
+    const copies = validatePreparedCopiesForRollback(state.preparedCopies, layout).reverse();
+    for (const copy of copies) {
+      if (copy.stagingPath) {
+        await rm(copy.stagingPath, { recursive: true, force: true });
+      }
+      if (copy.backupPath) {
+        try {
+          await rename(copy.backupPath, copy.destinationPath);
+        } catch (error) {
+          if (!isMissingFileError(error)) {
+            await rm(copy.destinationPath, { recursive: true, force: true });
+            await rename(copy.backupPath, copy.destinationPath);
+          }
+        }
+      } else {
+        await rm(copy.destinationPath, { recursive: true, force: true });
+      }
+    }
+
+    if (state.previousPointerExisted === true) {
+      if (typeof state.previousPointerBytesBase64 !== "string") {
+        throw new Error("Previous Windows data-root pointer contents are unavailable");
+      }
+      await mkdir(win32.dirname(layout.pointerPath), { recursive: true });
+      const temporaryPointerPath = `${layout.pointerPath}.rollback-${randomUUID()}`;
+      await writeFile(temporaryPointerPath, Buffer.from(state.previousPointerBytesBase64, "base64"), { flag: "wx" });
+      await rename(temporaryPointerPath, layout.pointerPath);
+    } else {
+      await rm(layout.pointerPath, { force: true });
+    }
+    await rm(layout.migrationStatePath, { force: true });
+    return { status: "rolled-back", reason };
+  } catch (error) {
+    const quarantinePath = await quarantineMigrationState(layout.migrationStatePath);
+    return { status: "quarantined", reason: `${reason}: ${String(error)}`, ...(quarantinePath ? { quarantinePath } : {}) };
+  }
+};
+
+export const recordWindowsDataLayoutAfterBoot = async (
+  layout: WindowsDataLayout,
+  appVersion: string
+): Promise<void> => {
+  await writeJsonAtomically(layout.installationRecordPath, {
+    schemaVersion: 1,
+    dataLayoutGeneration: "external-v1",
+    installDir: win32.dirname(layout.legacyInstallDataPath),
+    userDataPath: layout.userDataPath,
+    runtimeHomePath: layout.runtimeHomePath,
+    appVersion,
+    recordedAt: new Date().toISOString()
+  });
+};
+
+/**
+ * Advances installer-owned migration cleanup only after the new runtime has completed a boot.
+ * The first successful boot records verification. A later successful boot removes validated
+ * rollback copies, so a just-installed app always has one full-boot rollback window.
+ */
+export const advanceWindowsDataMigrationAfterBoot = async (
+  layout: WindowsDataLayout,
+  trustedLegacyRuntimeHomePaths: string[] = []
+): Promise<"none" | "verified" | "cleaned"> => {
+  let state: WindowsDataMigrationState;
+  try {
+    state = JSON.parse(await readFile(layout.migrationStatePath, "utf8")) as WindowsDataMigrationState;
+  } catch (error) {
+    if (isMissingFileError(error)) return "none";
+    throw error;
+  }
+
+  validateMigrationTargets(state, layout);
+
+  if (
+    state.phase === "awaiting-app-verification"
+    || state.phase === "prepared-for-retry"
+  ) {
+    await writeMigrationStateAtomically(layout.migrationStatePath, {
+      ...state,
+      phase: "app-verified",
+      appVerifiedAt: new Date().toISOString()
+    });
+    return "verified";
+  }
+
+  if (state.phase !== "app-verified") return "none";
+
+  const cleanupStates = [
+    ...(Array.isArray(state.deferredCleanupStates)
+      ? state.deferredCleanupStates.filter((value): value is WindowsDataMigrationState => Boolean(value && typeof value === "object"))
+      : []),
+    state
+  ];
+  for (const cleanupState of cleanupStates) {
+    const cleanupLayout = resolveValidatedCleanupLayout(cleanupState, layout, trustedLegacyRuntimeHomePaths);
+    if (!cleanupLayout) continue;
+    const backupPaths = Array.isArray(cleanupState.backupPaths)
+      ? cleanupState.backupPaths.filter((value): value is string => typeof value === "string")
+      : [];
+    for (const backupPath of backupPaths) {
+      if (isValidatedTargetBackup(backupPath, cleanupLayout)) {
+        await rm(backupPath, { recursive: true, force: true });
+      }
+    }
+
+    for (const sourcePath of resolveValidatedRuntimeSourcesForCleanup(
+      cleanupState,
+      cleanupLayout,
+      trustedLegacyRuntimeHomePaths
+    )) {
+      await rm(sourcePath, { recursive: true, force: true });
+    }
+
+    await cleanupValidatedInstallSources(cleanupState, cleanupLayout);
+
+    if (typeof cleanupState.sourceDataPath === "string") {
+      const relayBackupRoot = resolveValidatedRelayBackupRoot(cleanupState, cleanupLayout);
+      if (relayBackupRoot) {
+        await rm(relayBackupRoot, { recursive: true, force: true });
+        await rmdir(win32.dirname(relayBackupRoot)).catch((error: unknown) => {
+          if (!isMissingFileError(error) && !isDirectoryNotEmptyError(error)) throw error;
+        });
+      }
+    }
+  }
+
+  await rm(layout.migrationStatePath, { force: true });
+  return "cleaned";
+};
+
+const sameWindowsRoot = (left: string, right: string): boolean =>
+  left.replace(/[\\/]+$/u, "").toLowerCase()
+  === right.replace(/[\\/]+$/u, "").toLowerCase();
+
+const sameWindowsPath = (left: string, right: string): boolean =>
+  win32.normalize(left).toLowerCase() === win32.normalize(right).toLowerCase();
+
+const isValidatedTargetBackup = (backupPath: string, layout: WindowsDataLayout): boolean => {
+  const normalizedBackupPath = win32.normalize(backupPath);
+  return [layout.userDataPath, layout.runtimeHomePath].some((targetPath) => {
+    const prefix = `${win32.normalize(targetPath)}.migration-backup-`;
+    const suffix = normalizedBackupPath.slice(prefix.length);
+    return normalizedBackupPath.toLowerCase().startsWith(prefix.toLowerCase())
+      && /^[a-f0-9]{32}$/iu.test(suffix);
+  });
+};
+
+const resolveValidatedRuntimeSourcesForCleanup = (
+  state: WindowsDataMigrationState,
+  layout: WindowsDataLayout,
+  trustedLegacyRuntimeHomePaths: string[]
+): string[] => {
+  if (!Array.isArray(state.preparedCopies)) return [];
+
+  const explicitlyTrustedSources = new Set(
+    trustedLegacyRuntimeHomePaths.map((path) => win32.normalize(path).toLowerCase())
+  );
+  const copiedRuntimeSources = new Set<string>();
+  for (const copy of state.preparedCopies) {
+    if (!copy || typeof copy !== "object") continue;
+    const sourcePath = "SourcePath" in copy ? copy.SourcePath : undefined;
+    const destinationPath = "DestinationPath" in copy ? copy.DestinationPath : undefined;
+    if (
+      typeof sourcePath === "string"
+      && win32.isAbsolute(sourcePath)
+      && typeof destinationPath === "string"
+      && sameWindowsPath(destinationPath, layout.runtimeHomePath)
+    ) {
+      copiedRuntimeSources.add(win32.normalize(sourcePath).toLowerCase());
+    }
+  }
+
+  const candidates = Array.isArray(state.runtimeSourcePaths)
+    ? state.runtimeSourcePaths
+    : [state.runtimeSourcePath];
+  const validated: string[] = [];
+  for (const candidate of candidates) {
+    if (typeof candidate !== "string" || !win32.isAbsolute(candidate)) continue;
+    const normalizedCandidate = win32.normalize(candidate);
+    if (sameWindowsPath(normalizedCandidate, layout.runtimeHomePath)) continue;
+    const candidateKey = normalizedCandidate.toLowerCase();
+    if (!copiedRuntimeSources.has(candidateKey)) continue;
+
+    const root = win32.parse(normalizedCandidate).root;
+    const canonicalDriveRuntimeHome = win32.join(root, "MemmyData", ".memmy");
+    if (
+      !sameWindowsPath(normalizedCandidate, canonicalDriveRuntimeHome)
+      && !explicitlyTrustedSources.has(candidateKey)
+    ) {
+      continue;
+    }
+    if (!validated.some((path) => sameWindowsPath(path, normalizedCandidate))) {
+      validated.push(normalizedCandidate);
+    }
+  }
+  return validated;
+};
+
+const resolveValidatedRelayBackupRoot = (
+  state: WindowsDataMigrationState,
+  layout: WindowsDataLayout
+): string | null => {
+  if (
+    state.owner !== "relay"
+    || typeof state.sourceDataPath !== "string"
+    || typeof state.sourceInstallDir !== "string"
+    || !win32.isAbsolute(state.sourceInstallDir)
+    || !sameWindowsPath(state.sourceInstallDir, win32.dirname(layout.legacyInstallDataPath))
+    || !Array.isArray(state.preparedCopies)
+  ) return null;
+  const normalizedSourcePath = win32.normalize(state.sourceDataPath);
+  if (win32.basename(normalizedSourcePath).toLowerCase() !== "data-backup") return null;
+  const backupRoot = win32.dirname(normalizedSourcePath);
+  const backupParent = win32.dirname(backupRoot);
+  const workLeaf = win32.basename(backupRoot);
+  const sourceInstallDir = win32.normalize(state.sourceInstallDir);
+  const expectedBackupParent = `${sourceInstallDir}.memmy-upgrade-backup`;
+  if (!/^\d+$/u.test(workLeaf) || !sameWindowsPath(backupParent, expectedBackupParent)) return null;
+  const copiedFromRelayBackup = state.preparedCopies.some((copy) => {
+    if (!copy || typeof copy !== "object") return false;
+    const sourcePath = "SourcePath" in copy ? copy.SourcePath : undefined;
+    const destinationPath = "DestinationPath" in copy ? copy.DestinationPath : undefined;
+    return typeof sourcePath === "string"
+      && typeof destinationPath === "string"
+      && (
+        (sameWindowsPath(sourcePath, win32.join(normalizedSourcePath, "Memmy"))
+          && sameWindowsPath(destinationPath, layout.userDataPath))
+        || (sameWindowsPath(sourcePath, win32.join(normalizedSourcePath, ".memmy"))
+          && sameWindowsPath(destinationPath, layout.runtimeHomePath))
+      );
+  });
+  return copiedFromRelayBackup ? backupRoot : null;
+};
+
+const resolveValidatedCleanupLayout = (
+  state: WindowsDataMigrationState,
+  layout: WindowsDataLayout,
+  trustedLegacyRuntimeHomePaths: string[]
+): WindowsDataLayout | null => {
+  if (
+    typeof state.targetUserDataPath !== "string"
+    || typeof state.targetRuntimeHomePath !== "string"
+    || !sameWindowsPath(state.targetUserDataPath, layout.userDataPath)
+    || !win32.isAbsolute(state.targetRuntimeHomePath)
+  ) return null;
+  const runtimePath = win32.normalize(state.targetRuntimeHomePath);
+  const canonicalRuntimePath = win32.join(win32.parse(runtimePath).root, "MemmyData", ".memmy");
+  const runtimeIsTrusted = sameWindowsPath(runtimePath, layout.runtimeHomePath)
+    || sameWindowsPath(runtimePath, canonicalRuntimePath)
+    || trustedLegacyRuntimeHomePaths.some((candidate) => sameWindowsPath(candidate, runtimePath));
+  return runtimeIsTrusted ? { ...layout, runtimeHomePath: runtimePath } : null;
+};
+
+const cleanupValidatedInstallSources = async (
+  state: WindowsDataMigrationState,
+  layout: WindowsDataLayout
+): Promise<void> => {
+  if (
+    !trustedInstallAuthorities.has(String(state.sourceAuthority))
+    || state.sourceAuthority === "relay-backup-authority"
+    || typeof state.sourceDataPath !== "string"
+    || typeof state.sourceInstallDir !== "string"
+    || !win32.isAbsolute(state.sourceDataPath)
+    || !win32.isAbsolute(state.sourceInstallDir)
+    || !Array.isArray(state.preparedCopies)
+  ) return;
+
+  const sourceDataPath = win32.normalize(state.sourceDataPath);
+  const sourceInstallDir = win32.normalize(state.sourceInstallDir);
+  if (!sameWindowsPath(sourceInstallDir, win32.dirname(layout.legacyInstallDataPath))) return;
+  const directDataPath = win32.join(sourceInstallDir, "data");
+  const failedBackupRoot = win32.dirname(sourceDataPath);
+  const failedBackupParent = win32.dirname(failedBackupRoot);
+  const isFailedBackup = win32.basename(sourceDataPath).toLowerCase() === "data-backup"
+    && sameWindowsPath(failedBackupParent, `${sourceInstallDir}.memmy-migration-failed`)
+    && /^[0-9]{14}-[a-f0-9]{32}$/iu.test(win32.basename(failedBackupRoot));
+  if (!sameWindowsPath(sourceDataPath, directDataPath) && !isFailedBackup) return;
+
+  const validatedSources: string[] = [];
+  for (const copy of state.preparedCopies) {
+    if (!copy || typeof copy !== "object") continue;
+    const sourcePath = "SourcePath" in copy ? copy.SourcePath : undefined;
+    const destinationPath = "DestinationPath" in copy ? copy.DestinationPath : undefined;
+    if (typeof sourcePath !== "string" || typeof destinationPath !== "string") continue;
+    const isAccountCopy = sameWindowsPath(sourcePath, win32.join(sourceDataPath, "Memmy"))
+      && sameWindowsPath(destinationPath, layout.userDataPath);
+    const isRuntimeCopy = sameWindowsPath(sourcePath, win32.join(sourceDataPath, ".memmy"))
+      && sameWindowsPath(destinationPath, layout.runtimeHomePath);
+    if ((isAccountCopy || isRuntimeCopy) && !validatedSources.some((path) => sameWindowsPath(path, sourcePath))) {
+      validatedSources.push(sourcePath);
+    }
+  }
+  for (const sourcePath of validatedSources) {
+    await rm(sourcePath, { recursive: true, force: true });
+  }
+  if (isFailedBackup && validatedSources.length > 0) {
+    await rm(failedBackupRoot, { recursive: true, force: true });
+    await rmdir(failedBackupParent).catch((error: unknown) => {
+      if (!isMissingFileError(error) && !isDirectoryNotEmptyError(error)) throw error;
+    });
+  }
+};
+
+const writeJsonAtomically = async (statePath: string, state: object): Promise<void> => {
+  await mkdir(win32.dirname(statePath), { recursive: true });
+  const temporaryPath = `${statePath}.tmp-${process.pid}-${randomUUID()}`;
+  try {
+    await writeFile(temporaryPath, JSON.stringify(state, null, 2), { encoding: "utf8", flag: "wx" });
+    await rename(temporaryPath, statePath);
+  } catch (error) {
+    await rm(temporaryPath, { force: true });
+    throw error;
+  }
+};
+
+const writeMigrationStateAtomically = writeJsonAtomically;
+
+const validateMigrationTargets = (
+  state: WindowsDataMigrationState,
+  layout: WindowsDataLayout
+): void => {
+  if (
+    typeof state.targetUserDataPath !== "string"
+    || typeof state.targetRuntimeHomePath !== "string"
+    || !sameWindowsPath(state.targetUserDataPath, layout.userDataPath)
+    || !sameWindowsPath(state.targetRuntimeHomePath, layout.runtimeHomePath)
+  ) {
+    throw new Error("Windows data migration state does not match the active data layout");
+  }
+};
+
+const validatePreparedCopiesForRollback = (
+  preparedCopies: unknown,
+  layout: WindowsDataLayout
+): Array<{ destinationPath: string; backupPath?: string; stagingPath?: string }> => {
+  if (!Array.isArray(preparedCopies)) return [];
+  const validated: Array<{ destinationPath: string; backupPath?: string; stagingPath?: string }> = [];
+  const destinationKeys = new Set<string>();
+  for (const value of preparedCopies) {
+    if (!value || typeof value !== "object") continue;
+    const destinationPath = "DestinationPath" in value ? value.DestinationPath : undefined;
+    const backupPath = "BackupPath" in value ? value.BackupPath : undefined;
+    const stagingPath = "StagingPath" in value ? value.StagingPath : undefined;
+    if (
+      typeof destinationPath !== "string"
+      || ![layout.userDataPath, layout.runtimeHomePath].some((target) => sameWindowsPath(target, destinationPath))
+    ) {
+      throw new Error("Prepared Windows migration copy has an unsafe destination");
+    }
+    const normalizedDestinationPath = win32.normalize(destinationPath);
+    const destinationKey = normalizedDestinationPath.toLowerCase();
+    if (destinationKeys.has(destinationKey)) {
+      throw new Error("Prepared Windows migration state contains a duplicate destination");
+    }
+    destinationKeys.add(destinationKey);
+    let normalizedStagingPath: string | undefined;
+    if (stagingPath !== null && stagingPath !== undefined) {
+      normalizedStagingPath = typeof stagingPath === "string" ? win32.normalize(stagingPath) : "";
+      const expectedStagingPrefix = `${normalizedDestinationPath}.migrating-`;
+      const stagingSuffix = normalizedStagingPath.slice(expectedStagingPrefix.length);
+      if (
+        typeof stagingPath !== "string"
+        || !normalizedStagingPath.toLowerCase().startsWith(expectedStagingPrefix.toLowerCase())
+        || !/^[a-f0-9]{32}$/iu.test(stagingSuffix)
+      ) {
+        throw new Error("Prepared Windows migration copy has an unsafe staging path");
+      }
+    }
+    if (backupPath !== null && backupPath !== undefined) {
+      const normalizedBackupPath = typeof backupPath === "string" ? win32.normalize(backupPath) : "";
+      const expectedPrefix = `${normalizedDestinationPath}.migration-backup-`;
+      const suffix = normalizedBackupPath.slice(expectedPrefix.length);
+      if (
+        typeof backupPath !== "string"
+        || !normalizedBackupPath.toLowerCase().startsWith(expectedPrefix.toLowerCase())
+        || !/^[a-f0-9]{32}$/iu.test(suffix)
+      ) {
+        throw new Error("Prepared Windows migration copy has an unsafe backup");
+      }
+      validated.push({
+        destinationPath: normalizedDestinationPath,
+        backupPath: normalizedBackupPath,
+        ...(normalizedStagingPath ? { stagingPath: normalizedStagingPath } : {})
+      });
+    } else {
+      validated.push({
+        destinationPath: normalizedDestinationPath,
+        ...(normalizedStagingPath ? { stagingPath: normalizedStagingPath } : {})
+      });
+    }
+  }
+  return validated;
+};
+
+const quarantineMigrationState = async (statePath: string): Promise<string | undefined> => {
+  const quarantinePath = `${statePath}.startup-failed-${Date.now()}-${randomUUID()}`;
+  try {
+    await rename(statePath, quarantinePath);
+    return quarantinePath;
+  } catch (error) {
+    if (!isMissingFileError(error)) return undefined;
+    return undefined;
+  }
+};
+
+const isMissingFileError = (error: unknown): error is NodeJS.ErrnoException =>
+  error instanceof Error && "code" in error && error.code === "ENOENT";
+
+const isDirectoryNotEmptyError = (error: unknown): error is NodeJS.ErrnoException =>
+  error instanceof Error && "code" in error && error.code === "ENOTEMPTY";

--- a/App/shell/desktop/src/preload/preload.cts
+++ b/App/shell/desktop/src/preload/preload.cts
@@ -23,6 +23,7 @@ type DiagnosticsReportExportResult = { canceled: true } | DiagnosticsReportExpor
 
 interface MemmyPreloadApi {
   platform: string;
+  notifyRendererReady(): void;
   getRuntimeConfig(): Promise<unknown>;
   getAppInfo(): Promise<DesktopAppInfo>;
   getInstallationId(): Promise<string>;
@@ -110,6 +111,10 @@ ipcRenderer.on("memmy:main-window-action-requested", (_event: IpcRendererEvent, 
 
 const memmyPreloadApi: MemmyPreloadApi = {
   platform: process.platform,
+
+  notifyRendererReady(): void {
+    ipcRenderer.send("memmy:renderer-ready");
+  },
 
   async getRuntimeConfig(): Promise<unknown> {
     return ipcRenderer.invoke("memmy:get-runtime-config");

--- a/App/shell/desktop/tests/packaged-runtime-boundary.test.ts
+++ b/App/shell/desktop/tests/packaged-runtime-boundary.test.ts
@@ -5,6 +5,7 @@ import { parse as parseYaml } from "yaml";
 
 const mainSourcePath = fileURLToPath(new URL("../src/main/main.ts", import.meta.url));
 const preloadSourcePath = fileURLToPath(new URL("../src/preload/preload.cts", import.meta.url));
+const frontendAppSourcePath = fileURLToPath(new URL("../../../frontend/desktop/src/app.tsx", import.meta.url));
 const runtimeServicesPath = fileURLToPath(new URL("../src/main/runtime-services.ts", import.meta.url));
 const backendSourcePath = fileURLToPath(new URL("../../../backend/src/index.ts", import.meta.url));
 const agentCommandsPath = fileURLToPath(
@@ -34,6 +35,7 @@ const winUnsignedBuilderPath = fileURLToPath(new URL("../electron-builder.win.un
 const winUnsignedInstallerIncludePath = fileURLToPath(new URL("../build/installer-win-unsigned.nsh", import.meta.url));
 const winUpgradeRelayScriptPath = fileURLToPath(new URL("../build/MemmyWindowsUpgradeRelay.ps1", import.meta.url));
 const winUpgradeRecoveryScriptPath = fileURLToPath(new URL("../build/MemmyWindowsUpgradeRecovery.ps1", import.meta.url));
+const winDataMigrationScriptPath = fileURLToPath(new URL("../build/MemmyWindowsDataMigration.ps1", import.meta.url));
 const desktopInterfacePath = fileURLToPath(new URL("../interface/src/index.ts", import.meta.url));
 const localApiContractsPath = fileURLToPath(new URL("../../../../App/backend/local-api-contracts/src/index.ts", import.meta.url));
 const rootPackagePath = fileURLToPath(new URL("../../../../package.json", import.meta.url));
@@ -447,10 +449,14 @@ describe("desktop packaged runtime boundaries", () => {
     const source = readFileSync(mainSourcePath, "utf8");
 
     expect(source).toContain('app.setName("Memmy");');
-    expect(source).toContain("const userDataPath = resolveDesktopUserDataPath(edition);");
-    expect(source).toContain("const memmyHome = resolveDesktopRuntimeHomePath(edition);");
+    expect(source).toContain("windowsDataLayout = resolveWindowsDataLayout({");
+    expect(source).toContain("const userDataPath = windowsDataLayout?.userDataPath ?? resolveDesktopUserDataPath(edition);");
+    expect(source).toContain("const memmyHome = windowsDataLayout?.runtimeHomePath ?? resolveDesktopRuntimeHomePath(edition);");
     expect(source).toContain('app.setPath("userData", userDataPath);');
-    expect(source).toContain('return join(dirname(process.execPath), "data");');
+    expect(source).not.toContain('return join(dirname(process.execPath), "data");');
+    expect(source).toContain('windowsDataLayout?.updatesPath ?? join(app.getPath("userData"), "updates")');
+    expect(source).toContain("advanceWindowsDataMigrationAfterBoot(");
+    expect(source).toContain('[join(homedir(), ".memmy")]');
     expect(source).toContain("process.env.MEMMY_MEMORY_DB = memoryDatabasePath;");
     expect(source).toContain('const appDatabaseFile = join(app.getPath("userData"), "app.sqlite");');
     expect(source).toContain("accountChannel: resolveCurrentDesktopAccountChannel()");
@@ -465,6 +471,42 @@ describe("desktop packaged runtime boundaries", () => {
     expect(source).toContain("resolveDevelopmentRuntimeEntryPaths(import.meta.dirname)");
     expect(source).toContain("memmyConfigPath: process.env.MEMMY_CONFIG");
     expect(source).not.toContain("startDesktopRuntimeServices");
+  });
+
+  it("waits for an active renderer bootstrap handshake before verifying migrated data", () => {
+    const mainSource = readFileSync(mainSourcePath, "utf8");
+    const preloadSource = readFileSync(preloadSourcePath, "utf8");
+    const frontendSource = readFileSync(frontendAppSourcePath, "utf8");
+    const verificationStart = mainSource.indexOf("function waitForInitialRendererVerification");
+    const verificationEnd = mainSource.indexOf("function isWindowsDataMigrationConsistencyError", verificationStart);
+    const verificationSource = mainSource.slice(verificationStart, verificationEnd);
+
+    expect(mainSource).toContain('ipcMain.on("memmy:renderer-ready"');
+    expect(preloadSource).toContain('ipcRenderer.send("memmy:renderer-ready")');
+    expect(frontendSource).toContain("window.memmy.notifyRendererReady()");
+    expect(frontendSource).toContain("!clients");
+    expect(frontendSource).toContain("!state.bootstrap");
+    expect(verificationSource).toContain("rendererReadyWaiters.set");
+    expect(verificationSource).not.toContain("did-finish-load");
+  });
+
+  it("journals each prepared Windows data copy before later migration steps can fail", () => {
+    const migrationSource = readFileSync(winDataMigrationScriptPath, "utf8");
+    const transactionStart = migrationSource.indexOf("function Invoke-TransactionalDirectoryCopy");
+    const transactionEnd = migrationSource.indexOf("function Write-UnicodeFileAtomically", transactionStart);
+    const transactionSource = migrationSource.slice(transactionStart, transactionEnd);
+    const journalIndex = transactionSource.indexOf("Write-PreparedRollbackJournal");
+    const destinationBackupMoveIndex = transactionSource.indexOf("Move-Item -LiteralPath $Destination -Destination $backupPath");
+    const stagedReplacementMoveIndex = transactionSource.indexOf("Move-Item -LiteralPath $stagingPath -Destination $Destination");
+
+    expect(journalIndex).toBeGreaterThan(-1);
+    expect(destinationBackupMoveIndex).toBeGreaterThan(journalIndex);
+    expect(stagedReplacementMoveIndex).toBeGreaterThan(journalIndex);
+    expect(transactionSource).toContain("-Copies @($PreviouslyPreparedCopies + $copyRecord)");
+    expect(transactionSource).toContain("StagingPath = $stagingPath");
+    expect(migrationSource).toContain('Prepared copy staging path is outside the validated migration staging path');
+    expect(migrationSource).toContain('phase = "recovery-required"');
+    expect(migrationSource).toContain("rollback requires recovery from '$StatePath'");
   });
 
   it("persists gtag client_id into the shared ~/.memmy analytics-client-id file", () => {
@@ -548,6 +590,24 @@ describe("desktop packaged runtime boundaries", () => {
     expect(includeSource).toContain("CRCCheck off");
   });
 
+  it("uses the exact-image close-and-verify flow in both the installer and uninstaller", () => {
+    const includeSource = readFileSync(winUnsignedInstallerIncludePath, "utf8");
+    const installerOnlyStart = includeSource.indexOf("!ifndef BUILD_UNINSTALLER");
+    const customCheckStart = includeSource.indexOf("!macro customCheckAppRunning");
+    const customCheckEnd = includeSource.indexOf("!macroend", customCheckStart);
+    const customCheckSource = includeSource.slice(customCheckStart, customCheckEnd);
+    const pidDeclaration = includeSource.indexOf("Var pid");
+
+    expect(customCheckStart).toBeGreaterThan(-1);
+    expect(customCheckStart).toBeLessThan(installerOnlyStart);
+    expect(pidDeclaration).toBeGreaterThan(-1);
+    expect(pidDeclaration).toBeLessThan(installerOnlyStart);
+    expect(customCheckSource).toContain("!insertmacro _CHECK_APP_RUNNING");
+    expect(customCheckSource).toContain('StrCpy $IsPowerShellAvailable "1"');
+    expect(customCheckSource).toContain("!ifndef BUILD_UNINSTALLER");
+    expect(customCheckSource).toContain("Call MemmyPrepareDirectDataMigration");
+  });
+
   it("relays legacy in-app upgrades outside the installed data directory", () => {
     const signedBuilderConfig = readFileSync(winElectronBuilderPath, "utf8");
     const unsignedBuilderConfig = readFileSync(winUnsignedBuilderPath, "utf8");
@@ -564,14 +624,18 @@ describe("desktop packaged runtime boundaries", () => {
     expect(includeSource).toContain("MemmyWindowsUpgradeRecovery.ps1");
     expect(includeSource).toContain('$LOCALAPPDATA\\Memmy\\upgrade-staging');
     expect(includeSource).toContain("GetCurrentProcessId");
+    expect(includeSource).toContain('ReadRegStr $MemmyPreviousInstalledVersion HKCU "${UNINSTALL_REGISTRY_KEY}" "DisplayVersion"');
+    expect(includeSource).not.toContain('ReadRegStr $MemmyPreviousInstalledVersion HKCU "${INSTALL_REGISTRY_KEY}" "DisplayVersion"');
     expect(includeSource).toContain('upgrade-staging\\$2');
     expect(includeSource).toContain("OriginalInstallerPid $2");
     expect(includeSource).toContain("LegacyHelperPid $3");
     expect(includeSource).toContain("ReopenAfterInstall");
-    expect(includeSource).toContain("Call MemmyRestoreRelayedUpgradeData");
+    expect(includeSource).toContain('$APPDATA\\Memmy\\prepared-required-update.json');
+    expect(includeSource).toContain("MemmyWindowsDataMigration.ps1");
+    expect(includeSource).not.toContain("Call MemmyRestoreRelayedUpgradeData");
     expect(includeSource).toContain("Call MemmyClearRelayedUpgradeMarkers");
-    expect(includeSource).toContain("Call MemmyLaunchRelayedUpgrade");
-    expect(includeSource).toContain("Call MemmyScheduleRelayedUpgradeCleanup");
+    expect(includeSource).not.toContain("Call MemmyLaunchRelayedUpgrade");
+    expect(includeSource).not.toContain("Call MemmyScheduleRelayedUpgradeCleanup");
     expect(includeSource).toContain("MEMMY_UPGRADE_WORK_DIR");
     expect(includeSource).toContain("MEMMY_UPGRADE_REOPEN_AFTER_INSTALL");
     expect(includeSource).toContain("relay-ready");
@@ -580,15 +644,15 @@ describe("desktop packaged runtime boundaries", () => {
     expect(includeSource).toContain('FileOpen $0 "$R4" w');
     expect(includeSource.indexOf('FileOpen $0 "$R4" w')).toBeLessThan(includeSource.indexOf('CopyFiles /SILENT "$EXEPATH" "$R4"'));
     expect(includeSource).toContain('ExecShell "open" "$R5"');
-    expect(includeSource).toContain('ExecShell "open" "$1"');
-    expect(includeSource.match(/ExecShell "open" .* SW_HIDE/g)).toHaveLength(2);
+    expect(includeSource.match(/ExecShell "open" .* SW_HIDE/g)).toHaveLength(1);
     expect(includeSource).not.toContain('Exec \'$\\\"$R5$\\\"');
-    expect(includeSource).toContain('Exec \'$\\\"$INSTDIR\\${PRODUCT_FILENAME}.exe$\\\" --updated\'');
+    expect(includeSource).not.toContain('Exec \'$\\\"$INSTDIR\\${PRODUCT_FILENAME}.exe$\\\" --updated\'');
     expect(includeSource).toContain('$LOCALAPPDATA\\Memmy\\upgrade-staging\\active.lock');
     expect(includeSource).toContain('GetFullPathName $4 "$MemmyUpgradeWorkDir"');
-    expect(includeSource).toContain('GetFullPathName $5 "$MemmyUpgradeBackupRoot"');
+    expect(includeSource).not.toContain('GetFullPathName $5 "$MemmyUpgradeBackupRoot"');
     expect(includeSource).toContain('${GetFileName} "$MemmyUpgradeWorkDir" $5');
     expect(includeSource).toContain('StrCpy $0 "$INSTDIR.memmy-upgrade-backup\\$4"');
+    expect(includeSource).toContain('StrCmp $MemmyUpgradeBackupRoot $0 0 memmy_relay_context_failed');
     const relayInitIndex = includeSource.indexOf("Function MemmyRelayLegacyUpgrade");
     const earlyLaunchProxyIndex = includeSource.indexOf("Call MemmyInstallLaunchProxy", relayInitIndex);
     const relayStartIndex = includeSource.indexOf('ExecShell "open" "$R5"', relayInitIndex);
@@ -600,12 +664,21 @@ describe("desktop packaged runtime boundaries", () => {
     expect(relaySource).toContain(".memmy-upgrade-backup");
     expect(relaySource).toContain("active.lock\\state.json");
     expect(relaySource).toContain("Restore-MemmyData");
+    expect(relaySource).toContain("Invoke-MemmyDataMigration -Mode Prepare");
+    expect(relaySource).toContain("Invoke-MemmyDataMigration -Mode Complete");
+    expect(relaySource).toContain("Invoke-MemmyDataMigration -Mode Rollback");
+    expect(relaySource).toContain("migration-completed");
     expect(relaySource).toContain("Resolve-MemmyLegacyHelperReopenIntent");
+    expect(relaySource).toContain("Wait-MemmyInstallProcessesExit -TimeoutSeconds 20");
+    expect(relaySource).toContain("forcing remaining installed app processes to exit after timeout");
+    expect(relaySource).toContain("if ($InstalledVersion)");
+    expect(relaySource).toContain("data migration $Mode output:");
+    expect(relaySource).toContain("$roamingMarkerPath");
     expect(relaySource).toContain("MEMMY_UPGRADE_WORK_DIR");
     expect(relaySource).toContain("MEMMY_UPGRADE_REOPEN_AFTER_INSTALL");
     expect(relaySource).toContain("$installerProcess.WaitForExit()");
     expect(relaySource).not.toContain("-Wait -PassThru");
-    expect(relaySource.indexOf("Write-MemmyRelayState", relaySource.indexOf("$installerProcess = Start-Process"))).toBe(-1);
+    expect(relaySource.indexOf("Write-MemmyRelayState", relaySource.indexOf("$installerProcess = Start-Process"))).toBeGreaterThan(-1);
     expect(relaySource).toContain("MemmyWindowsUpgradeCleanup.ps1");
     expect(relaySource).not.toContain("cmd.exe");
     expect(relaySource).not.toContain("$env:ComSpec");
@@ -615,8 +688,80 @@ describe("desktop packaged runtime boundaries", () => {
     expect(recoverySource).toContain("Test-MemmyUpgradeProcessRunning");
     expect(recoverySource).toContain("data-backup");
     expect(recoverySource).toContain("installer-created-data");
+    expect(recoverySource).toContain("completed migration lock cleared without restoring install-local data");
     expect(recoverySource).toContain("Remove-Item -LiteralPath $LockPath");
     expect(mainSource).toContain('spawn("/bin/zsh", [helperPath, filePath, destinationAppPath, logPath, String(process.pid), options.openAfterInstall ? "1" : "0"');
+  });
+
+  it("validates Windows install and external data permissions before uninstalling the old version", () => {
+    const includeSource = readFileSync(winUnsignedInstallerIncludePath, "utf8");
+    const customInitIndex = includeSource.indexOf("!macro customInit");
+    const customInstallIndex = includeSource.indexOf("!macro customInstall", customInitIndex);
+    const customInitEnd = includeSource.indexOf("!macroend", customInitIndex);
+    const customInitSource = includeSource.slice(customInitIndex, customInitEnd);
+    const customCheckStart = includeSource.indexOf("!macro customCheckAppRunning");
+    const customCheckEnd = includeSource.indexOf("!macroend", customCheckStart);
+    const customCheckSource = includeSource.slice(customCheckStart, customCheckEnd);
+    const installPageStart = includeSource.indexOf("Function MemmyValidateInstallPage");
+    const installPageEnd = includeSource.indexOf("FunctionEnd", installPageStart);
+    const installPageSource = includeSource.slice(installPageStart, installPageEnd);
+    const directPrepareStart = includeSource.indexOf("Function MemmyPrepareDirectDataMigration");
+    const directPrepareEnd = includeSource.indexOf("FunctionEnd", directPrepareStart);
+    const directPrepareSource = includeSource.slice(directPrepareStart, directPrepareEnd);
+    const directCompleteStart = includeSource.indexOf("Function MemmyCompleteDirectDataMigration");
+    const directCompleteEnd = includeSource.indexOf("FunctionEnd", directCompleteStart);
+    const directCompleteSource = includeSource.slice(directCompleteStart, directCompleteEnd);
+    const directCompleteFailureStart = directCompleteSource.indexOf("migration completion failed");
+    const directCompleteSuccessLabel = directCompleteSource.indexOf("memmy_direct_complete_succeeded:");
+    const directCompleteFailureSource = directCompleteSource.slice(directCompleteFailureStart, directCompleteSuccessLabel);
+
+    expect(includeSource).toContain("!macro customPageAfterChangeDir");
+    expect(includeSource).toContain("Function MemmyProbeWritableDirectory");
+    expect(includeSource).toContain("Function MemmyValidateSelectedDirectories");
+    expect(includeSource).toContain('StrCpy $R0 "$INSTDIR"');
+    expect(includeSource).toContain('StrCpy $R0 "$MemmyTargetUserDataPath"');
+    expect(includeSource).toContain('StrCpy $R0 "$MemmyTargetRuntimeHomePath"');
+    expect(includeSource).toContain('ReadRegStr $MemmyPreviousInstallDir HKCU "${INSTALL_REGISTRY_KEY}" "InstallLocation"');
+    expect(includeSource).toContain('StrCpy $MemmyDirectSourceDataPath "$MemmyPreviousInstallDir\\data"');
+    expect(includeSource).toContain('StrCpy $MemmyTargetRuntimeHomePath "$0\\MemmyData\\.memmy"');
+    expect(includeSource).toContain('StrCpy $MemmyTargetRuntimeHomePath "$PROFILE\\.memmy"');
+    expect(includeSource).toContain("Call MemmyPrepareDirectDataMigration");
+    expect(includeSource).toContain("Call MemmyCompleteDirectDataMigration");
+    expect(customCheckSource).toContain("!insertmacro IS_POWERSHELL_AVAILABLE");
+    expect(customCheckSource).toContain("!insertmacro _CHECK_APP_RUNNING");
+    expect(includeSource).toContain("Var pid");
+    expect(customCheckSource).toContain('StrCpy $IsPowerShellAvailable "1"');
+    expect(customCheckSource).not.toContain('StrCpy $INSTDIR "$MemmyPreviousInstallDir"');
+    expect(customCheckSource).not.toContain('StrCpy $INSTDIR "$R7"');
+    expect(customCheckSource).toContain("Call MemmyPrepareDirectDataMigration");
+    expect(customCheckSource.indexOf("!insertmacro _CHECK_APP_RUNNING"))
+      .toBeLessThan(customCheckSource.indexOf("Call MemmyPrepareDirectDataMigration"));
+    expect(customInitSource).not.toContain("Call MemmyPrepareDirectDataMigration");
+    expect(customCheckSource.indexOf("Call MemmyPrepareDirectDataMigration"))
+      .toBeLessThan(customCheckSource.indexOf("${IfNot} ${Silent}"));
+    expect(customCheckSource).toContain('StrCmp $MemmyIsRelayedUpgrade "1"');
+    expect(installPageSource).not.toContain("Call MemmyPrepareDirectDataMigration");
+    expect(includeSource).not.toContain("Function MemmyEnsureManualInstallAppStopped");
+    expect(includeSource).not.toContain("MemmyWindowsInstallProcessControl.ps1");
+    expect(includeSource).not.toContain("MB_ICONQUESTION|MB_YESNO|MB_DEFBUTTON1");
+    expect(includeSource).not.toContain("-GracefulTimeoutSeconds 10");
+    expect(directPrepareSource).toContain("-AcquireLock");
+    expect(directPrepareSource).toContain("migration was skipped after a safe rollback; installation will continue");
+    expect(directPrepareSource).toContain('RMDir /r "$MemmyMigrationLockPath"');
+    expect(includeSource).toContain("migration completion failed; the migration will be rolled back and installation will continue");
+    expect(directCompleteSource).not.toContain("SetErrorLevel 5");
+    expect(directCompleteSource).not.toContain("Quit");
+    expect(directCompleteFailureSource).toContain("Call MemmyRecoverDirectDataMigration");
+    expect(directCompleteFailureSource).not.toContain('RMDir /r "$MemmyMigrationLockPath"');
+    expect(includeSource).toContain("Function MemmyRecoverDirectDataMigration");
+    expect(includeSource).toContain("-Mode Recover");
+    expect(includeSource).toContain("-Mode RequireRecovery");
+    expect(includeSource).toContain("startup will conservatively recover the remaining prepared state");
+    expect(includeSource).toContain("Function .onInstFailed");
+    expect(includeSource).toContain("Function MemmyOnUserAbort");
+    expect(includeSource).toContain('$LOCALAPPDATA\\Memmy\\upgrade-staging\\active.lock');
+    expect(customInitIndex).toBeGreaterThan(-1);
+    expect(customInstallIndex).toBeGreaterThan(customInitIndex);
   });
 
   it("adds packaged Windows CLI launchers to the user PATH", () => {
@@ -657,9 +802,10 @@ describe("desktop packaged runtime boundaries", () => {
     expect(includeSource).toContain('File /oname=MemmyWindowsUpgradeRecovery.ps1 "${BUILD_RESOURCES_DIR}\\MemmyWindowsUpgradeRecovery.ps1"');
     expect(includeSource).toContain('FileOpen $1 "$0\\MemmyLauncher.vbs" w');
     expect(includeSource).toContain('promptPath = $\\"$0\\MemmyUpdatePrompt.ps1$\\"');
-    expect(includeSource).toContain('dataRoot = $\\"$INSTDIR\\data$\\"');
-    expect(includeSource).toContain('languagePath = dataRoot & $\\"\\Memmy\\update-prompt-language.txt$\\"');
-    expect(includeSource).toContain('markerPath = dataRoot & $\\"\\Memmy\\prepared-required-update.json$\\"');
+    expect(includeSource).toContain('userDataRoot = shell.ExpandEnvironmentStrings($\\"%APPDATA%$\\") & $\\"\\Memmy$\\"');
+    expect(includeSource).toContain('legacyUserDataRoot = $\\"$INSTDIR\\data\\Memmy$\\"');
+    expect(includeSource).toContain('languagePath = userDataRoot & $\\"\\update-prompt-language.txt$\\"');
+    expect(includeSource).toContain('markerPath = userDataRoot & $\\"\\prepared-required-update.json$\\"');
     expect(includeSource).toContain('relayLockPath = shell.ExpandEnvironmentStrings($\\"%LOCALAPPDATA%$\\") & $\\"\\Memmy\\upgrade-staging\\active.lock$\\"');
     expect(includeSource).toContain('recoveryPath = $\\"$0\\MemmyWindowsUpgradeRecovery.ps1$\\"');
     expect(includeSource).toContain("If fso.FolderExists(relayLockPath) And fso.FileExists(recoveryPath) Then");

--- a/App/shell/desktop/tests/windows-data-layout.test.ts
+++ b/App/shell/desktop/tests/windows-data-layout.test.ts
@@ -1,0 +1,154 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, win32 } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  readWindowsDataMigrationConsistency,
+  recordWindowsDataLayoutAfterBoot,
+  resolveWindowsDataLayout
+} from "../src/main/windows-data-layout.js";
+
+describe("Windows desktop data layout", () => {
+  it("keeps packaged system-drive data outside the installation directory", () => {
+    expect(resolveWindowsDataLayout({
+      platform: "win32",
+      isPackaged: true,
+      isWindowsStore: false,
+      executablePath: "C:\\Users\\lee\\AppData\\Local\\Programs\\Memmy\\Memmy.exe",
+      appDataPath: "C:\\Users\\lee\\AppData\\Roaming",
+      localAppDataPath: "C:\\Users\\lee\\AppData\\Local",
+      homeDirectory: "C:\\Users\\lee"
+    })).toEqual({
+      userDataPath: "C:\\Users\\lee\\AppData\\Roaming\\Memmy",
+      runtimeHomePath: "C:\\Users\\lee\\.memmy",
+      updatesPath: "C:\\Users\\lee\\.memmy\\updates",
+      pointerPath: "C:\\Users\\lee\\AppData\\Roaming\\Memmy\\data-root.txt",
+      migrationStatePath: "C:\\Users\\lee\\AppData\\Local\\Memmy\\data-migration\\state.json",
+      installationRecordPath: "C:\\Users\\lee\\AppData\\Local\\Memmy\\data-layout\\last-install.json",
+      legacyInstallDataPath: "C:\\Users\\lee\\AppData\\Local\\Programs\\Memmy\\data"
+    });
+  });
+
+  it("uses MemmyData on the packaged non-system installation drive", () => {
+    expect(resolveWindowsDataLayout({
+      platform: "win32",
+      isPackaged: true,
+      isWindowsStore: false,
+      executablePath: "E:\\Apps\\Memmy\\Memmy.exe",
+      appDataPath: "C:\\Users\\lee\\AppData\\Roaming",
+      localAppDataPath: "C:\\Users\\lee\\AppData\\Local",
+      homeDirectory: "C:\\Users\\lee"
+    })).toEqual({
+      userDataPath: "C:\\Users\\lee\\AppData\\Roaming\\Memmy",
+      runtimeHomePath: "E:\\MemmyData\\.memmy",
+      updatesPath: "E:\\MemmyData\\updates",
+      pointerPath: "C:\\Users\\lee\\AppData\\Roaming\\Memmy\\data-root.txt",
+      migrationStatePath: "C:\\Users\\lee\\AppData\\Local\\Memmy\\data-migration\\state.json",
+      installationRecordPath: "C:\\Users\\lee\\AppData\\Local\\Memmy\\data-layout\\last-install.json",
+      legacyInstallDataPath: "E:\\Apps\\Memmy\\data"
+    });
+  });
+
+  it("keeps the literal C-drive rule even when Windows reports another system drive", () => {
+    expect(resolveWindowsDataLayout({
+      platform: "win32",
+      isPackaged: true,
+      isWindowsStore: false,
+      executablePath: "C:\\Apps\\Memmy\\Memmy.exe",
+      appDataPath: "D:\\Users\\lee\\AppData\\Roaming",
+      localAppDataPath: "D:\\Users\\lee\\AppData\\Local",
+      homeDirectory: "D:\\Users\\lee"
+    })?.runtimeHomePath).toBe("D:\\Users\\lee\\.memmy");
+  });
+
+  it("does not apply the NSIS installation-drive rule to macOS or Windows Store", () => {
+    expect(resolveWindowsDataLayout({
+      platform: "darwin",
+      isPackaged: true,
+      isWindowsStore: false,
+      executablePath: "/Applications/Memmy.app/Contents/MacOS/Memmy",
+      appDataPath: "/Users/lee/Library/Application Support",
+      localAppDataPath: "",
+      homeDirectory: "/Users/lee"
+    })).toBeNull();
+
+    expect(resolveWindowsDataLayout({
+      platform: "win32",
+      isPackaged: true,
+      isWindowsStore: true,
+      executablePath: "C:\\Program Files\\WindowsApps\\Memmy\\Memmy.exe",
+      appDataPath: "C:\\Users\\lee\\AppData\\Roaming",
+      localAppDataPath: "C:\\Users\\lee\\AppData\\Local",
+      homeDirectory: "C:\\Users\\lee"
+    })?.runtimeHomePath).toBe("C:\\Users\\lee\\.memmy");
+  });
+
+  it.runIf(process.platform === "win32")(
+    "exposes migration consistency only for categories copied by the active transaction",
+    async () => {
+      const root = await mkdtemp(join(tmpdir(), "memmy-layout-consistency-"));
+      try {
+        const layout = resolveWindowsDataLayout({
+          platform: "win32",
+          isPackaged: true,
+          isWindowsStore: false,
+          executablePath: join(root, "new-install", "Memmy.exe"),
+          appDataPath: join(root, "roaming"),
+          localAppDataPath: join(root, "local"),
+          homeDirectory: join(root, "Users", "tester")
+        });
+        expect(layout).not.toBeNull();
+        if (!layout) return;
+        await mkdir(win32.dirname(layout.migrationStatePath), { recursive: true });
+        await writeFile(layout.migrationStatePath, JSON.stringify({
+          phase: "awaiting-app-verification",
+          targetUserDataPath: layout.userDataPath,
+          targetRuntimeHomePath: layout.runtimeHomePath,
+          accountSourceAuthority: "current-install-authority",
+          runtimeSourceAuthority: "current-install-authority",
+          categorySourcesShareGeneration: true
+        }), "utf8");
+
+        await expect(readWindowsDataMigrationConsistency(layout)).resolves.toEqual({
+          accountSourceIsAuthoritative: true,
+          runtimeSourceWasMigrated: true,
+          categorySourcesShareGeneration: true
+        });
+      } finally {
+        await rm(root, { recursive: true, force: true });
+      }
+    }
+  );
+
+  it.runIf(process.platform === "win32")(
+    "records the verified external layout generation after a successful boot",
+    async () => {
+      const root = await mkdtemp(join(tmpdir(), "memmy-layout-record-"));
+      try {
+        const layout = resolveWindowsDataLayout({
+          platform: "win32",
+          isPackaged: true,
+          isWindowsStore: false,
+          executablePath: join(root, "new-install", "Memmy.exe"),
+          appDataPath: join(root, "roaming"),
+          localAppDataPath: join(root, "local"),
+          homeDirectory: join(root, "Users", "tester")
+        });
+        expect(layout).not.toBeNull();
+        if (!layout) return;
+
+        await recordWindowsDataLayoutAfterBoot(layout, "1.1.0");
+        expect(JSON.parse(await readFile(layout.installationRecordPath, "utf8"))).toMatchObject({
+          schemaVersion: 1,
+          dataLayoutGeneration: "external-v1",
+          installDir: win32.dirname(layout.legacyInstallDataPath),
+          userDataPath: layout.userDataPath,
+          runtimeHomePath: layout.runtimeHomePath,
+          appVersion: "1.1.0"
+        });
+      } finally {
+        await rm(root, { recursive: true, force: true });
+      }
+    }
+  );
+});

--- a/App/shell/desktop/tests/windows-data-migration-state.test.ts
+++ b/App/shell/desktop/tests/windows-data-migration-state.test.ts
@@ -1,0 +1,426 @@
+import { existsSync } from "node:fs";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  advanceWindowsDataMigrationAfterBoot,
+  readWindowsDataMigrationConsistency,
+  recoverWindowsDataMigrationForStartup,
+  type WindowsDataLayout
+} from "../src/main/windows-data-layout.js";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(temporaryDirectories.splice(0).map((directory) =>
+    rm(directory, { recursive: true, force: true })
+  ));
+});
+
+describe.runIf(process.platform === "win32")("Windows data migration boot verification", () => {
+  it("rolls a valid inconsistent migration back before startup continues", async () => {
+    const root = await mkdtemp(join(tmpdir(), "memmy-migration-state-"));
+    temporaryDirectories.push(root);
+    const layout = createLayout(root);
+    const userBackup = `${layout.userDataPath}.migration-backup-0123456789abcdef0123456789abcdef`;
+    const runtimeBackup = `${layout.runtimeHomePath}.migration-backup-fedcba9876543210fedcba9876543210`;
+    await Promise.all([
+      mkdir(layout.userDataPath, { recursive: true }),
+      mkdir(layout.runtimeHomePath, { recursive: true }),
+      mkdir(userBackup, { recursive: true }),
+      mkdir(runtimeBackup, { recursive: true }),
+      mkdir(dirname(layout.migrationStatePath), { recursive: true })
+    ]);
+    await Promise.all([
+      writeFile(join(layout.userDataPath, "app.sqlite"), "migrated-account", "utf8"),
+      writeFile(join(layout.runtimeHomePath, "config.yaml"), "migrated-runtime", "utf8"),
+      writeFile(join(userBackup, "app.sqlite"), "old-account", "utf8"),
+      writeFile(join(runtimeBackup, "config.yaml"), "old-runtime", "utf8"),
+      writeFile(layout.migrationStatePath, JSON.stringify({
+        phase: "awaiting-app-verification",
+        targetUserDataPath: layout.userDataPath,
+        targetRuntimeHomePath: layout.runtimeHomePath,
+        previousPointerExisted: false,
+        preparedCopies: [
+          { DestinationPath: layout.userDataPath, BackupPath: userBackup },
+          { DestinationPath: layout.runtimeHomePath, BackupPath: runtimeBackup }
+        ]
+      }), "utf8")
+    ]);
+
+    await expect(recoverWindowsDataMigrationForStartup(layout, "owner mismatch"))
+      .resolves.toMatchObject({ status: "rolled-back" });
+    await expect(readFile(join(layout.userDataPath, "app.sqlite"), "utf8")).resolves.toBe("old-account");
+    await expect(readFile(join(layout.runtimeHomePath, "config.yaml"), "utf8")).resolves.toBe("old-runtime");
+    expect(existsSync(layout.migrationStatePath)).toBe(false);
+  });
+
+  it("quarantines cross-category rollback backups without touching either target", async () => {
+    const root = await mkdtemp(join(tmpdir(), "memmy-migration-state-"));
+    temporaryDirectories.push(root);
+    const layout = createLayout(root);
+    const userBackup = `${layout.userDataPath}.migration-backup-0123456789abcdef0123456789abcdef`;
+    const runtimeBackup = `${layout.runtimeHomePath}.migration-backup-fedcba9876543210fedcba9876543210`;
+    await Promise.all([
+      mkdir(layout.userDataPath, { recursive: true }),
+      mkdir(layout.runtimeHomePath, { recursive: true }),
+      mkdir(userBackup, { recursive: true }),
+      mkdir(runtimeBackup, { recursive: true }),
+      mkdir(dirname(layout.migrationStatePath), { recursive: true })
+    ]);
+    await Promise.all([
+      writeFile(join(layout.userDataPath, "app.sqlite"), "keep-account", "utf8"),
+      writeFile(join(layout.runtimeHomePath, "config.yaml"), "keep-runtime", "utf8"),
+      writeFile(join(userBackup, "app.sqlite"), "old-account", "utf8"),
+      writeFile(join(runtimeBackup, "config.yaml"), "old-runtime", "utf8"),
+      writeFile(layout.migrationStatePath, JSON.stringify({
+        phase: "awaiting-app-verification",
+        targetUserDataPath: layout.userDataPath,
+        targetRuntimeHomePath: layout.runtimeHomePath,
+        previousPointerExisted: false,
+        preparedCopies: [
+          { DestinationPath: layout.userDataPath, BackupPath: runtimeBackup },
+          { DestinationPath: layout.runtimeHomePath, BackupPath: userBackup }
+        ]
+      }), "utf8")
+    ]);
+
+    const recovery = await recoverWindowsDataMigrationForStartup(layout, "cross-category backup");
+    expect(recovery.status).toBe("quarantined");
+    expect(recovery.quarantinePath && existsSync(recovery.quarantinePath)).toBe(true);
+    await expect(readFile(join(layout.userDataPath, "app.sqlite"), "utf8")).resolves.toBe("keep-account");
+    await expect(readFile(join(layout.runtimeHomePath, "config.yaml"), "utf8")).resolves.toBe("keep-runtime");
+    expect(existsSync(userBackup)).toBe(true);
+    expect(existsSync(runtimeBackup)).toBe(true);
+  });
+
+  it("quarantines duplicate rollback destinations without touching the target", async () => {
+    const root = await mkdtemp(join(tmpdir(), "memmy-migration-state-"));
+    temporaryDirectories.push(root);
+    const layout = createLayout(root);
+    const firstBackup = `${layout.userDataPath}.migration-backup-0123456789abcdef0123456789abcdef`;
+    const secondBackup = `${layout.userDataPath}.migration-backup-fedcba9876543210fedcba9876543210`;
+    await Promise.all([
+      mkdir(layout.userDataPath, { recursive: true }),
+      mkdir(firstBackup, { recursive: true }),
+      mkdir(secondBackup, { recursive: true }),
+      mkdir(dirname(layout.migrationStatePath), { recursive: true })
+    ]);
+    await Promise.all([
+      writeFile(join(layout.userDataPath, "app.sqlite"), "keep-account", "utf8"),
+      writeFile(join(firstBackup, "app.sqlite"), "first-old", "utf8"),
+      writeFile(join(secondBackup, "app.sqlite"), "second-old", "utf8"),
+      writeFile(layout.migrationStatePath, JSON.stringify({
+        phase: "awaiting-app-verification",
+        targetUserDataPath: layout.userDataPath,
+        targetRuntimeHomePath: layout.runtimeHomePath,
+        previousPointerExisted: false,
+        preparedCopies: [
+          { DestinationPath: layout.userDataPath, BackupPath: firstBackup },
+          { DestinationPath: layout.userDataPath, BackupPath: secondBackup }
+        ]
+      }), "utf8")
+    ]);
+
+    const recovery = await recoverWindowsDataMigrationForStartup(layout, "duplicate destination");
+    expect(recovery.status).toBe("quarantined");
+    expect(recovery.quarantinePath && existsSync(recovery.quarantinePath)).toBe(true);
+    await expect(readFile(join(layout.userDataPath, "app.sqlite"), "utf8")).resolves.toBe("keep-account");
+    expect(existsSync(firstBackup)).toBe(true);
+    expect(existsSync(secondBackup)).toBe(true);
+  });
+
+  it("quarantines an arbitrary staging path without deleting it or the target", async () => {
+    const root = await mkdtemp(join(tmpdir(), "memmy-migration-state-"));
+    temporaryDirectories.push(root);
+    const layout = createLayout(root);
+    const arbitraryStaging = join(root, "unrelated", "private-data");
+    await Promise.all([
+      mkdir(layout.userDataPath, { recursive: true }),
+      mkdir(arbitraryStaging, { recursive: true }),
+      mkdir(dirname(layout.migrationStatePath), { recursive: true })
+    ]);
+    await Promise.all([
+      writeFile(join(layout.userDataPath, "app.sqlite"), "keep-account", "utf8"),
+      writeFile(join(arbitraryStaging, "keep.txt"), "keep-private", "utf8"),
+      writeFile(layout.migrationStatePath, JSON.stringify({
+        phase: "recovery-required",
+        targetUserDataPath: layout.userDataPath,
+        targetRuntimeHomePath: layout.runtimeHomePath,
+        previousPointerExisted: false,
+        preparedCopies: [
+          { DestinationPath: layout.userDataPath, BackupPath: null, StagingPath: arbitraryStaging }
+        ]
+      }), "utf8")
+    ]);
+
+    const recovery = await recoverWindowsDataMigrationForStartup(layout, "unsafe staging path");
+    expect(recovery.status).toBe("quarantined");
+    expect(recovery.quarantinePath && existsSync(recovery.quarantinePath)).toBe(true);
+    await expect(readFile(join(layout.userDataPath, "app.sqlite"), "utf8")).resolves.toBe("keep-account");
+    await expect(readFile(join(arbitraryStaging, "keep.txt"), "utf8")).resolves.toBe("keep-private");
+  });
+
+  it("quarantines malformed migration state without deleting target data", async () => {
+    const root = await mkdtemp(join(tmpdir(), "memmy-migration-state-"));
+    temporaryDirectories.push(root);
+    const layout = createLayout(root);
+    await mkdir(layout.userDataPath, { recursive: true });
+    await mkdir(dirname(layout.migrationStatePath), { recursive: true });
+    await writeFile(join(layout.userDataPath, "app.sqlite"), "keep-account", "utf8");
+    await writeFile(layout.migrationStatePath, "{broken", "utf8");
+
+    const recovery = await recoverWindowsDataMigrationForStartup(layout, "malformed state");
+    expect(recovery.status).toBe("quarantined");
+    expect(recovery.quarantinePath && existsSync(recovery.quarantinePath)).toBe(true);
+    await expect(readFile(join(layout.userDataPath, "app.sqlite"), "utf8")).resolves.toBe("keep-account");
+  });
+
+  it("forces a write-ahead recovery-required transaction to roll back before verification", async () => {
+    const root = await mkdtemp(join(tmpdir(), "memmy-migration-state-"));
+    temporaryDirectories.push(root);
+    const layout = createLayout(root);
+    const userBackup = `${layout.userDataPath}.migration-backup-0123456789abcdef0123456789abcdef`;
+    const userStaging = `${layout.userDataPath}.migrating-abcdef0123456789abcdef0123456789`;
+    await Promise.all([
+      mkdir(layout.userDataPath, { recursive: true }),
+      mkdir(userBackup, { recursive: true }),
+      mkdir(userStaging, { recursive: true }),
+      mkdir(dirname(layout.migrationStatePath), { recursive: true })
+    ]);
+    await Promise.all([
+      writeFile(join(layout.userDataPath, "app.sqlite"), "partially-migrated", "utf8"),
+      writeFile(join(userBackup, "app.sqlite"), "pre-migration", "utf8"),
+      writeFile(join(userStaging, "app.sqlite"), "staged-copy", "utf8"),
+      writeFile(layout.migrationStatePath, JSON.stringify({
+        phase: "recovery-required",
+        targetUserDataPath: layout.userDataPath,
+        targetRuntimeHomePath: layout.runtimeHomePath,
+        previousPointerExisted: false,
+        preparedCopies: [
+          { DestinationPath: layout.userDataPath, BackupPath: userBackup, StagingPath: userStaging }
+        ]
+      }), "utf8")
+    ]);
+
+    await expect(readWindowsDataMigrationConsistency(layout)).rejects.toThrow("requires startup rollback");
+    await expect(advanceWindowsDataMigrationAfterBoot(layout)).resolves.toBe("none");
+    expect(existsSync(layout.migrationStatePath)).toBe(true);
+    await expect(recoverWindowsDataMigrationForStartup(layout, "write-ahead transaction interrupted"))
+      .resolves.toMatchObject({ status: "rolled-back" });
+    await expect(readFile(join(layout.userDataPath, "app.sqlite"), "utf8")).resolves.toBe("pre-migration");
+    expect(existsSync(userStaging)).toBe(false);
+    expect(existsSync(layout.migrationStatePath)).toBe(false);
+  });
+
+  it("retains rollback data for one successful boot and cleans it on the next boot", async () => {
+    const root = await mkdtemp(join(tmpdir(), "memmy-migration-state-"));
+    temporaryDirectories.push(root);
+    const layout: WindowsDataLayout = {
+      userDataPath: join(root, "AppData", "Roaming", "Memmy"),
+      runtimeHomePath: join(root, "new-drive", "MemmyData", ".memmy"),
+      updatesPath: join(root, "new-drive", "MemmyData", "updates"),
+      pointerPath: join(root, "AppData", "Roaming", "Memmy", "data-root.txt"),
+      migrationStatePath: join(root, "AppData", "Local", "Memmy", "data-migration", "state.json"),
+      installationRecordPath: join(root, "AppData", "Local", "Memmy", "data-layout", "last-install.json"),
+      legacyInstallDataPath: join(root, "new-install", "data")
+    };
+    const targetBackup = `${layout.runtimeHomePath}.migration-backup-0123456789abcdef0123456789abcdef`;
+    const relayBackupRoot = join(`${join(root, "new-install")}.memmy-upgrade-backup`, "1234");
+    const sourceDataPath = join(relayBackupRoot, "data-backup");
+    await mkdir(targetBackup, { recursive: true });
+    await mkdir(join(sourceDataPath, "Memmy"), { recursive: true });
+    await mkdir(join(layout.migrationStatePath, ".."), { recursive: true });
+    await writeFile(join(targetBackup, "old.txt"), "old", "utf8");
+    await writeFile(join(sourceDataPath, "Memmy", "app.sqlite"), "source", "utf8");
+    await writeFile(layout.migrationStatePath, JSON.stringify({
+      owner: "relay",
+      phase: "awaiting-app-verification",
+      sourceInstallDir: join(root, "new-install"),
+      sourceDataPath,
+      targetUserDataPath: layout.userDataPath,
+      targetRuntimeHomePath: layout.runtimeHomePath,
+      backupPaths: [targetBackup],
+      preparedCopies: [
+        { SourcePath: join(sourceDataPath, "Memmy"), DestinationPath: layout.userDataPath, BackupPath: null }
+      ]
+    }), "utf8");
+
+    await expect(advanceWindowsDataMigrationAfterBoot(layout)).resolves.toBe("verified");
+    expect(existsSync(targetBackup)).toBe(true);
+    expect(existsSync(sourceDataPath)).toBe(true);
+    expect(JSON.parse(await readFile(layout.migrationStatePath, "utf8"))).toMatchObject({
+      phase: "app-verified"
+    });
+
+    await expect(advanceWindowsDataMigrationAfterBoot(layout)).resolves.toBe("cleaned");
+    expect(existsSync(targetBackup)).toBe(false);
+    expect(existsSync(relayBackupRoot)).toBe(false);
+    expect(existsSync(layout.migrationStatePath)).toBe(false);
+  });
+
+  it("does not delete a relay-shaped backup outside the active installation sibling", async () => {
+    const root = await mkdtemp(join(tmpdir(), "memmy-migration-state-"));
+    temporaryDirectories.push(root);
+    const layout: WindowsDataLayout = {
+      userDataPath: join(root, "AppData", "Roaming", "Memmy"),
+      runtimeHomePath: join(root, "new-drive", "MemmyData", ".memmy"),
+      updatesPath: join(root, "new-drive", "MemmyData", "updates"),
+      pointerPath: join(root, "AppData", "Roaming", "Memmy", "data-root.txt"),
+      migrationStatePath: join(root, "AppData", "Local", "Memmy", "data-migration", "state.json"),
+      installationRecordPath: join(root, "AppData", "Local", "Memmy", "data-layout", "last-install.json"),
+      legacyInstallDataPath: join(root, "new-install", "data")
+    };
+    const unrelatedBackupRoot = join(`${join(root, "unrelated")}.memmy-upgrade-backup`, "1234");
+    const sourceDataPath = join(unrelatedBackupRoot, "data-backup");
+    await mkdir(sourceDataPath, { recursive: true });
+    await mkdir(join(layout.migrationStatePath, ".."), { recursive: true });
+    await writeFile(join(sourceDataPath, "keep.txt"), "keep", "utf8");
+    await writeFile(layout.migrationStatePath, JSON.stringify({
+      owner: "relay",
+      phase: "app-verified",
+      sourceDataPath,
+      targetUserDataPath: layout.userDataPath,
+      targetRuntimeHomePath: layout.runtimeHomePath,
+      backupPaths: []
+    }), "utf8");
+
+    await expect(advanceWindowsDataMigrationAfterBoot(layout)).resolves.toBe("cleaned");
+    expect(existsSync(sourceDataPath)).toBe(true);
+  });
+
+  it("removes only a trusted runtime source copied to the active target after verification", async () => {
+    const root = await mkdtemp(join(tmpdir(), "memmy-migration-state-"));
+    temporaryDirectories.push(root);
+    const layout: WindowsDataLayout = {
+      userDataPath: join(root, "AppData", "Roaming", "Memmy"),
+      runtimeHomePath: join(root, "new-drive", "MemmyData", ".memmy"),
+      updatesPath: join(root, "new-drive", "MemmyData", "updates"),
+      pointerPath: join(root, "AppData", "Roaming", "Memmy", "data-root.txt"),
+      migrationStatePath: join(root, "AppData", "Local", "Memmy", "data-migration", "state.json"),
+      installationRecordPath: join(root, "AppData", "Local", "Memmy", "data-layout", "last-install.json"),
+      legacyInstallDataPath: join(root, "new-install", "data")
+    };
+    const trustedSource = join(root, "old-drive", "MemmyData", ".memmy");
+    const unrelatedSource = join(root, "unrelated", ".memmy");
+    await mkdir(trustedSource, { recursive: true });
+    await mkdir(unrelatedSource, { recursive: true });
+    await mkdir(layout.runtimeHomePath, { recursive: true });
+    await mkdir(join(layout.migrationStatePath, ".."), { recursive: true });
+    await writeFile(join(trustedSource, "old.txt"), "old", "utf8");
+    await writeFile(join(unrelatedSource, "keep.txt"), "keep", "utf8");
+    await writeFile(join(layout.runtimeHomePath, "current.txt"), "current", "utf8");
+    await writeFile(layout.migrationStatePath, JSON.stringify({
+      owner: "installer",
+      phase: "app-verified",
+      targetUserDataPath: layout.userDataPath,
+      targetRuntimeHomePath: layout.runtimeHomePath,
+      runtimeSourcePaths: [trustedSource, unrelatedSource],
+      preparedCopies: [
+        { SourcePath: trustedSource, DestinationPath: layout.runtimeHomePath, BackupPath: null },
+        { SourcePath: unrelatedSource, DestinationPath: layout.userDataPath, BackupPath: null }
+      ],
+      backupPaths: []
+    }), "utf8");
+
+    await expect(advanceWindowsDataMigrationAfterBoot(layout, [trustedSource]))
+      .resolves.toBe("cleaned");
+    expect(existsSync(trustedSource)).toBe(false);
+    expect(existsSync(unrelatedSource)).toBe(true);
+    expect(await readFile(join(layout.runtimeHomePath, "current.txt"), "utf8")).toBe("current");
+  });
+
+  it("cleans only copied categories from an exact trusted install source after the second boot", async () => {
+    const root = await mkdtemp(join(tmpdir(), "memmy-migration-state-"));
+    temporaryDirectories.push(root);
+    const sourceInstallDir = join(root, "new-install");
+    const sourceDataPath = join(sourceInstallDir, "data");
+    const accountSourcePath = join(sourceDataPath, "Memmy");
+    const runtimeSourcePath = join(sourceDataPath, ".memmy");
+    const unrelatedPath = join(sourceDataPath, "user-export");
+    const layout: WindowsDataLayout = {
+      userDataPath: join(root, "AppData", "Roaming", "Memmy"),
+      runtimeHomePath: join(root, "new-drive", "MemmyData", ".memmy"),
+      updatesPath: join(root, "new-drive", "MemmyData", "updates"),
+      pointerPath: join(root, "AppData", "Roaming", "Memmy", "data-root.txt"),
+      migrationStatePath: join(root, "AppData", "Local", "Memmy", "data-migration", "state.json"),
+      installationRecordPath: join(root, "AppData", "Local", "Memmy", "data-layout", "last-install.json"),
+      legacyInstallDataPath: join(root, "new-install", "data")
+    };
+    await Promise.all([
+      mkdir(accountSourcePath, { recursive: true }),
+      mkdir(runtimeSourcePath, { recursive: true }),
+      mkdir(unrelatedPath, { recursive: true }),
+      mkdir(dirname(layout.migrationStatePath), { recursive: true })
+    ]);
+    await Promise.all([
+      writeFile(join(accountSourcePath, "app.sqlite"), "account", "utf8"),
+      writeFile(join(runtimeSourcePath, "config.yaml"), "runtime", "utf8"),
+      writeFile(join(unrelatedPath, "keep.txt"), "keep", "utf8"),
+      writeFile(layout.migrationStatePath, JSON.stringify({
+        owner: "installer",
+        phase: "app-verified",
+        sourceAuthority: "current-install-authority",
+        sourceInstallDir,
+        sourceDataPath,
+        targetUserDataPath: layout.userDataPath,
+        targetRuntimeHomePath: layout.runtimeHomePath,
+        preparedCopies: [
+          { SourcePath: accountSourcePath, DestinationPath: layout.userDataPath, BackupPath: null },
+          { SourcePath: runtimeSourcePath, DestinationPath: layout.runtimeHomePath, BackupPath: null }
+        ],
+        backupPaths: []
+      }), "utf8")
+    ]);
+
+    await expect(advanceWindowsDataMigrationAfterBoot(layout)).resolves.toBe("cleaned");
+    expect(existsSync(accountSourcePath)).toBe(false);
+    expect(existsSync(runtimeSourcePath)).toBe(false);
+    expect(await readFile(join(unrelatedPath, "keep.txt"), "utf8")).toBe("keep");
+  });
+
+  it("does not delete a legal-shaped direct source outside the active installation", async () => {
+    const root = await mkdtemp(join(tmpdir(), "memmy-migration-state-"));
+    temporaryDirectories.push(root);
+    const sourceInstallDir = join(root, "unrelated-install");
+    const sourceDataPath = join(sourceInstallDir, "data");
+    const accountSourcePath = join(sourceDataPath, "Memmy");
+    const layout = createLayout(root);
+    await Promise.all([
+      mkdir(accountSourcePath, { recursive: true }),
+      mkdir(dirname(layout.migrationStatePath), { recursive: true })
+    ]);
+    await Promise.all([
+      writeFile(join(accountSourcePath, "app.sqlite"), "keep-unrelated", "utf8"),
+      writeFile(layout.migrationStatePath, JSON.stringify({
+        owner: "installer",
+        phase: "app-verified",
+        sourceAuthority: "current-install-authority",
+        sourceInstallDir,
+        sourceDataPath,
+        targetUserDataPath: layout.userDataPath,
+        targetRuntimeHomePath: layout.runtimeHomePath,
+        preparedCopies: [
+          { SourcePath: accountSourcePath, DestinationPath: layout.userDataPath, BackupPath: null }
+        ],
+        backupPaths: []
+      }), "utf8")
+    ]);
+
+    await expect(advanceWindowsDataMigrationAfterBoot(layout)).resolves.toBe("cleaned");
+    await expect(readFile(join(accountSourcePath, "app.sqlite"), "utf8")).resolves.toBe("keep-unrelated");
+  });
+});
+
+function createLayout(root: string): WindowsDataLayout {
+  return {
+    userDataPath: join(root, "AppData", "Roaming", "Memmy"),
+    runtimeHomePath: join(root, "new-drive", "MemmyData", ".memmy"),
+    updatesPath: join(root, "new-drive", "MemmyData", "updates"),
+    pointerPath: join(root, "AppData", "Roaming", "Memmy", "data-root.txt"),
+    migrationStatePath: join(root, "AppData", "Local", "Memmy", "data-migration", "state.json"),
+    installationRecordPath: join(root, "AppData", "Local", "Memmy", "data-layout", "last-install.json"),
+    legacyInstallDataPath: join(root, "new-install", "data")
+  };
+}

--- a/App/shell/desktop/tests/windows-data-migration.test.ts
+++ b/App/shell/desktop/tests/windows-data-migration.test.ts
@@ -1,0 +1,988 @@
+import { existsSync } from "node:fs";
+import { mkdir, mkdtemp, open, readFile, rename, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { spawnSync } from "node:child_process";
+import { afterEach, describe, expect, it } from "vitest";
+
+const scriptPath = new URL("../build/MemmyWindowsDataMigration.ps1", import.meta.url).pathname
+  .replace(/^\/(?:[A-Za-z]:)/u, (value) => value.slice(1));
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(temporaryDirectories.splice(0).map((directory) =>
+    rm(directory, { recursive: true, force: true })
+  ));
+});
+
+describe.runIf(process.platform === "win32")("Windows data migration helper", () => {
+  it("prefers install-local runtime data without merging legacy-home data", async () => {
+    const fixture = await createFixture();
+    await mkdir(join(fixture.sourceDataPath, "Memmy"), { recursive: true });
+    await mkdir(join(fixture.sourceDataPath, ".memmy", "memory-service"), { recursive: true });
+    await mkdir(fixture.legacyRuntimeHomePath, { recursive: true });
+    await writeFile(join(fixture.sourceDataPath, "Memmy", "app.sqlite"), "login-state", "utf8");
+    await writeFile(
+      join(fixture.sourceDataPath, ".memmy", "memory-service", "memory.sqlite"),
+      "memory-state",
+      "utf8"
+    );
+    await writeFile(join(fixture.sourceDataPath, ".memmy", "config.yaml"), "current-runtime", "utf8");
+    await writeFile(join(fixture.legacyRuntimeHomePath, "config.yaml"), "stale-runtime", "utf8");
+
+    const prepared = runMigration("Prepare", fixture, false, "", "current-install-authority", "1.1.0");
+    expect(prepared.status, prepared.stderr || prepared.stdout).toBe(0);
+    expect(await readFile(join(fixture.targetUserDataPath, "app.sqlite"), "utf8"))
+      .toBe("login-state");
+    expect(await readFile(join(fixture.targetRuntimeHomePath, "memory-service", "memory.sqlite"), "utf8"))
+      .toBe("memory-state");
+    expect(await readFile(join(fixture.targetRuntimeHomePath, "config.yaml"), "utf8")).toBe("current-runtime");
+    expect(await readFile(join(fixture.sourceDataPath, "Memmy", "app.sqlite"), "utf8"))
+      .toBe("login-state");
+    expect(await readPointer(fixture.pointerPath)).toBe(`${fixture.targetRuntimeHomePath}\r\n`);
+
+    const state = JSON.parse(await readFile(fixture.statePath, "utf8")) as {
+      phase: string;
+      owner: string;
+      targetRuntimeHomePath: string;
+      runtimeSourcePaths: string[];
+    };
+    expect(state).toMatchObject({
+      phase: "prepared",
+      owner: "installer",
+      targetRuntimeHomePath: fixture.targetRuntimeHomePath
+    });
+    expect(state.runtimeSourcePaths).toEqual([
+      join(fixture.sourceDataPath, ".memmy")
+    ]);
+    expect(existsSync(fixture.lockPath)).toBe(true);
+  });
+
+  it("rebases only staged Windows runtime defaults and standalone session bindings", async () => {
+    const fixture = await createFixture();
+    const sourceRuntimeHomePath = join(fixture.sourceDataPath, ".memmy");
+    const sourceWorkspacePath = join(sourceRuntimeHomePath, "workspace");
+    const targetWorkspacePath = join(fixture.targetRuntimeHomePath, "workspace");
+    const sourceMemoryDatabasePath = join(sourceRuntimeHomePath, "memory-service", "memory.sqlite");
+    const targetMemoryDatabasePath = join(fixture.targetRuntimeHomePath, "memory-service", "memory.sqlite");
+    const sessionsPath = join(sourceWorkspacePath, "sessions");
+    const standalonePath = join(sessionsPath, "websocket_standalone.jsonl");
+    const projectPath = join(sessionsPath, "websocket_project.jsonl");
+    const customWorkspacePath = join(fixture.root, "custom-workspace");
+    const customPath = join(sessionsPath, "websocket_custom.jsonl");
+    await Promise.all([
+      mkdir(join(fixture.sourceDataPath, "Memmy"), { recursive: true }),
+      mkdir(join(sourceRuntimeHomePath, "memory-service"), { recursive: true }),
+      mkdir(sessionsPath, { recursive: true })
+    ]);
+    await writeFile(join(fixture.sourceDataPath, "Memmy", "app.sqlite"), "account-state", "utf8");
+    await writeFile(sourceMemoryDatabasePath, "memory-state", "utf8");
+    await writeFile(join(sourceRuntimeHomePath, "config.yaml"), [
+      "agents:",
+      "  defaults:",
+      `    workspace: ${sourceWorkspacePath}`,
+      "memmyMemory:",
+      "  storage:",
+      `    sqlitePath: ${sourceMemoryDatabasePath}`,
+      ""
+    ].join("\r\n"), "utf8");
+    const historyRecord = JSON.stringify({ recordType: "message", role: "user", content: "history remains byte-for-byte" });
+    const standaloneContents = `${JSON.stringify({
+      recordType: "session",
+      key: "websocket:standalone",
+      metadata: { webui: true, webuiProjectId: null, webuiWorkspaceCwd: sourceWorkspacePath }
+    })}\r\n${historyRecord}\r\n`;
+    const projectContents = `${JSON.stringify({
+      recordType: "session",
+      key: "websocket:project",
+      metadata: { webui: true, webuiProjectId: "project-1", webuiWorkspaceCwd: sourceWorkspacePath }
+    })}\r\n${historyRecord}\r\n`;
+    const customContents = `${JSON.stringify({
+      recordType: "session",
+      key: "websocket:custom",
+      metadata: { webui: true, webuiProjectId: null, webuiWorkspaceCwd: customWorkspacePath }
+    })}\r\n${historyRecord}\r\n`;
+    await Promise.all([
+      writeFile(standalonePath, standaloneContents, "utf8"),
+      writeFile(projectPath, projectContents, "utf8"),
+      writeFile(customPath, customContents, "utf8")
+    ]);
+
+    const prepared = runMigration("Prepare", fixture, false, "", "current-install-authority", "1.0.9");
+    expect(prepared.status, prepared.stderr || prepared.stdout).toBe(0);
+
+    const migratedConfig = await readFile(join(fixture.targetRuntimeHomePath, "config.yaml"), "utf8");
+    expect(migratedConfig).toContain(targetWorkspacePath);
+    expect(migratedConfig).toContain(targetMemoryDatabasePath);
+    expect(migratedConfig).not.toContain(sourceWorkspacePath);
+    expect(migratedConfig).not.toContain(sourceMemoryDatabasePath);
+
+    const migratedStandalone = await readFile(
+      join(targetWorkspacePath, "sessions", "websocket_standalone.jsonl"),
+      "utf8"
+    );
+    const [standaloneMetadata, standaloneHistory] = migratedStandalone.split("\r\n");
+    expect(JSON.parse(standaloneMetadata).metadata).toMatchObject({
+      webuiProjectId: null,
+      webuiWorkspaceCwd: targetWorkspacePath
+    });
+    expect(standaloneHistory).toBe(historyRecord);
+    await expect(readFile(
+      join(targetWorkspacePath, "sessions", "websocket_project.jsonl"),
+      "utf8"
+    )).resolves.toBe(projectContents);
+    await expect(readFile(
+      join(targetWorkspacePath, "sessions", "websocket_custom.jsonl"),
+      "utf8"
+    )).resolves.toBe(customContents);
+    await expect(readFile(standalonePath, "utf8")).resolves.toBe(standaloneContents);
+  });
+
+  it("uses the remembered runtime root before legacy-home data without merging", async () => {
+    const fixture = await createFixture();
+    const rememberedRuntimeHomePath = join(fixture.root, "previous-drive", "MemmyData", ".memmy");
+    const relativeSessionPath = join("workspace", "sessions");
+    await Promise.all([
+      mkdir(join(rememberedRuntimeHomePath, relativeSessionPath), { recursive: true }),
+      mkdir(join(fixture.legacyRuntimeHomePath, relativeSessionPath), { recursive: true }),
+      mkdir(fixture.targetUserDataPath, { recursive: true })
+    ]);
+    await Promise.all([
+      writeFile(join(rememberedRuntimeHomePath, relativeSessionPath, "remembered.jsonl"), "remembered-chat", "utf8"),
+      writeFile(join(rememberedRuntimeHomePath, relativeSessionPath, "shared.jsonl"), "remembered-wins", "utf8"),
+      writeFile(join(fixture.legacyRuntimeHomePath, relativeSessionPath, "legacy.jsonl"), "legacy-chat", "utf8"),
+      writeFile(fixture.pointerPath, Buffer.concat([
+        Buffer.from([0xff, 0xfe]),
+        Buffer.from(`${rememberedRuntimeHomePath}\r\n`, "utf16le")
+      ]))
+    ]);
+
+    const prepared = runMigration("Prepare", fixture, false, rememberedRuntimeHomePath);
+    expect(prepared.status, prepared.stderr || prepared.stdout).toBe(0);
+
+    const targetSessionsPath = join(fixture.targetRuntimeHomePath, relativeSessionPath);
+    await expect(readFile(join(targetSessionsPath, "remembered.jsonl"), "utf8"))
+      .resolves.toBe("remembered-chat");
+    expect(existsSync(join(targetSessionsPath, "legacy.jsonl"))).toBe(false);
+    await expect(readFile(join(targetSessionsPath, "shared.jsonl"), "utf8"))
+      .resolves.toBe("remembered-wins");
+
+    const state = JSON.parse(await readFile(fixture.statePath, "utf8")) as {
+      runtimeSourcePaths: string[];
+      backupPaths: string[];
+    };
+    expect(state.runtimeSourcePaths).toEqual([
+      rememberedRuntimeHomePath
+    ]);
+    expect(state.backupPaths).toHaveLength(0);
+  });
+
+  it("skips every legacy runtime source when the target already contains data", async () => {
+    const fixture = await createFixture();
+    const installRuntimeHomePath = join(fixture.sourceDataPath, ".memmy");
+    const rememberedRuntimeHomePath = join(fixture.root, "previous-drive", "MemmyData", ".memmy");
+    await Promise.all([
+      mkdir(join(installRuntimeHomePath, "workspace", "sessions"), { recursive: true }),
+      mkdir(join(rememberedRuntimeHomePath, "workspace", "sessions"), { recursive: true }),
+      mkdir(join(fixture.legacyRuntimeHomePath, "workspace", "sessions"), { recursive: true }),
+      mkdir(join(fixture.targetRuntimeHomePath, "workspace", "sessions"), { recursive: true }),
+      mkdir(fixture.targetUserDataPath, { recursive: true })
+    ]);
+    await Promise.all([
+      writeFile(join(installRuntimeHomePath, "workspace", "sessions", "install.jsonl"), "install-chat", "utf8"),
+      writeFile(join(rememberedRuntimeHomePath, "workspace", "sessions", "remembered.jsonl"), "remembered-chat", "utf8"),
+      writeFile(join(fixture.legacyRuntimeHomePath, "workspace", "sessions", "legacy.jsonl"), "legacy-chat", "utf8"),
+      writeFile(join(fixture.targetRuntimeHomePath, "workspace", "sessions", "current.jsonl"), "current-chat", "utf8"),
+      writeFile(fixture.pointerPath, Buffer.concat([
+        Buffer.from([0xff, 0xfe]),
+        Buffer.from(`${rememberedRuntimeHomePath}\r\n`, "utf16le")
+      ]))
+    ]);
+
+    const prepared = runMigration("Prepare", fixture);
+    expect(prepared.status, prepared.stderr || prepared.stdout).toBe(0);
+    const targetSessionsPath = join(fixture.targetRuntimeHomePath, "workspace", "sessions");
+    await expect(readFile(join(targetSessionsPath, "current.jsonl"), "utf8"))
+      .resolves.toBe("current-chat");
+    expect(existsSync(join(targetSessionsPath, "install.jsonl"))).toBe(false);
+    expect(existsSync(join(targetSessionsPath, "remembered.jsonl"))).toBe(false);
+    expect(existsSync(join(targetSessionsPath, "legacy.jsonl"))).toBe(false);
+
+    const state = JSON.parse(await readFile(fixture.statePath, "utf8")) as {
+      runtimeSourcePaths: string[];
+      backupPaths: string[];
+      targetRuntimeHadData: boolean;
+    };
+    expect(state).toMatchObject({
+      runtimeSourcePaths: [],
+      backupPaths: [],
+      targetRuntimeHadData: true
+    });
+  });
+
+  it("falls back to the legacy user-profile runtime home when install-local runtime data is absent", async () => {
+    const fixture = await createFixture();
+    await mkdir(join(fixture.sourceDataPath, "Memmy"), { recursive: true });
+    await mkdir(join(fixture.sourceDataPath, ".memmy"), { recursive: true });
+    await mkdir(join(fixture.legacyRuntimeHomePath, "memory-service"), { recursive: true });
+    await mkdir(join(fixture.legacyRuntimeHomePath, "updates"), { recursive: true });
+    await writeFile(join(fixture.sourceDataPath, "Memmy", "app.sqlite"), "login-state", "utf8");
+    await writeFile(
+      join(fixture.legacyRuntimeHomePath, "memory-service", "memory.sqlite"),
+      "legacy-home-state",
+      "utf8"
+    );
+    await writeFile(join(fixture.legacyRuntimeHomePath, "updates", "old-installer.exe"), "cache", "utf8");
+
+    const prepared = runMigration("Prepare", fixture);
+    expect(prepared.status, prepared.stderr || prepared.stdout).toBe(0);
+    expect(await readFile(join(fixture.targetRuntimeHomePath, "memory-service", "memory.sqlite"), "utf8"))
+      .toBe("legacy-home-state");
+    expect(await readFile(join(fixture.legacyRuntimeHomePath, "memory-service", "memory.sqlite"), "utf8"))
+      .toBe("legacy-home-state");
+    expect(existsSync(join(fixture.targetRuntimeHomePath, "updates"))).toBe(false);
+  });
+
+  it("keeps early APPDATA account data and copies early profile runtime when no install-local generation exists", async () => {
+    const fixture = await createFixture();
+    await Promise.all([
+      mkdir(fixture.targetUserDataPath, { recursive: true }),
+      mkdir(fixture.legacyRuntimeHomePath, { recursive: true })
+    ]);
+    await Promise.all([
+      writeFile(join(fixture.targetUserDataPath, "app.sqlite"), "early-account", "utf8"),
+      writeFile(join(fixture.targetUserDataPath, "history.json"), "early-history", "utf8"),
+      writeFile(join(fixture.legacyRuntimeHomePath, "config.yaml"), "early-runtime", "utf8")
+    ]);
+
+    const prepared = runMigration("Prepare", fixture);
+    expect(prepared.status, prepared.stderr || prepared.stdout).toBe(0);
+    await expect(readFile(join(fixture.targetUserDataPath, "app.sqlite"), "utf8"))
+      .resolves.toBe("early-account");
+    await expect(readFile(join(fixture.targetUserDataPath, "history.json"), "utf8"))
+      .resolves.toBe("early-history");
+    await expect(readFile(join(fixture.targetRuntimeHomePath, "config.yaml"), "utf8"))
+      .resolves.toBe("early-runtime");
+    expect(JSON.parse(await readFile(fixture.statePath, "utf8"))).toMatchObject({
+      accountSourceAuthority: "target-existing",
+      runtimeSourceAuthority: "legacy-home-fallback",
+      categorySourcesShareGeneration: false
+    });
+  });
+
+  it("acquires the unified update lock atomically for a direct installer migration", async () => {
+    const fixture = await createFixture();
+    await rm(fixture.lockPath, { recursive: true, force: true });
+    await mkdir(join(fixture.sourceDataPath, "Memmy"), { recursive: true });
+    await writeFile(join(fixture.sourceDataPath, "Memmy", "app.sqlite"), "login-state", "utf8");
+
+    const prepared = runMigration("Prepare", fixture, true);
+    expect(prepared.status, prepared.stderr || prepared.stdout).toBe(0);
+    expect(existsSync(fixture.lockPath)).toBe(true);
+
+    const competing = runMigration("Prepare", fixture, true);
+    expect(competing.status).not.toBe(0);
+    expect(existsSync(fixture.lockPath)).toBe(true);
+  });
+
+  it("refuses to copy a SQLite database that is still open for writing", async () => {
+    const fixture = await createFixture();
+    const sourceUserDataPath = join(fixture.sourceDataPath, "Memmy");
+    const sqlitePath = join(sourceUserDataPath, "app.sqlite");
+    await mkdir(sourceUserDataPath, { recursive: true });
+    await writeFile(sqlitePath, "login-state", "utf8");
+    const handle = await open(sqlitePath, "r+");
+    try {
+      const prepared = runMigration("Prepare", fixture);
+      expect(prepared.status).not.toBe(0);
+      expect(existsSync(fixture.targetUserDataPath)).toBe(false);
+      expect(await readFile(sqlitePath, "utf8")).toBe("login-state");
+    } finally {
+      await handle.close();
+    }
+  });
+
+  it("preserves a verified same-volume recovery copy when direct migration fails before uninstall", async () => {
+    const fixture = await createFixture();
+    const sourceUserDataPath = join(fixture.sourceDataPath, "Memmy");
+    const sourceRuntimePath = join(fixture.sourceDataPath, ".memmy");
+    const blockedStateParent = dirname(fixture.statePath);
+    await Promise.all([
+      mkdir(sourceUserDataPath, { recursive: true }),
+      mkdir(sourceRuntimePath, { recursive: true }),
+      mkdir(dirname(blockedStateParent), { recursive: true })
+    ]);
+    await Promise.all([
+      writeFile(join(sourceUserDataPath, "app.sqlite"), "recoverable-login", "utf8"),
+      writeFile(join(sourceRuntimePath, "config.yaml"), "recoverable-runtime", "utf8"),
+      writeFile(blockedStateParent, "block state directory creation", "utf8")
+    ]);
+
+    const failed = runMigration("Prepare", fixture);
+    expect(failed.status).not.toBe(0);
+    expect(existsSync(fixture.targetUserDataPath)).toBe(false);
+    expect(existsSync(fixture.targetRuntimeHomePath)).toBe(false);
+    const failedRecord = JSON.parse(await readFile(fixture.installationRecordPath, "utf8")) as {
+      sourceDataPath: string;
+      migrationFailed: boolean;
+    };
+    expect(failedRecord.migrationFailed).toBe(true);
+    await expect(readFile(join(failedRecord.sourceDataPath, "Memmy", "app.sqlite"), "utf8"))
+      .resolves.toBe("recoverable-login");
+    await expect(readFile(join(failedRecord.sourceDataPath, ".memmy", "config.yaml"), "utf8"))
+      .resolves.toBe("recoverable-runtime");
+
+    await rm(fixture.sourceDataPath, { recursive: true, force: true });
+    await rm(blockedStateParent, { force: true });
+    const retried = runMigration("Prepare", fixture, false, "", "untrusted-residual");
+    expect(retried.status, retried.stderr || retried.stdout).toBe(0);
+    await expect(readFile(join(fixture.targetUserDataPath, "app.sqlite"), "utf8"))
+      .resolves.toBe("recoverable-login");
+    await expect(readFile(join(fixture.targetRuntimeHomePath, "config.yaml"), "utf8"))
+      .resolves.toBe("recoverable-runtime");
+  });
+
+  it("replaces historical target data from the current install authority without merging", async () => {
+    const fixture = await createFixture();
+    await mkdir(join(fixture.sourceDataPath, "Memmy", "prepared-required-update.json.lock"), { recursive: true });
+    await mkdir(join(fixture.sourceDataPath, "Memmy", "updates"), { recursive: true });
+    await mkdir(join(fixture.sourceDataPath, ".memmy"), { recursive: true });
+    await mkdir(fixture.targetUserDataPath, { recursive: true });
+    await mkdir(fixture.targetRuntimeHomePath, { recursive: true });
+    await writeFile(join(fixture.sourceDataPath, "Memmy", "app.sqlite"), "new-login", "utf8");
+    await writeFile(join(fixture.sourceDataPath, "Memmy", "prepared-required-update.json"), "{}", "utf8");
+    await writeFile(join(fixture.sourceDataPath, "Memmy", "updates", "old-installer.exe"), "cache", "utf8");
+    await writeFile(join(fixture.sourceDataPath, ".memmy", "config.yaml"), "new-runtime", "utf8");
+    await writeFile(join(fixture.targetUserDataPath, "app.sqlite"), "old-login", "utf8");
+    await writeFile(join(fixture.targetRuntimeHomePath, "config.yaml"), "old-runtime", "utf8");
+    await writeFile(join(fixture.targetUserDataPath, "historical-only.txt"), "do-not-merge", "utf8");
+    await writeFile(join(fixture.targetRuntimeHomePath, "historical-only.txt"), "do-not-merge", "utf8");
+
+    const prepared = runMigration("Prepare", fixture);
+    expect(prepared.status, prepared.stderr || prepared.stdout).toBe(0);
+    const preparedState = JSON.parse(await readFile(fixture.statePath, "utf8")) as {
+      backupPaths: string[];
+      targetUserDataHadData: boolean;
+      targetRuntimeHadData: boolean;
+      sourceAuthority: string;
+    };
+    expect(preparedState).toMatchObject({
+      targetUserDataHadData: true,
+      targetRuntimeHadData: true,
+      sourceAuthority: "current-install-authority"
+    });
+    expect(preparedState.backupPaths).toHaveLength(2);
+    expect(await readFile(join(fixture.targetUserDataPath, "app.sqlite"), "utf8")).toBe("new-login");
+    expect(await readFile(join(fixture.targetRuntimeHomePath, "config.yaml"), "utf8")).toBe("new-runtime");
+    expect(existsSync(join(fixture.targetUserDataPath, "historical-only.txt"))).toBe(false);
+    expect(existsSync(join(fixture.targetRuntimeHomePath, "historical-only.txt"))).toBe(false);
+    expect(existsSync(join(fixture.targetUserDataPath, "prepared-required-update.json"))).toBe(false);
+    expect(existsSync(join(fixture.targetUserDataPath, "updates"))).toBe(false);
+
+    const completed = runMigration("Complete", fixture);
+    expect(completed.status, completed.stderr || completed.stdout).toBe(0);
+    expect(existsSync(join(fixture.targetUserDataPath, "prepared-required-update.json"))).toBe(false);
+    expect(existsSync(join(fixture.targetUserDataPath, "prepared-required-update.json.lock"))).toBe(false);
+    expect(existsSync(join(fixture.targetUserDataPath, "updates"))).toBe(false);
+    expect(existsSync(fixture.lockPath)).toBe(true);
+    expect(JSON.parse(await readFile(fixture.statePath, "utf8"))).toMatchObject({
+      phase: "awaiting-app-verification"
+    });
+  });
+
+  it("keeps verified targets when the install directory is only an untrusted residual", async () => {
+    const fixture = await createFixture();
+    await Promise.all([
+      mkdir(join(fixture.sourceDataPath, "Memmy"), { recursive: true }),
+      mkdir(join(fixture.sourceDataPath, ".memmy"), { recursive: true }),
+      mkdir(fixture.targetUserDataPath, { recursive: true }),
+      mkdir(fixture.targetRuntimeHomePath, { recursive: true })
+    ]);
+    await Promise.all([
+      writeFile(join(fixture.sourceDataPath, "Memmy", "app.sqlite"), "residual-login", "utf8"),
+      writeFile(join(fixture.sourceDataPath, ".memmy", "config.yaml"), "residual-runtime", "utf8"),
+      writeFile(join(fixture.targetUserDataPath, "app.sqlite"), "verified-login", "utf8"),
+      writeFile(join(fixture.targetRuntimeHomePath, "config.yaml"), "verified-runtime", "utf8")
+    ]);
+
+    const prepared = runMigration("Prepare", fixture, false, "", "untrusted-residual");
+    expect(prepared.status, prepared.stderr || prepared.stdout).toBe(0);
+    await expect(readFile(join(fixture.targetUserDataPath, "app.sqlite"), "utf8"))
+      .resolves.toBe("verified-login");
+    await expect(readFile(join(fixture.targetRuntimeHomePath, "config.yaml"), "utf8"))
+      .resolves.toBe("verified-runtime");
+    expect(JSON.parse(await readFile(fixture.statePath, "utf8"))).toMatchObject({
+      sourceAuthority: "untrusted-residual",
+      preparedCopies: []
+    });
+  });
+
+  it("trusts the exact user-selected install directory after a legacy uninstall removed its registry entry", async () => {
+    const fixture = await createFixture();
+    await Promise.all([
+      mkdir(join(fixture.sourceDataPath, "Memmy"), { recursive: true }),
+      mkdir(join(fixture.sourceDataPath, ".memmy"), { recursive: true }),
+      mkdir(fixture.targetUserDataPath, { recursive: true }),
+      mkdir(fixture.targetRuntimeHomePath, { recursive: true })
+    ]);
+    await Promise.all([
+      writeFile(join(fixture.sourceDataPath, "Memmy", "app.sqlite"), "selected-login", "utf8"),
+      writeFile(join(fixture.sourceDataPath, ".memmy", "config.yaml"), "selected-runtime", "utf8"),
+      writeFile(join(fixture.targetUserDataPath, "app.sqlite"), "historical-login", "utf8"),
+      writeFile(join(fixture.targetRuntimeHomePath, "config.yaml"), "historical-runtime", "utf8")
+    ]);
+
+    const prepared = runMigration("Prepare", fixture, false, "", "selected-install-authority");
+    expect(prepared.status, prepared.stderr || prepared.stdout).toBe(0);
+    await expect(readFile(join(fixture.targetUserDataPath, "app.sqlite"), "utf8"))
+      .resolves.toBe("selected-login");
+    await expect(readFile(join(fixture.targetRuntimeHomePath, "config.yaml"), "utf8"))
+      .resolves.toBe("selected-runtime");
+    expect(JSON.parse(await readFile(fixture.statePath, "utf8"))).toMatchObject({
+      sourceAuthority: "selected-install-authority"
+    });
+  });
+
+  it("does not trust a selected install residual already marked as the verified external generation", async () => {
+    const fixture = await createFixture();
+    await Promise.all([
+      mkdir(join(fixture.sourceDataPath, "Memmy"), { recursive: true }),
+      mkdir(join(fixture.sourceDataPath, ".memmy"), { recursive: true }),
+      mkdir(fixture.targetUserDataPath, { recursive: true }),
+      mkdir(fixture.targetRuntimeHomePath, { recursive: true }),
+      mkdir(dirname(fixture.installationRecordPath), { recursive: true })
+    ]);
+    await Promise.all([
+      writeFile(join(fixture.sourceDataPath, "Memmy", "app.sqlite"), "residual-login", "utf8"),
+      writeFile(join(fixture.sourceDataPath, ".memmy", "config.yaml"), "residual-runtime", "utf8"),
+      writeFile(join(fixture.targetUserDataPath, "app.sqlite"), "verified-login", "utf8"),
+      writeFile(join(fixture.targetRuntimeHomePath, "config.yaml"), "verified-runtime", "utf8"),
+      writeFile(fixture.installationRecordPath, JSON.stringify({
+        schemaVersion: 1,
+        dataLayoutGeneration: "external-v1",
+        installDir: dirname(fixture.sourceDataPath),
+        appVersion: "1.1.0",
+        recordedAt: new Date().toISOString()
+      }), "utf8")
+    ]);
+
+    expect(runMigration("Prepare", fixture, false, "", "selected-install-authority").status).toBe(0);
+    await expect(readFile(join(fixture.targetUserDataPath, "app.sqlite"), "utf8")).resolves.toBe("verified-login");
+    await expect(readFile(join(fixture.targetRuntimeHomePath, "config.yaml"), "utf8")).resolves.toBe("verified-runtime");
+  });
+
+  it("keeps verified targets when the registered install is already marked as external layout", async () => {
+    const fixture = await createFixture();
+    await Promise.all([
+      mkdir(join(fixture.sourceDataPath, "Memmy"), { recursive: true }),
+      mkdir(join(fixture.sourceDataPath, ".memmy"), { recursive: true }),
+      mkdir(fixture.targetUserDataPath, { recursive: true }),
+      mkdir(fixture.targetRuntimeHomePath, { recursive: true }),
+      mkdir(dirname(fixture.installationRecordPath), { recursive: true })
+    ]);
+    await Promise.all([
+      writeFile(join(fixture.sourceDataPath, "Memmy", "app.sqlite"), "residual-login", "utf8"),
+      writeFile(join(fixture.sourceDataPath, ".memmy", "config.yaml"), "residual-runtime", "utf8"),
+      writeFile(join(fixture.targetUserDataPath, "app.sqlite"), "verified-login", "utf8"),
+      writeFile(join(fixture.targetRuntimeHomePath, "config.yaml"), "verified-runtime", "utf8")
+    ]);
+    await writeFile(fixture.installationRecordPath, JSON.stringify({
+      schemaVersion: 1,
+      dataLayoutGeneration: "external-v1",
+      installDir: dirname(fixture.sourceDataPath),
+      recordedAt: new Date(Date.now() + 10_000).toISOString()
+    }), "utf8");
+
+    const prepared = runMigration("Prepare", fixture);
+    expect(prepared.status, prepared.stderr || prepared.stdout).toBe(0);
+    await expect(readFile(join(fixture.targetUserDataPath, "app.sqlite"), "utf8"))
+      .resolves.toBe("verified-login");
+    await expect(readFile(join(fixture.targetRuntimeHomePath, "config.yaml"), "utf8"))
+      .resolves.toBe("verified-runtime");
+    expect(JSON.parse(await readFile(fixture.statePath, "utf8"))).toMatchObject({
+      sourceAuthority: "untrusted-residual",
+      preparedCopies: []
+    });
+  });
+
+  it("lets a registered 1.0.9 install override an earlier external-layout marker without relying on mtimes", async () => {
+    const fixture = await createFixture();
+    await Promise.all([
+      mkdir(join(fixture.sourceDataPath, "Memmy"), { recursive: true }),
+      mkdir(join(fixture.sourceDataPath, ".memmy"), { recursive: true }),
+      mkdir(fixture.targetUserDataPath, { recursive: true }),
+      mkdir(fixture.targetRuntimeHomePath, { recursive: true }),
+      mkdir(dirname(fixture.installationRecordPath), { recursive: true })
+    ]);
+    await writeFile(fixture.installationRecordPath, JSON.stringify({
+      schemaVersion: 1,
+      dataLayoutGeneration: "external-v1",
+      installDir: dirname(fixture.sourceDataPath),
+      recordedAt: "2000-01-01T00:00:00.000Z"
+    }), "utf8");
+    await Promise.all([
+      writeFile(join(fixture.sourceDataPath, "Memmy", "app.sqlite"), "newer-login", "utf8"),
+      writeFile(join(fixture.sourceDataPath, ".memmy", "config.yaml"), "newer-runtime", "utf8"),
+      writeFile(join(fixture.targetUserDataPath, "app.sqlite"), "old-target-login", "utf8"),
+      writeFile(join(fixture.targetRuntimeHomePath, "config.yaml"), "old-target-runtime", "utf8")
+    ]);
+
+    const prepared = runMigration("Prepare", fixture, false, "", "current-install-authority", "1.0.9");
+    expect(prepared.status, prepared.stderr || prepared.stdout).toBe(0);
+    await expect(readFile(join(fixture.targetUserDataPath, "app.sqlite"), "utf8"))
+      .resolves.toBe("newer-login");
+    await expect(readFile(join(fixture.targetRuntimeHomePath, "config.yaml"), "utf8"))
+      .resolves.toBe("newer-runtime");
+    expect(JSON.parse(await readFile(fixture.installationRecordPath, "utf8"))).toMatchObject({
+      dataLayoutGeneration: "install-local-v1",
+      installDir: dirname(fixture.sourceDataPath)
+    });
+  });
+
+  it("uses an exact persisted install-local record when the registry source is unavailable", async () => {
+    const fixture = await createFixture();
+    await Promise.all([
+      mkdir(join(fixture.sourceDataPath, "Memmy"), { recursive: true }),
+      mkdir(join(fixture.sourceDataPath, ".memmy"), { recursive: true }),
+      mkdir(fixture.targetUserDataPath, { recursive: true }),
+      mkdir(fixture.targetRuntimeHomePath, { recursive: true }),
+      mkdir(dirname(fixture.installationRecordPath), { recursive: true })
+    ]);
+    await Promise.all([
+      writeFile(join(fixture.sourceDataPath, "Memmy", "app.sqlite"), "persisted-login", "utf8"),
+      writeFile(join(fixture.sourceDataPath, ".memmy", "config.yaml"), "persisted-runtime", "utf8"),
+      writeFile(join(fixture.targetUserDataPath, "app.sqlite"), "historical-login", "utf8"),
+      writeFile(join(fixture.targetRuntimeHomePath, "config.yaml"), "historical-runtime", "utf8"),
+      writeFile(fixture.installationRecordPath, JSON.stringify({
+        schemaVersion: 1,
+        dataLayoutGeneration: "install-local-v1",
+        installDir: dirname(fixture.sourceDataPath),
+        sourceGeneration: "legacy-install:test-record",
+        recordedAt: new Date().toISOString()
+      }), "utf8")
+    ]);
+
+    const prepared = runMigration("Prepare", fixture, false, "", "untrusted-residual");
+    expect(prepared.status, prepared.stderr || prepared.stdout).toBe(0);
+    await expect(readFile(join(fixture.targetUserDataPath, "app.sqlite"), "utf8"))
+      .resolves.toBe("persisted-login");
+    await expect(readFile(join(fixture.targetRuntimeHomePath, "config.yaml"), "utf8"))
+      .resolves.toBe("persisted-runtime");
+    expect(JSON.parse(await readFile(fixture.statePath, "utf8"))).toMatchObject({
+      sourceAuthority: "persisted-install-authority",
+      sourceGeneration: "legacy-install:test-record"
+    });
+  });
+
+  it("keeps the exact user-selected install source instead of an older persisted install record", async () => {
+    const fixture = await createFixture();
+    const olderInstallDir = join(fixture.root, "older-install");
+    const olderDataPath = join(olderInstallDir, "data");
+    await Promise.all([
+      mkdir(join(fixture.sourceDataPath, "Memmy"), { recursive: true }),
+      mkdir(join(fixture.sourceDataPath, ".memmy"), { recursive: true }),
+      mkdir(join(olderDataPath, "Memmy"), { recursive: true }),
+      mkdir(join(olderDataPath, ".memmy"), { recursive: true }),
+      mkdir(dirname(fixture.installationRecordPath), { recursive: true })
+    ]);
+    await Promise.all([
+      writeFile(join(fixture.sourceDataPath, "Memmy", "app.sqlite"), "selected-login", "utf8"),
+      writeFile(join(fixture.sourceDataPath, ".memmy", "config.yaml"), "selected-runtime", "utf8"),
+      writeFile(join(olderDataPath, "Memmy", "app.sqlite"), "older-login", "utf8"),
+      writeFile(join(olderDataPath, ".memmy", "config.yaml"), "older-runtime", "utf8"),
+      writeFile(fixture.installationRecordPath, JSON.stringify({
+        schemaVersion: 1,
+        dataLayoutGeneration: "install-local-v1",
+        installDir: olderInstallDir,
+        sourceDataPath: olderDataPath,
+        sourceGeneration: "legacy-install:older",
+        recordedAt: new Date().toISOString()
+      }), "utf8")
+    ]);
+
+    const prepared = runMigration("Prepare", fixture, false, "", "selected-install-authority");
+    expect(prepared.status, prepared.stderr || prepared.stdout).toBe(0);
+    await expect(readFile(join(fixture.targetUserDataPath, "app.sqlite"), "utf8")).resolves.toBe("selected-login");
+    await expect(readFile(join(fixture.targetRuntimeHomePath, "config.yaml"), "utf8")).resolves.toBe("selected-runtime");
+    expect(JSON.parse(await readFile(fixture.statePath, "utf8"))).toMatchObject({
+      sourceAuthority: "selected-install-authority",
+      sourceDataPath: fixture.sourceDataPath
+    });
+  });
+
+  it("replaces a non-empty target from a complete trusted account source", async () => {
+    const fixture = await createFixture();
+    await mkdir(join(fixture.sourceDataPath, "Memmy"), { recursive: true });
+    await mkdir(fixture.targetUserDataPath, { recursive: true });
+    await writeFile(join(fixture.sourceDataPath, "Memmy", "app.sqlite"), "legacy-login", "utf8");
+    await writeFile(join(fixture.targetUserDataPath, "session.json"), "current-login", "utf8");
+
+    const prepared = runMigration("Prepare", fixture);
+    expect(prepared.status, prepared.stderr || prepared.stdout).toBe(0);
+    expect(existsSync(join(fixture.targetUserDataPath, "session.json"))).toBe(false);
+    expect(await readFile(join(fixture.targetUserDataPath, "app.sqlite"), "utf8")).toBe("legacy-login");
+    expect(JSON.parse(await readFile(fixture.statePath, "utf8"))).toMatchObject({
+      targetUserDataHadData: true,
+      accountSourceAuthority: "current-install-authority"
+    });
+  });
+
+  it("ignores a data-root pointer outside supported Memmy runtime roots", async () => {
+    const fixture = await createFixture();
+    const arbitraryRuntimePath = join(fixture.root, "arbitrary", "runtime");
+    await mkdir(arbitraryRuntimePath, { recursive: true });
+    await mkdir(fixture.targetUserDataPath, { recursive: true });
+    await writeFile(join(arbitraryRuntimePath, "do-not-copy.txt"), "private", "utf8");
+    await writeFile(fixture.pointerPath, Buffer.concat([
+      Buffer.from([0xff, 0xfe]),
+      Buffer.from(`${arbitraryRuntimePath}\r\n`, "utf16le")
+    ]));
+
+    const prepared = runMigration("Prepare", fixture);
+    expect(prepared.status, prepared.stderr || prepared.stdout).toBe(0);
+    expect(existsSync(join(fixture.targetRuntimeHomePath, "do-not-copy.txt"))).toBe(false);
+    expect(await readFile(join(arbitraryRuntimePath, "do-not-copy.txt"), "utf8")).toBe("private");
+    expect(await readFile(fixture.logPath, "utf8")).toContain(
+      "Ignoring data-root pointer outside a supported Memmy runtime root"
+    );
+  });
+
+  it("rolls back newly copied destinations and the previous data-root pointer after an installer failure", async () => {
+    const fixture = await createFixture();
+    const previousRuntimeHomePath = join(fixture.root, "previous-runtime", ".memmy");
+    await mkdir(join(fixture.sourceDataPath, "Memmy"), { recursive: true });
+    await mkdir(join(fixture.sourceDataPath, ".memmy"), { recursive: true });
+    await writeFile(join(fixture.sourceDataPath, "Memmy", "app.sqlite"), "new-login", "utf8");
+    await writeFile(join(fixture.sourceDataPath, ".memmy", "config.yaml"), "new-runtime", "utf8");
+    await mkdir(fixture.targetUserDataPath, { recursive: true });
+    await writeFile(fixture.pointerPath, `${previousRuntimeHomePath}\r\n`, "utf16le");
+
+    const prepared = runMigration("Prepare", fixture);
+    expect(prepared.status, prepared.stderr || prepared.stdout).toBe(0);
+    expect(await readFile(join(fixture.targetUserDataPath, "app.sqlite"), "utf8")).toBe("new-login");
+
+    const rolledBack = runMigration("Rollback", fixture);
+    expect(rolledBack.status, rolledBack.stderr || rolledBack.stdout).toBe(0);
+    expect(existsSync(join(fixture.targetUserDataPath, "app.sqlite"))).toBe(false);
+    expect(existsSync(fixture.targetRuntimeHomePath)).toBe(false);
+    expect(await readFile(fixture.pointerPath, "utf16le")).toBe(`${previousRuntimeHomePath}\r\n`);
+    expect(existsSync(fixture.statePath)).toBe(false);
+  });
+
+  it("retries rollback idempotently after one category was already restored", async () => {
+    const fixture = await createFixture();
+    await Promise.all([
+      mkdir(join(fixture.sourceDataPath, "Memmy"), { recursive: true }),
+      mkdir(join(fixture.sourceDataPath, ".memmy"), { recursive: true }),
+      mkdir(fixture.targetUserDataPath, { recursive: true }),
+      mkdir(fixture.targetRuntimeHomePath, { recursive: true })
+    ]);
+    await Promise.all([
+      writeFile(join(fixture.sourceDataPath, "Memmy", "app.sqlite"), "new-login", "utf8"),
+      writeFile(join(fixture.sourceDataPath, ".memmy", "config.yaml"), "new-runtime", "utf8"),
+      writeFile(join(fixture.targetUserDataPath, "app.sqlite"), "old-login", "utf8"),
+      writeFile(join(fixture.targetRuntimeHomePath, "config.yaml"), "old-runtime", "utf8")
+    ]);
+    expect(runMigration("Prepare", fixture).status).toBe(0);
+    const state = JSON.parse(await readFile(fixture.statePath, "utf8")) as {
+      preparedCopies: Array<{ DestinationPath: string; BackupPath?: string }>;
+    };
+    const runtimeCopy = state.preparedCopies.find((copy) => copy.DestinationPath === fixture.targetRuntimeHomePath);
+    expect(runtimeCopy?.BackupPath).toBeTruthy();
+    await rm(fixture.targetRuntimeHomePath, { recursive: true, force: true });
+    await rename(runtimeCopy!.BackupPath!, fixture.targetRuntimeHomePath);
+
+    const rolledBack = runMigration("Rollback", fixture);
+    expect(rolledBack.status, rolledBack.stderr || rolledBack.stdout).toBe(0);
+    await expect(readFile(join(fixture.targetUserDataPath, "app.sqlite"), "utf8")).resolves.toBe("old-login");
+    await expect(readFile(join(fixture.targetRuntimeHomePath, "config.yaml"), "utf8")).resolves.toBe("old-runtime");
+    expect(existsSync(fixture.statePath)).toBe(false);
+  });
+
+  it("rolls back a no-op preparation with no copied directories", async () => {
+    const fixture = await createFixture();
+    await mkdir(fixture.targetUserDataPath, { recursive: true });
+    await mkdir(fixture.targetRuntimeHomePath, { recursive: true });
+    await writeFile(join(fixture.targetRuntimeHomePath, "config.yaml"), "same-runtime", "utf8");
+    await writeFile(fixture.pointerPath, `${fixture.targetRuntimeHomePath}\r\n`, "utf16le");
+
+    const prepared = runMigration("Prepare", fixture);
+    expect(prepared.status, prepared.stderr || prepared.stdout).toBe(0);
+    expect(JSON.parse(await readFile(fixture.statePath, "utf8"))).toMatchObject({
+      phase: "prepared",
+      preparedCopies: []
+    });
+
+    const rolledBack = runMigration("Rollback", fixture);
+    expect(rolledBack.status, rolledBack.stderr || rolledBack.stdout).toBe(0);
+    expect(existsSync(fixture.statePath)).toBe(false);
+    expect(await readFile(join(fixture.targetRuntimeHomePath, "config.yaml"), "utf8")).toBe("same-runtime");
+  });
+
+  it("refuses verified-backup cleanup when state targets differ from the trusted layout", async () => {
+    const fixture = await createFixture();
+    const unrelatedTarget = join(fixture.root, "unrelated", "user-data");
+    const unrelatedBackup = `${unrelatedTarget}.migration-backup-0123456789abcdef0123456789abcdef`;
+    await mkdir(unrelatedBackup, { recursive: true });
+    await writeFile(join(unrelatedBackup, "keep.txt"), "keep", "utf8");
+    await mkdir(join(fixture.statePath, ".."), { recursive: true });
+    await writeFile(fixture.statePath, JSON.stringify({
+      phase: "app-verified",
+      targetUserDataPath: unrelatedTarget,
+      targetRuntimeHomePath: fixture.targetRuntimeHomePath,
+      backupPaths: [unrelatedBackup]
+    }), "utf8");
+
+    const nextPrepare = runMigration("Prepare", fixture);
+    expect(nextPrepare.status).not.toBe(0);
+    expect(await readFile(join(unrelatedBackup, "keep.txt"), "utf8")).toBe("keep");
+    expect(existsSync(fixture.statePath)).toBe(true);
+  });
+
+  it("cleans verified state through the trusted pointer before switching runtime drives", async () => {
+    const fixture = await createFixture();
+    const previousRuntimeHomePath = join(fixture.root, "previous-drive", "MemmyData", ".memmy");
+    const previousBackup = `${previousRuntimeHomePath}.migration-backup-0123456789abcdef0123456789abcdef`;
+    await mkdir(fixture.targetUserDataPath, { recursive: true });
+    await mkdir(previousRuntimeHomePath, { recursive: true });
+    await mkdir(previousBackup, { recursive: true });
+    await writeFile(join(previousRuntimeHomePath, "config.yaml"), "previous-runtime", "utf8");
+    await writeFile(join(previousBackup, "stale.txt"), "stale-backup", "utf8");
+    await writeFile(fixture.pointerPath, Buffer.concat([
+      Buffer.from([0xff, 0xfe]),
+      Buffer.from(`${previousRuntimeHomePath}\r\n`, "utf16le")
+    ]));
+    await mkdir(join(fixture.statePath, ".."), { recursive: true });
+    await writeFile(fixture.statePath, JSON.stringify({
+      phase: "app-verified",
+      targetUserDataPath: fixture.targetUserDataPath,
+      targetRuntimeHomePath: previousRuntimeHomePath,
+      backupPaths: [previousBackup]
+    }), "utf8");
+
+    const nextPrepare = runMigration("Prepare", fixture, false, previousRuntimeHomePath);
+    expect(nextPrepare.status, nextPrepare.stderr || nextPrepare.stdout).toBe(0);
+    expect(existsSync(previousBackup)).toBe(true);
+    expect(await readFile(join(fixture.targetRuntimeHomePath, "config.yaml"), "utf8"))
+      .toBe("previous-runtime");
+    expect(JSON.parse(await readFile(fixture.statePath, "utf8"))).toMatchObject({
+      phase: "prepared",
+      runtimeSourcePaths: [previousRuntimeHomePath],
+      targetRuntimeHomePath: fixture.targetRuntimeHomePath,
+      deferredCleanupStates: [{ phase: "app-verified" }]
+    });
+  });
+
+  it("recovers a failed direct install by rolling back while the old source still exists", async () => {
+    const fixture = await createFixture();
+    await mkdir(join(fixture.sourceDataPath, "Memmy"), { recursive: true });
+    await mkdir(join(fixture.sourceDataPath, ".memmy"), { recursive: true });
+    await writeFile(join(fixture.sourceDataPath, "Memmy", "app.sqlite"), "login-state", "utf8");
+    await writeFile(join(fixture.sourceDataPath, ".memmy", "config.yaml"), "runtime-state", "utf8");
+
+    const prepared = runMigration("Prepare", fixture);
+    expect(prepared.status, prepared.stderr || prepared.stdout).toBe(0);
+
+    const recovered = runMigration("Recover", fixture);
+    expect(recovered.status, recovered.stderr || recovered.stdout).toBe(0);
+    expect(existsSync(join(fixture.targetUserDataPath, "app.sqlite"))).toBe(false);
+    expect(existsSync(fixture.targetRuntimeHomePath)).toBe(false);
+    expect(existsSync(fixture.statePath)).toBe(false);
+  });
+
+  it("preserves migrated data for retry when the failed installer already removed the old source", async () => {
+    const fixture = await createFixture();
+    await mkdir(join(fixture.sourceDataPath, "Memmy"), { recursive: true });
+    await mkdir(join(fixture.sourceDataPath, ".memmy"), { recursive: true });
+    await writeFile(join(fixture.sourceDataPath, "Memmy", "app.sqlite"), "login-state", "utf8");
+    await writeFile(join(fixture.sourceDataPath, ".memmy", "config.yaml"), "runtime-state", "utf8");
+
+    const prepared = runMigration("Prepare", fixture);
+    expect(prepared.status, prepared.stderr || prepared.stdout).toBe(0);
+    await rm(fixture.sourceDataPath, { recursive: true, force: true });
+
+    const recovered = runMigration("Recover", fixture);
+    expect(recovered.status, recovered.stderr || recovered.stdout).toBe(0);
+    expect(await readFile(join(fixture.targetUserDataPath, "app.sqlite"), "utf8")).toBe("login-state");
+    expect(await readFile(join(fixture.targetRuntimeHomePath, "config.yaml"), "utf8")).toBe("runtime-state");
+    expect(JSON.parse(await readFile(fixture.statePath, "utf8"))).toMatchObject({
+      phase: "prepared-for-retry"
+    });
+
+    await rm(fixture.lockPath, { recursive: true, force: true });
+    const resumed = runMigration("Prepare", fixture, true);
+    expect(resumed.status, resumed.stderr || resumed.stdout).toBe(0);
+    expect(JSON.parse(await readFile(fixture.statePath, "utf8"))).toMatchObject({
+      phase: "prepared-for-retry"
+    });
+
+    const completed = runMigration("Complete", fixture);
+    expect(completed.status, completed.stderr || completed.stdout).toBe(0);
+    expect(JSON.parse(await readFile(fixture.statePath, "utf8"))).toMatchObject({
+      phase: "awaiting-app-verification"
+    });
+  });
+
+  it("lets a newly confirmed current install source supersede prepared-for-retry data", async () => {
+    const fixture = await createFixture();
+    await Promise.all([
+      mkdir(join(fixture.sourceDataPath, "Memmy"), { recursive: true }),
+      mkdir(join(fixture.sourceDataPath, ".memmy"), { recursive: true })
+    ]);
+    await Promise.all([
+      writeFile(join(fixture.sourceDataPath, "Memmy", "app.sqlite"), "first-login", "utf8"),
+      writeFile(join(fixture.sourceDataPath, ".memmy", "config.yaml"), "first-runtime", "utf8")
+    ]);
+    expect(runMigration("Prepare", fixture).status).toBe(0);
+    await rm(fixture.sourceDataPath, { recursive: true, force: true });
+    expect(runMigration("Recover", fixture).status).toBe(0);
+    await Promise.all([
+      mkdir(join(fixture.sourceDataPath, "Memmy"), { recursive: true }),
+      mkdir(join(fixture.sourceDataPath, ".memmy"), { recursive: true })
+    ]);
+    await Promise.all([
+      writeFile(join(fixture.sourceDataPath, "Memmy", "app.sqlite"), "newest-login", "utf8"),
+      writeFile(join(fixture.sourceDataPath, ".memmy", "config.yaml"), "newest-runtime", "utf8")
+    ]);
+    await rm(fixture.lockPath, { recursive: true, force: true });
+
+    const resumed = runMigration("Prepare", fixture, true);
+    expect(resumed.status, resumed.stderr || resumed.stdout).toBe(0);
+    await expect(readFile(join(fixture.targetUserDataPath, "app.sqlite"), "utf8")).resolves.toBe("newest-login");
+    await expect(readFile(join(fixture.targetRuntimeHomePath, "config.yaml"), "utf8")).resolves.toBe("newest-runtime");
+    expect(JSON.parse(await readFile(fixture.statePath, "utf8"))).toMatchObject({ phase: "prepared" });
+  });
+
+  it("rolls back a fresh-install preparation that copied no data", async () => {
+    const fixture = await createFixture();
+
+    const prepared = runMigration("Prepare", fixture);
+    expect(prepared.status, prepared.stderr || prepared.stdout).toBe(0);
+    expect(JSON.parse(await readFile(fixture.statePath, "utf8"))).toMatchObject({
+      phase: "prepared",
+      preparedCopies: []
+    });
+
+    const recovered = runMigration("Recover", fixture);
+    expect(recovered.status, recovered.stderr || recovered.stdout).toBe(0);
+    expect(existsSync(fixture.statePath)).toBe(false);
+    expect(existsSync(fixture.pointerPath)).toBe(false);
+  });
+
+  it("rolls back copied external runtime data while its real source still exists", async () => {
+    const fixture = await createFixture();
+    await mkdir(fixture.legacyRuntimeHomePath, { recursive: true });
+    await writeFile(join(fixture.legacyRuntimeHomePath, "config.yaml"), "legacy-runtime", "utf8");
+
+    const prepared = runMigration("Prepare", fixture);
+    expect(prepared.status, prepared.stderr || prepared.stdout).toBe(0);
+    expect(await readFile(join(fixture.targetRuntimeHomePath, "config.yaml"), "utf8"))
+      .toBe("legacy-runtime");
+
+    const recovered = runMigration("Recover", fixture);
+    expect(recovered.status, recovered.stderr || recovered.stdout).toBe(0);
+    expect(existsSync(fixture.targetRuntimeHomePath)).toBe(false);
+    expect(await readFile(join(fixture.legacyRuntimeHomePath, "config.yaml"), "utf8"))
+      .toBe("legacy-runtime");
+    expect(existsSync(fixture.statePath)).toBe(false);
+  });
+
+  it("preserves a copied runtime destination when its real source disappeared", async () => {
+    const fixture = await createFixture();
+    await mkdir(fixture.sourceDataPath, { recursive: true });
+    await mkdir(fixture.legacyRuntimeHomePath, { recursive: true });
+    await writeFile(join(fixture.legacyRuntimeHomePath, "config.yaml"), "only-runtime-copy", "utf8");
+
+    const prepared = runMigration("Prepare", fixture);
+    expect(prepared.status, prepared.stderr || prepared.stdout).toBe(0);
+    await rm(fixture.legacyRuntimeHomePath, { recursive: true, force: true });
+
+    const recovered = runMigration("Recover", fixture);
+    expect(recovered.status, recovered.stderr || recovered.stdout).toBe(0);
+    expect(await readFile(join(fixture.targetRuntimeHomePath, "config.yaml"), "utf8"))
+      .toBe("only-runtime-copy");
+    expect(JSON.parse(await readFile(fixture.statePath, "utf8"))).toMatchObject({
+      phase: "prepared-for-retry"
+    });
+  });
+});
+
+interface MigrationFixture {
+  root: string;
+  sourceDataPath: string;
+  legacyRuntimeHomePath: string;
+  targetUserDataPath: string;
+  targetRuntimeHomePath: string;
+  pointerPath: string;
+  statePath: string;
+  installationRecordPath: string;
+  lockPath: string;
+  logPath: string;
+}
+
+async function createFixture(): Promise<MigrationFixture> {
+  const root = await mkdtemp(join(tmpdir(), "memmy-windows-data-migration-"));
+  temporaryDirectories.push(root);
+  const lockPath = join(root, "upgrade-staging", "active.lock");
+  await mkdir(lockPath, { recursive: true });
+  return {
+    root,
+    sourceDataPath: join(root, "old-install", "data"),
+    legacyRuntimeHomePath: join(root, "Users", "tester", ".memmy"),
+    targetUserDataPath: join(root, "AppData", "Roaming", "Memmy"),
+    targetRuntimeHomePath: join(root, "new-drive", "MemmyData", ".memmy"),
+    pointerPath: join(root, "AppData", "Roaming", "Memmy", "data-root.txt"),
+    statePath: join(root, "AppData", "Local", "Memmy", "data-migration", "state.json"),
+    installationRecordPath: join(root, "AppData", "Local", "Memmy", "data-layout", "last-install.json"),
+    lockPath,
+    logPath: join(root, "migration.log")
+  };
+}
+
+function runMigration(
+  mode: "Prepare" | "Complete" | "Rollback" | "Recover",
+  fixture: MigrationFixture,
+  acquireLock = false,
+  allowedRememberedRuntimeHomePath = "",
+  sourceAuthority: "current-install-authority" | "selected-install-authority" | "relay-backup-authority" | "persisted-install-authority" | "untrusted-residual" = "current-install-authority",
+  sourceInstalledVersion = ""
+) {
+  const args = [
+    "-NoProfile",
+    "-NonInteractive",
+    "-ExecutionPolicy", "Bypass",
+    "-File", scriptPath,
+    "-Mode", mode,
+    "-SourceDataPath", fixture.sourceDataPath,
+    "-SourceAuthority", sourceAuthority,
+    "-SourceInstallDir", dirname(fixture.sourceDataPath),
+    "-SourceInstalledVersion", sourceInstalledVersion,
+    "-InstallationRecordPath", fixture.installationRecordPath,
+    "-LegacyRuntimeHomePath", fixture.legacyRuntimeHomePath,
+    "-TargetUserDataPath", fixture.targetUserDataPath,
+    "-TargetRuntimeHomePath", fixture.targetRuntimeHomePath,
+    "-PointerPath", fixture.pointerPath,
+    "-StatePath", fixture.statePath,
+    "-LockPath", fixture.lockPath,
+    "-LogPath", fixture.logPath,
+    "-Owner", "installer"
+  ];
+  if (acquireLock) {
+    args.push(
+      "-InstallerPid", String(process.pid),
+      "-InstallerPath", process.execPath,
+      "-InstallerInstallDir", join(fixture.root, "new-install"),
+      "-AcquireLock"
+    );
+  }
+  if (allowedRememberedRuntimeHomePath) {
+    args.push("-AllowedRememberedRuntimeHomePath", allowedRememberedRuntimeHomePath);
+  }
+  return spawnSync("powershell.exe", args, { encoding: "utf8" });
+}
+
+async function readPointer(pointerPath: string): Promise<string> {
+  const contents = await readFile(pointerPath);
+  expect([...contents.subarray(0, 2)]).toEqual([0xff, 0xfe]);
+  return contents.subarray(2).toString("utf16le");
+}

--- a/App/shell/desktop/tests/windows-installer-nsis-compile.test.ts
+++ b/App/shell/desktop/tests/windows-installer-nsis-compile.test.ts
@@ -1,0 +1,71 @@
+import { execFile as execFileCallback } from "node:child_process";
+import { existsSync } from "node:fs";
+import { copyFile, mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { promisify } from "node:util";
+import { afterEach, describe, expect, it } from "vitest";
+
+const execFile = promisify(execFileCallback);
+const describeOnWindows = process.platform === "win32" ? describe : describe.skip;
+const desktopRoot = resolve(import.meta.dirname, "..");
+const electronBuilderCli = resolve(
+  desktopRoot,
+  "..",
+  "..",
+  "..",
+  "node_modules",
+  "electron-builder",
+  "out",
+  "cli",
+  "cli.js"
+);
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(temporaryDirectories.splice(0).map((directory) =>
+    rm(directory, { recursive: true, force: true })
+  ));
+});
+
+describeOnWindows("Windows installer NSIS compilation", () => {
+  it("compiles the real installer include with electron-builder's generated NSIS macros", async () => {
+    const root = await mkdtemp(join(tmpdir(), "memmy-nsis-compile-"));
+    temporaryDirectories.push(root);
+    const prepackagedRoot = join(root, "win-unpacked");
+    const outputRoot = join(root, "out");
+    const artifactPath = join(outputRoot, "Memmy-nsis-compile-check.exe");
+    await mkdir(join(prepackagedRoot, "resources"), { recursive: true });
+    await copyFile(
+      join(process.env.SystemRoot ?? "C:\\Windows", "System32", "where.exe"),
+      join(prepackagedRoot, "Memmy.exe")
+    );
+
+    await execFile(process.execPath, [
+      electronBuilderCli,
+      "--config",
+      "electron-builder.win.unsigned.yml",
+      "--config.extraMetadata.version=1.1.0",
+      `--config.directories.output=${outputRoot}`,
+      "--config.win.signAndEditExecutable=false",
+      "--config.compression=store",
+      "--prepackaged",
+      prepackagedRoot,
+      "--win",
+      "nsis",
+      "--x64",
+      "--config.artifactName=Memmy-nsis-compile-check.exe"
+    ], {
+      cwd: desktopRoot,
+      env: {
+        ...process.env,
+        CSC_IDENTITY_AUTO_DISCOVERY: "false"
+      },
+      timeout: 120_000,
+      windowsHide: true,
+      maxBuffer: 10 * 1024 * 1024
+    });
+
+    expect(existsSync(artifactPath)).toBe(true);
+  }, 120_000);
+});

--- a/App/shell/desktop/tests/windows-upgrade-relay.test.ts
+++ b/App/shell/desktop/tests/windows-upgrade-relay.test.ts
@@ -10,6 +10,7 @@ const execFile = promisify(execFileCallback);
 const relayScriptPath = resolve(import.meta.dirname, "../build/MemmyWindowsUpgradeRelay.ps1");
 const cleanupScriptPath = resolve(import.meta.dirname, "../build/MemmyWindowsUpgradeCleanup.ps1");
 const recoveryScriptPath = resolve(import.meta.dirname, "../build/MemmyWindowsUpgradeRecovery.ps1");
+const migrationScriptPath = resolve(import.meta.dirname, "../build/MemmyWindowsDataMigration.ps1");
 const temporaryDirectories: string[] = [];
 const helperProcesses: ChildProcess[] = [];
 const descendantProcessIds: number[] = [];
@@ -46,7 +47,17 @@ afterEach(async () => {
   })));
 });
 
-const createRelayFixture = async (installerExitCode: number, options: { installerDelaySeconds?: number; spawnLongLivedDescendant?: boolean } = {}) => {
+const createRelayFixture = async (
+  installerExitCode: number,
+  options: {
+    installerDelaySeconds?: number;
+    spawnLongLivedDescendant?: boolean;
+    failMigrationPrepare?: boolean;
+    failMigrationComplete?: boolean;
+    failMigrationRollback?: boolean;
+    failFirstMigrationRollback?: boolean;
+  } = {}
+) => {
   const root = await mkdtemp(join(tmpdir(), "memmy-upgrade-relay-"));
   temporaryDirectories.push(root);
   const installDir = join(root, "installed Memmy");
@@ -55,13 +66,47 @@ const createRelayFixture = async (installerExitCode: number, options: { installe
   const backupRoot = join(`${installDir}.memmy-upgrade-backup`, basename(workDir));
   const backupPath = join(backupRoot, "data-backup");
   const logPath = join(root, "logs", "windows-upgrade.log");
+  const targetUserDataPath = join(root, "roaming", "Memmy");
+  const targetRuntimeHomePath = join(root, "new-runtime", ".memmy");
+  const legacyRuntimeHomePath = join(root, "legacy-profile", ".memmy");
+  const migrationStatePath = join(root, "local", "Memmy", "data-migration", "state.json");
+  const migrationLogPath = join(root, "logs", "data-migration.log");
+  const installationRecordPath = join(root, "local", "Memmy", "data-layout", "last-install.json");
   const installerPath = join(workDir, `fake-installer-${installerExitCode}.cmd`);
   const descendantPidPath = join(root, "installer-descendant.pid");
   const descendantScriptPath = join(root, "installer-descendant.ps1");
   await mkdir(dataDir, { recursive: true });
   await mkdir(workDir, { recursive: true });
   await copyFile(cleanupScriptPath, join(workDir, "MemmyWindowsUpgradeCleanup.ps1"));
+  await copyFile(migrationScriptPath, join(workDir, "MemmyWindowsDataMigration.ps1"));
+  if (options.failMigrationPrepare) {
+    await writeFile(join(workDir, "MemmyWindowsDataMigration.ps1"), "Write-Error 'injected migration failure'\r\nexit 5\r\n", "utf8");
+  } else if (options.failMigrationComplete || options.failMigrationRollback || options.failFirstMigrationRollback) {
+    const copiedMigrationPath = join(workDir, "MemmyWindowsDataMigration.ps1");
+    let copiedMigration = await readFile(copiedMigrationPath, "utf8");
+    if (options.failMigrationComplete) {
+      copiedMigration = copiedMigration.replace(
+        'elseif ($Mode -eq "Complete") {',
+        'elseif ($Mode -eq "Complete") {\r\n    throw "injected Complete failure"'
+      );
+    }
+    if (options.failMigrationRollback) {
+      copiedMigration = copiedMigration.replace(
+        'elseif ($Mode -eq "Rollback") {',
+        'elseif ($Mode -eq "Rollback") {\r\n    throw "injected Rollback failure"'
+      );
+    }
+    if (options.failFirstMigrationRollback) {
+      const firstRollbackMarker = join(root, "first-rollback-failed.marker").replaceAll("'", "''");
+      copiedMigration = copiedMigration.replace(
+        'elseif ($Mode -eq "Rollback") {',
+        `elseif ($Mode -eq "Rollback") {\r\n    if (-not (Test-Path -LiteralPath '${firstRollbackMarker}')) { Set-Content -LiteralPath '${firstRollbackMarker}' -Value 'failed'; throw "injected first Rollback failure" }`
+      );
+    }
+    await writeFile(copiedMigrationPath, copiedMigration, "utf8");
+  }
   await writeFile(join(dataDir, "sentinel.txt"), "keep-me", "utf8");
+  await writeFile(join(dataDir, "app.sqlite"), "account-state", "utf8");
   await writeFile(join(dataDir, "prepared-required-update.json"), "{}", "utf8");
   await mkdir(join(dataDir, "prepared-required-update.json.lock"), { recursive: true });
   await writeFile(join(dataDir, "prepared-required-update.json.prompt"), "prompt", "utf8");
@@ -92,14 +137,28 @@ const createRelayFixture = async (installerExitCode: number, options: { installe
     `copy /y "${escapedAppStubPath}" "${escapedInstallDir}\\Memmy.exe" >nul`,
     "if not defined MEMMY_UPGRADE_WORK_DIR goto installer_done",
     ">\"%MEMMY_UPGRADE_WORK_DIR%\\child-reopen-intent.txt\" echo(%MEMMY_UPGRADE_REOPEN_AFTER_INSTALL%",
-    `move /y "${backupPath.replaceAll("%", "%%")}" "${escapedInstallDir}\\data" >nul`,
-    ...(installerExitCode === 0 ? ['rmdir /s /q "%MEMMY_UPGRADE_WORK_DIR%\\..\\active.lock"'] : []),
     ":installer_done",
     `exit /b ${installerExitCode}`,
     ""
   );
   await writeFile(installerPath, installerLines.join("\r\n"), "utf8");
-  return { root, installDir, dataDir, workDir, backupRoot, backupPath, logPath, installerPath, descendantPidPath };
+  return {
+    root,
+    installDir,
+    dataDir,
+    workDir,
+    backupRoot,
+    backupPath,
+    logPath,
+    installerPath,
+    descendantPidPath,
+    targetUserDataPath,
+    targetRuntimeHomePath,
+    legacyRuntimeHomePath,
+    migrationStatePath,
+    migrationLogPath,
+    installationRecordPath
+  };
 };
 
 const runRecovery = async (fixture: Awaited<ReturnType<typeof createRelayFixture>>) => {
@@ -115,21 +174,79 @@ const runRecovery = async (fixture: Awaited<ReturnType<typeof createRelayFixture
     "-LockPath",
     join(fixture.root, "active.lock"),
     "-LogPath",
-    fixture.logPath
+    fixture.logPath,
+    "-DirectMigrationStatePath",
+    fixture.migrationStatePath,
+    "-DirectMigrationScriptPath",
+    join(fixture.workDir, "MemmyWindowsDataMigration.ps1"),
+    "-DirectMigrationLogPath",
+    fixture.migrationLogPath,
+    "-TargetUserDataPathOverride",
+    fixture.targetUserDataPath,
+    "-TargetRuntimeHomePathOverride",
+    fixture.targetRuntimeHomePath,
+    "-LegacyRuntimeHomePathOverride",
+    fixture.legacyRuntimeHomePath,
+    "-MigrationStatePathOverride",
+    fixture.migrationStatePath
+  ], { timeout: 30_000, windowsHide: true });
+};
+
+const runDataMigration = async (
+  fixture: Awaited<ReturnType<typeof createRelayFixture>>,
+  mode: "Prepare" | "Complete" | "Rollback" | "RequireRecovery",
+  owner: "relay" | "installer" = "relay",
+  sourceDataPath = fixture.backupPath
+) => {
+  const powershellPath = join(process.env.SystemRoot ?? "C:\\Windows", "System32", "WindowsPowerShell", "v1.0", "powershell.exe");
+  return execFile(powershellPath, [
+    "-NoProfile",
+    "-ExecutionPolicy",
+    "Bypass",
+    "-File",
+    join(fixture.workDir, "MemmyWindowsDataMigration.ps1"),
+    "-Mode",
+    mode,
+    "-SourceDataPath",
+    sourceDataPath,
+    "-SourceAuthority",
+    owner === "relay" ? "relay-backup-authority" : "current-install-authority",
+    "-SourceInstallDir",
+    fixture.installDir,
+    "-LegacyRuntimeHomePath",
+    fixture.legacyRuntimeHomePath,
+    "-TargetUserDataPath",
+    fixture.targetUserDataPath,
+    "-TargetRuntimeHomePath",
+    fixture.targetRuntimeHomePath,
+    "-PointerPath",
+    join(fixture.targetUserDataPath, "data-root.txt"),
+    "-StatePath",
+    fixture.migrationStatePath,
+    "-LockPath",
+    join(fixture.root, "active.lock"),
+    "-LogPath",
+    fixture.migrationLogPath,
+    "-Owner",
+    owner
   ], { timeout: 30_000, windowsHide: true });
 };
 
 const runRelay = async (
   fixture: Awaited<ReturnType<typeof createRelayFixture>>,
-  options: { legacyHelperPid?: number; reopenAfterInstall?: "0" | "1" } = {}
+  options: { appDataPath?: string; legacyHelperPid?: number; reopenAfterInstall?: "0" | "1"; installedVersion?: string } = {}
 ) => {
   const powershellPath = join(process.env.SystemRoot ?? "C:\\Windows", "System32", "WindowsPowerShell", "v1.0", "powershell.exe");
-  return execFile(powershellPath, buildRelayArguments(fixture, options), { timeout: 30_000, windowsHide: true });
+  return execFile(powershellPath, buildRelayArguments(fixture, options), {
+    timeout: 30_000,
+    windowsHide: true,
+    env: options.appDataPath ? { ...process.env, APPDATA: options.appDataPath } : process.env
+  });
 };
 
 const buildRelayArguments = (
   fixture: Awaited<ReturnType<typeof createRelayFixture>>,
-  options: { legacyHelperPid?: number; reopenAfterInstall?: "0" | "1" } = {}
+  options: { legacyHelperPid?: number; reopenAfterInstall?: "0" | "1"; installedVersion?: string } = {}
 ) => [
     "-NoProfile",
     "-ExecutionPolicy",
@@ -146,6 +263,8 @@ const buildRelayArguments = (
     String(options.legacyHelperPid ?? 2147483647),
     "-ExpectedVersion",
     "10.",
+    "-InstalledVersion",
+    options.installedVersion ?? "1.0.9",
     "-ReopenAfterInstall",
     options.reopenAfterInstall ?? "0",
     "-ReadyPath",
@@ -153,13 +272,28 @@ const buildRelayArguments = (
     "-WorkDir",
     fixture.workDir,
     "-LogPath",
-    fixture.logPath
+    fixture.logPath,
+    "-TargetUserDataPathOverride",
+    fixture.targetUserDataPath,
+    "-TargetRuntimeHomePathOverride",
+    fixture.targetRuntimeHomePath,
+    "-LegacyRuntimeHomePathOverride",
+    fixture.legacyRuntimeHomePath,
+    "-MigrationStatePathOverride",
+    fixture.migrationStatePath,
+    "-MigrationLogPathOverride",
+    fixture.migrationLogPath,
+    "-InstallationRecordPathOverride",
+    fixture.installationRecordPath
   ];
 
-const startLegacyUpdateHelper = async (fixture: Awaited<ReturnType<typeof createRelayFixture>>, reopenAfterInstall: "0" | "1") => {
+const startLegacyUpdateHelper = async (
+  fixture: Awaited<ReturnType<typeof createRelayFixture>>,
+  reopenAfterInstall: "0" | "1",
+  markerPath = join(fixture.dataDir, "prepared-required-update.json")
+) => {
   const powershellPath = join(process.env.SystemRoot ?? "C:\\Windows", "System32", "WindowsPowerShell", "v1.0", "powershell.exe");
   const helperPath = join(fixture.root, "legacy update helper.ps1");
-  const markerPath = join(fixture.dataDir, "prepared-required-update.json");
   await writeFile(helperPath, "param($AppPid, $OpenAfterInstall, $MarkerPath)\nStart-Sleep -Seconds 20\n", "utf8");
   const helper = spawn(powershellPath, [
     "-NoProfile",
@@ -192,24 +326,142 @@ const waitForPathPresent = async (path: string) => {
 };
 
 describeOnWindows("Windows upgrade relay", () => {
-  it("restores install-local data and clears prepared markers after a verified upgrade", async () => {
+  it("migrates install-local data outside the installation directory before a verified upgrade", async () => {
     expect(existsSync(relayScriptPath)).toBe(true);
     const fixture = await createRelayFixture(0);
+    const sourceRuntimeHomePath = join(fixture.installDir, "data", ".memmy");
+    const sourceWorkspacePath = join(sourceRuntimeHomePath, "workspace");
+    const sourceSessionPath = join(sourceWorkspacePath, "sessions", "websocket_default.jsonl");
+    await mkdir(dirname(sourceSessionPath), { recursive: true });
+    await Promise.all([
+      writeFile(join(sourceRuntimeHomePath, "config.yaml"), [
+        "agents:",
+        "  defaults:",
+        `    workspace: '${sourceWorkspacePath}'`,
+        ""
+      ].join("\n"), "utf8"),
+      writeFile(sourceSessionPath, `${JSON.stringify({
+        key: "websocket:default",
+        metadata: {
+          webui: true,
+          webuiProjectId: null,
+          webuiWorkspaceCwd: sourceWorkspacePath
+        }
+      })}\n{\"role\":\"user\",\"content\":\"keep history\"}\n`, "utf8")
+    ]);
     await runRelay(fixture);
 
-    expect(await readFile(join(fixture.dataDir, "sentinel.txt"), "utf8")).toBe("keep-me");
+    expect(await readFile(join(fixture.targetUserDataPath, "sentinel.txt"), "utf8")).toBe("keep-me");
     expect(existsSync(join(fixture.installDir, "Memmy.exe"))).toBe(true);
-    expect(existsSync(join(fixture.dataDir, "prepared-required-update.json"))).toBe(false);
-    expect(existsSync(join(fixture.dataDir, "prepared-required-update.json.lock"))).toBe(false);
-    expect(existsSync(join(fixture.dataDir, "prepared-required-update.json.prompt"))).toBe(false);
-    expect(existsSync(join(fixture.dataDir, "prepared-required-update.json.attempt"))).toBe(false);
+    expect(existsSync(join(fixture.installDir, "data"))).toBe(false);
+    expect(existsSync(join(fixture.targetUserDataPath, "prepared-required-update.json"))).toBe(false);
+    expect(existsSync(join(fixture.targetUserDataPath, "prepared-required-update.json.lock"))).toBe(false);
+    expect(existsSync(join(fixture.targetUserDataPath, "prepared-required-update.json.prompt"))).toBe(false);
+    expect(existsSync(join(fixture.targetUserDataPath, "prepared-required-update.json.attempt"))).toBe(false);
+    const migratedConfig = await readFile(join(fixture.targetRuntimeHomePath, "config.yaml"), "utf8");
+    expect(migratedConfig).toContain(join(fixture.targetRuntimeHomePath, "workspace"));
+    expect(migratedConfig).not.toContain(sourceWorkspacePath);
+    const migratedSessionLines = (await readFile(
+      join(fixture.targetRuntimeHomePath, "workspace", "sessions", "websocket_default.jsonl"),
+      "utf8"
+    )).trim().split(/\r?\n/u);
+    expect(JSON.parse(migratedSessionLines[0]).metadata.webuiWorkspaceCwd)
+      .toBe(join(fixture.targetRuntimeHomePath, "workspace"));
+    expect(JSON.parse(migratedSessionLines[1])).toMatchObject({ content: "keep history" });
+    expect(existsSync(fixture.backupPath)).toBe(true);
     const log = await readFile(fixture.logPath, "utf8");
     expect(log).toContain(`data moved to ${fixture.backupPath}`);
-    expect(log).toContain("data restore verified");
+    expect(log).toContain("data migration Prepare completed");
+    expect(log).toContain("data migration Complete completed");
     expect(log).toContain("upgrade verified");
+    expect(log).not.toContain("started app");
     expect(log).not.toContain("relay error");
     await waitForPathAbsent(fixture.workDir);
     expect(existsSync(fixture.workDir)).toBe(false);
+  }, 15_000);
+
+  it("runs migration when the previous installer did not record a DisplayVersion", async () => {
+    const fixture = await createRelayFixture(0);
+    await Promise.all([
+      mkdir(fixture.targetUserDataPath, { recursive: true }),
+      mkdir(fixture.targetRuntimeHomePath, { recursive: true }),
+      mkdir(join(fixture.installDir, "data", ".memmy"), { recursive: true })
+    ]);
+    await Promise.all([
+      writeFile(join(fixture.targetUserDataPath, "app.sqlite"), "stale-appdata-login", "utf8"),
+      writeFile(join(fixture.targetRuntimeHomePath, "config.yaml"), "stale-profile-runtime", "utf8"),
+      writeFile(join(fixture.installDir, "data", ".memmy", "config.yaml"), "current-install-runtime", "utf8")
+    ]);
+
+    await runRelay(fixture, { installedVersion: "" });
+
+    await expect(readFile(join(fixture.targetUserDataPath, "sentinel.txt"), "utf8"))
+      .resolves.toBe("keep-me");
+    await expect(readFile(join(fixture.targetUserDataPath, "app.sqlite"), "utf8"))
+      .resolves.toBe("account-state");
+    await expect(readFile(join(fixture.targetRuntimeHomePath, "config.yaml"), "utf8"))
+      .resolves.toBe("current-install-runtime");
+    expect(existsSync(fixture.migrationStatePath)).toBe(true);
+    const log = await readFile(fixture.logPath, "utf8");
+    expect(log).toContain("data migration Prepare completed");
+    expect(log).not.toContain("Missing an argument for parameter");
+  });
+
+  it("keeps a 1.1 external-layout target when relay backup data is only an install residual", async () => {
+    const fixture = await createRelayFixture(0);
+    await Promise.all([
+      mkdir(fixture.targetUserDataPath, { recursive: true }),
+      mkdir(dirname(fixture.installationRecordPath), { recursive: true })
+    ]);
+    await Promise.all([
+      writeFile(join(fixture.targetUserDataPath, "app.sqlite"), "verified-external-login", "utf8"),
+      writeFile(fixture.installationRecordPath, JSON.stringify({
+        schemaVersion: 1,
+        dataLayoutGeneration: "external-v1",
+        installDir: fixture.installDir,
+        appVersion: "1.1.0",
+        recordedAt: new Date().toISOString()
+      }), "utf8")
+    ]);
+
+    await runRelay(fixture, { installedVersion: "1.1.0" });
+
+    await expect(readFile(join(fixture.targetUserDataPath, "app.sqlite"), "utf8"))
+      .resolves.toBe("verified-external-login");
+    await expect(readFile(join(fixture.backupPath, "Memmy", "app.sqlite"), "utf8"))
+      .resolves.toBe("account-state");
+    expect(JSON.parse(await readFile(fixture.migrationStatePath, "utf8"))).toMatchObject({
+      phase: "awaiting-app-verification",
+      sourceAuthority: "untrusted-residual",
+      preparedCopies: []
+    });
+  });
+
+  it("lets a relay-confirmed 1.0.9 install override an earlier external-layout marker", async () => {
+    const fixture = await createRelayFixture(0);
+    await Promise.all([
+      mkdir(fixture.targetUserDataPath, { recursive: true }),
+      mkdir(dirname(fixture.installationRecordPath), { recursive: true })
+    ]);
+    await Promise.all([
+      writeFile(join(fixture.targetUserDataPath, "app.sqlite"), "historical-login", "utf8"),
+      writeFile(fixture.installationRecordPath, JSON.stringify({
+        schemaVersion: 1,
+        dataLayoutGeneration: "external-v1",
+        installDir: fixture.installDir,
+        appVersion: "1.1.0",
+        recordedAt: new Date().toISOString()
+      }), "utf8")
+    ]);
+
+    await runRelay(fixture, { installedVersion: "1.0.9" });
+
+    await expect(readFile(join(fixture.targetUserDataPath, "app.sqlite"), "utf8"))
+      .resolves.toBe("account-state");
+    expect(JSON.parse(await readFile(fixture.migrationStatePath, "utf8"))).toMatchObject({
+      phase: "awaiting-app-verification",
+      sourceAuthority: "relay-backup-authority"
+    });
   });
 
   it("restores data and retains update markers when the staged installer exits 2", async () => {
@@ -219,13 +471,96 @@ describeOnWindows("Windows upgrade relay", () => {
 
     expect(await readFile(join(fixture.dataDir, "sentinel.txt"), "utf8")).toBe("keep-me");
     expect(existsSync(join(fixture.dataDir, "prepared-required-update.json"))).toBe(true);
+    expect(existsSync(fixture.targetUserDataPath)).toBe(false);
+    expect(existsSync(fixture.migrationStatePath)).toBe(false);
     const log = await readFile(fixture.logPath, "utf8");
     expect(log).toContain("installer exit 2");
+    expect(log).toContain("data migration Rollback completed");
     expect(log).toContain("data restore verified");
     expect(log).not.toContain("upgrade verified");
   });
 
-  it("uses the legacy helper's explicit manual reopen intent and lets the child installer restore data", async () => {
+  it("continues a silent relay upgrade when migration fails and retains the original data for manual recovery", async () => {
+    const fixture = await createRelayFixture(0, { failMigrationPrepare: true });
+    const lockPath = join(fixture.root, "active.lock");
+    await mkdir(fixture.targetUserDataPath, { recursive: true });
+    await writeFile(join(fixture.targetUserDataPath, "historical.txt"), "keep-existing-target", "utf8");
+
+    await runRelay(fixture);
+
+    expect(existsSync(join(fixture.installDir, "Memmy.exe"))).toBe(true);
+    expect(existsSync(join(fixture.installDir, "data"))).toBe(false);
+    expect(await readFile(join(fixture.targetUserDataPath, "historical.txt"), "utf8")).toBe("keep-existing-target");
+    expect(await readFile(join(fixture.backupPath, "Memmy", "sentinel.txt"), "utf8")).toBe("keep-me");
+    expect(existsSync(fixture.migrationStatePath)).toBe(false);
+    expect(existsSync(lockPath)).toBe(false);
+    const log = await readFile(fixture.logPath, "utf8");
+    expect(log).toContain("data migration Prepare failed safely; continuing installation without migration");
+    expect(log).toContain(`original data retained for manual recovery at ${fixture.backupPath}`);
+    expect(log).not.toContain("upgrade not verified");
+    await waitForPathAbsent(fixture.workDir);
+  });
+
+  it("keeps the installed app when migration completion fails and rolls the targets back", async () => {
+    const fixture = await createRelayFixture(0, { failMigrationComplete: true });
+    const lockPath = join(fixture.root, "active.lock");
+
+    await runRelay(fixture);
+
+    expect(existsSync(join(fixture.installDir, "Memmy.exe"))).toBe(true);
+    expect(existsSync(fixture.targetUserDataPath)).toBe(false);
+    expect(await readFile(join(fixture.backupPath, "Memmy", "sentinel.txt"), "utf8")).toBe("keep-me");
+    expect(existsSync(fixture.migrationStatePath)).toBe(false);
+    expect(existsSync(lockPath)).toBe(false);
+    const log = await readFile(fixture.logPath, "utf8");
+    expect(log).toContain("data migration Complete failed; rolling back migration while retaining the installed app");
+    expect(log).toContain("data migration Rollback completed");
+    expect(log).toContain("upgrade verified without migration");
+  });
+
+  it("retries an interrupted rollback and restores the target on the second attempt", async () => {
+    const fixture = await createRelayFixture(0, {
+      failMigrationComplete: true,
+      failFirstMigrationRollback: true
+    });
+    const lockPath = join(fixture.root, "active.lock");
+
+    await runRelay(fixture);
+
+    expect(existsSync(join(fixture.installDir, "Memmy.exe"))).toBe(true);
+    expect(existsSync(fixture.targetUserDataPath)).toBe(false);
+    expect(existsSync(fixture.migrationStatePath)).toBe(false);
+    expect(existsSync(lockPath)).toBe(false);
+    const log = await readFile(fixture.logPath, "utf8");
+    expect(log).toContain("rollback attempt 1 after completion failure failed");
+    expect(log).toContain("data migration Rollback completed");
+    expect(log).not.toContain("migration-recovery-required");
+  });
+
+  it("releases the lock and retains an explicit recovery-required state when rollback retries fail", async () => {
+    const fixture = await createRelayFixture(0, {
+      failMigrationComplete: true,
+      failMigrationRollback: true
+    });
+    const lockPath = join(fixture.root, "active.lock");
+
+    await runRelay(fixture);
+
+    expect(existsSync(join(fixture.installDir, "Memmy.exe"))).toBe(true);
+    expect(await readFile(join(fixture.targetUserDataPath, "sentinel.txt"), "utf8")).toBe("keep-me");
+    expect(JSON.parse(await readFile(fixture.migrationStatePath, "utf8"))).toMatchObject({
+      phase: "recovery-required"
+    });
+    expect(existsSync(lockPath)).toBe(false);
+    const log = await readFile(fixture.logPath, "utf8");
+    expect(log).toContain("rollback attempt 1 after completion failure failed");
+    expect(log).toContain("rollback attempt 2 after completion failure failed");
+    expect(log).toContain("data migration RequireRecovery completed");
+    expect(log).toContain("retaining prepared migration state for startup recovery");
+    expect(log).not.toContain('"migrationCompleted":true');
+  });
+
+  it("uses the legacy helper's explicit manual reopen intent without restoring install-local data", async () => {
     const fixture = await createRelayFixture(0);
     const helperPid = await startLegacyUpdateHelper(fixture, "1");
 
@@ -233,12 +568,34 @@ describeOnWindows("Windows upgrade relay", () => {
 
     expect(await readFile(join(fixture.workDir, "child-reopen-intent.txt"), "utf8")).toBe("1\r\n");
     expect(await readFile(join(fixture.workDir, "relay-ready"), "utf8")).toBe("1");
-    expect(await readFile(join(fixture.dataDir, "sentinel.txt"), "utf8")).toBe("keep-me");
+    expect(await readFile(join(fixture.targetUserDataPath, "sentinel.txt"), "utf8")).toBe("keep-me");
+    expect(existsSync(join(fixture.installDir, "data"))).toBe(false);
     const log = await readFile(fixture.logPath, "utf8");
     expect(log).toContain(`reopen intent resolved from legacy helper pid ${helperPid}: 1`);
-    expect(log).toContain("data restore verified by child installer");
+    expect(log).not.toContain("data restore verified by child installer");
+    expect(log).toContain("started app");
     await waitForPathAbsent(fixture.workDir);
-  });
+  }, 10_000);
+
+  it("keeps a silent update closed when the helper references the roaming marker", async () => {
+    const fixture = await createRelayFixture(0);
+    const roamingMarkerPath = join(fixture.targetUserDataPath, "prepared-required-update.json");
+    await mkdir(fixture.targetUserDataPath, { recursive: true });
+    await writeFile(roamingMarkerPath, "{}", "utf8");
+    const helperPid = await startLegacyUpdateHelper(fixture, "0", roamingMarkerPath);
+
+    await runRelay(fixture, {
+      appDataPath: dirname(fixture.targetUserDataPath),
+      legacyHelperPid: helperPid,
+      reopenAfterInstall: "1"
+    });
+
+    const log = await readFile(fixture.logPath, "utf8");
+    expect(log).toContain(`reopen intent resolved from legacy helper pid ${helperPid}: 0`);
+    expect(await readFile(join(fixture.workDir, "child-reopen-intent.txt"), "utf8")).toBe("0\r\n");
+    expect(log).not.toContain("started app");
+    await waitForPathAbsent(fixture.workDir);
+  }, 10_000);
 
   it("waits for the installer itself without waiting for its long-lived descendant", async () => {
     const fixture = await createRelayFixture(0, { spawnLongLivedDescendant: true });
@@ -293,10 +650,160 @@ describeOnWindows("Windows upgrade relay", () => {
     expect(log).toContain("stale upgrade data restored");
   });
 
+  it("rolls back a prepared migration after restoring data from a crashed relay", async () => {
+    const fixture = await createRelayFixture(0);
+    const lockPath = join(fixture.root, "active.lock");
+    await mkdir(fixture.backupRoot, { recursive: true });
+    await rename(join(fixture.installDir, "data"), fixture.backupPath);
+    await mkdir(lockPath, { recursive: true });
+    await runDataMigration(fixture, "Prepare");
+    expect(await readFile(join(fixture.targetUserDataPath, "sentinel.txt"), "utf8")).toBe("keep-me");
+
+    await writeFile(join(lockPath, "state.json"), JSON.stringify({
+      schemaVersion: 3,
+      phase: "migration-prepared",
+      stateUpdatedAtUtc: "2000-01-01T00:00:00.0000000Z",
+      relayPid: 2147483647,
+      relayStartedAtUtc: "2000-01-01T00:00:00.0000000Z",
+      installerPid: null,
+      installerStartedAtUtc: null,
+      installerPath: fixture.installerPath,
+      installDir: fixture.installDir,
+      workDir: fixture.workDir,
+      backupRoot: fixture.backupRoot,
+      migrationStatePath: fixture.migrationStatePath,
+      migrationLogPath: fixture.migrationLogPath,
+      legacyRuntimeHomePath: fixture.legacyRuntimeHomePath,
+      targetUserDataPath: fixture.targetUserDataPath,
+      targetRuntimeHomePath: fixture.targetRuntimeHomePath
+    }), "utf8");
+
+    await runRecovery(fixture);
+
+    expect(await readFile(join(fixture.dataDir, "sentinel.txt"), "utf8")).toBe("keep-me");
+    expect(existsSync(fixture.targetUserDataPath)).toBe(false);
+    expect(existsSync(fixture.migrationStatePath)).toBe(false);
+    expect(existsSync(lockPath)).toBe(false);
+  });
+
+  it("rolls back a recovery-required migration after the relay crashes before releasing its lock", async () => {
+    const fixture = await createRelayFixture(0);
+    const lockPath = join(fixture.root, "active.lock");
+    await mkdir(fixture.backupRoot, { recursive: true });
+    await rename(join(fixture.installDir, "data"), fixture.backupPath);
+    await mkdir(lockPath, { recursive: true });
+    await runDataMigration(fixture, "Prepare");
+    await runDataMigration(fixture, "RequireRecovery");
+    await writeFile(join(lockPath, "state.json"), JSON.stringify({
+      schemaVersion: 3,
+      phase: "migration-recovery-required",
+      stateUpdatedAtUtc: "2000-01-01T00:00:00.0000000Z",
+      relayPid: 2147483647,
+      relayStartedAtUtc: "2000-01-01T00:00:00.0000000Z",
+      installerPid: null,
+      installerStartedAtUtc: null,
+      installerPath: fixture.installerPath,
+      installDir: fixture.installDir,
+      workDir: fixture.workDir,
+      backupRoot: fixture.backupRoot,
+      migrationStatePath: fixture.migrationStatePath,
+      migrationLogPath: fixture.migrationLogPath,
+      legacyRuntimeHomePath: fixture.legacyRuntimeHomePath,
+      targetUserDataPath: fixture.targetUserDataPath,
+      targetRuntimeHomePath: fixture.targetRuntimeHomePath
+    }), "utf8");
+
+    await runRecovery(fixture);
+
+    expect(await readFile(join(fixture.dataDir, "sentinel.txt"), "utf8")).toBe("keep-me");
+    expect(existsSync(fixture.targetUserDataPath)).toBe(false);
+    expect(existsSync(fixture.migrationStatePath)).toBe(false);
+    expect(existsSync(lockPath)).toBe(false);
+  });
+
+  it("finishes recovery idempotently when rollback completed before active-lock cleanup", async () => {
+    const fixture = await createRelayFixture(0);
+    const lockPath = join(fixture.root, "active.lock");
+    await mkdir(fixture.backupRoot, { recursive: true });
+    await rename(join(fixture.installDir, "data"), fixture.backupPath);
+    await mkdir(lockPath, { recursive: true });
+    await runDataMigration(fixture, "Prepare");
+
+    await writeFile(join(lockPath, "state.json"), JSON.stringify({
+      schemaVersion: 3,
+      phase: "migration-prepared",
+      stateUpdatedAtUtc: "2000-01-01T00:00:00.0000000Z",
+      relayPid: 2147483647,
+      relayStartedAtUtc: "2000-01-01T00:00:00.0000000Z",
+      installerPid: null,
+      installerStartedAtUtc: null,
+      installerPath: fixture.installerPath,
+      installDir: fixture.installDir,
+      workDir: fixture.workDir,
+      backupRoot: fixture.backupRoot,
+      migrationStatePath: fixture.migrationStatePath,
+      migrationLogPath: fixture.migrationLogPath,
+      legacyRuntimeHomePath: fixture.legacyRuntimeHomePath,
+      targetUserDataPath: fixture.targetUserDataPath,
+      targetRuntimeHomePath: fixture.targetRuntimeHomePath
+    }), "utf8");
+
+    await rename(fixture.backupPath, join(fixture.installDir, "data"));
+    await runDataMigration(fixture, "Rollback");
+    expect(existsSync(fixture.migrationStatePath)).toBe(false);
+    expect(existsSync(lockPath)).toBe(true);
+
+    await runRecovery(fixture);
+
+    expect(await readFile(join(fixture.dataDir, "sentinel.txt"), "utf8")).toBe("keep-me");
+    expect(existsSync(lockPath)).toBe(false);
+  });
+
+  it("keeps a completed migration when recovery observes the crash before the relay phase update", async () => {
+    const fixture = await createRelayFixture(0);
+    const lockPath = join(fixture.root, "active.lock");
+    await mkdir(fixture.backupRoot, { recursive: true });
+    await rename(join(fixture.installDir, "data"), fixture.backupPath);
+    await mkdir(lockPath, { recursive: true });
+    await runDataMigration(fixture, "Prepare");
+    await runDataMigration(fixture, "Complete");
+
+    await writeFile(join(lockPath, "state.json"), JSON.stringify({
+      schemaVersion: 3,
+      phase: "installer-starting",
+      stateUpdatedAtUtc: "2000-01-01T00:00:00.0000000Z",
+      relayPid: 2147483647,
+      relayStartedAtUtc: "2000-01-01T00:00:00.0000000Z",
+      installerPid: null,
+      installerStartedAtUtc: null,
+      installerPath: fixture.installerPath,
+      installDir: fixture.installDir,
+      workDir: fixture.workDir,
+      backupRoot: fixture.backupRoot,
+      migrationStatePath: fixture.migrationStatePath,
+      migrationLogPath: fixture.migrationLogPath,
+      legacyRuntimeHomePath: fixture.legacyRuntimeHomePath,
+      targetUserDataPath: fixture.targetUserDataPath,
+      targetRuntimeHomePath: fixture.targetRuntimeHomePath
+    }), "utf8");
+
+    await runRecovery(fixture);
+
+    expect(existsSync(join(fixture.installDir, "data"))).toBe(false);
+    expect(await readFile(join(fixture.targetUserDataPath, "sentinel.txt"), "utf8")).toBe("keep-me");
+    expect(JSON.parse(await readFile(fixture.migrationStatePath, "utf8"))).toMatchObject({
+      phase: "awaiting-app-verification"
+    });
+    expect(existsSync(lockPath)).toBe(false);
+  });
+
   it("clears only transient prepared-update markers for a stale state-less lock", async () => {
     const fixture = await createRelayFixture(0);
     const lockPath = join(fixture.root, "active.lock");
     await mkdir(lockPath, { recursive: true });
+    await mkdir(`${join(fixture.targetUserDataPath, "prepared-required-update.json")}.lock`, { recursive: true });
+    await writeFile(join(fixture.targetUserDataPath, "prepared-required-update.json"), "{}", "utf8");
+    await writeFile(`${join(fixture.targetUserDataPath, "prepared-required-update.json")}.prompt`, "prompt", "utf8");
     const staleTimestamp = new Date(Date.now() - 3 * 60_000);
     await utimes(lockPath, staleTimestamp, staleTimestamp);
 
@@ -307,6 +814,70 @@ describeOnWindows("Windows upgrade relay", () => {
     expect(existsSync(join(fixture.dataDir, "prepared-required-update.json.lock"))).toBe(false);
     expect(existsSync(join(fixture.dataDir, "prepared-required-update.json.prompt"))).toBe(false);
     expect(existsSync(join(fixture.dataDir, "prepared-required-update.json.attempt"))).toBe(true);
+    expect(existsSync(join(fixture.targetUserDataPath, "prepared-required-update.json"))).toBe(true);
+    expect(existsSync(`${join(fixture.targetUserDataPath, "prepared-required-update.json")}.lock`)).toBe(false);
+    expect(existsSync(`${join(fixture.targetUserDataPath, "prepared-required-update.json")}.prompt`)).toBe(false);
+  });
+
+  it("recovers a stale direct-install lock after the old install data was already removed", async () => {
+    const fixture = await createRelayFixture(0);
+    const lockPath = join(fixture.root, "active.lock");
+    await mkdir(lockPath, { recursive: true });
+    await runDataMigration(fixture, "Prepare", "installer", join(fixture.installDir, "data"));
+    await runDataMigration(fixture, "RequireRecovery", "installer", join(fixture.installDir, "data"));
+    await rm(join(fixture.installDir, "data"), { recursive: true, force: true });
+    const staleTimestamp = new Date(Date.now() - 3 * 60_000);
+    await utimes(lockPath, staleTimestamp, staleTimestamp);
+
+    await runRecovery(fixture);
+
+    expect(await readFile(join(fixture.targetUserDataPath, "sentinel.txt"), "utf8")).toBe("keep-me");
+    expect(JSON.parse(await readFile(fixture.migrationStatePath, "utf8"))).toMatchObject({
+      phase: "prepared-for-retry"
+    });
+    expect(existsSync(lockPath)).toBe(false);
+  });
+
+  it("does not recover or clear a direct-install lock while its exact installer is still running", async () => {
+    const fixture = await createRelayFixture(0);
+    const lockPath = join(fixture.root, "active.lock");
+    const pingPath = join(process.env.SystemRoot ?? "C:\\Windows", "System32", "PING.EXE");
+    const installer = spawn(pingPath, ["-n", "20", "127.0.0.1"], {
+      windowsHide: true,
+      stdio: "ignore"
+    });
+    helperProcesses.push(installer);
+    await new Promise((resolvePromise) => setTimeout(resolvePromise, 250));
+    expect(installer.pid).toBeGreaterThan(0);
+
+    await mkdir(lockPath, { recursive: true });
+    await writeFile(join(lockPath, "state.json"), JSON.stringify({
+      schemaVersion: 3,
+      owner: "installer",
+      phase: "direct-migration-running",
+      installerPid: installer.pid,
+      installerPath: pingPath,
+      installDir: fixture.installDir,
+      targetUserDataPath: fixture.targetUserDataPath,
+      targetRuntimeHomePath: fixture.targetRuntimeHomePath,
+      createdAt: "2000-01-01T00:00:00.0000000Z"
+    }), "utf8");
+    const staleTimestamp = new Date(Date.now() - 3 * 60_000);
+    await utimes(lockPath, staleTimestamp, staleTimestamp);
+
+    await expect(runRecovery(fixture)).rejects.toMatchObject({ code: 2 });
+    expect(existsSync(lockPath)).toBe(true);
+
+    installer.kill();
+    await new Promise<void>((resolvePromise) => {
+      if (installer.exitCode !== null) {
+        resolvePromise();
+        return;
+      }
+      installer.once("exit", () => resolvePromise());
+    });
+    await runRecovery(fixture);
+    expect(existsSync(lockPath)).toBe(false);
   });
 
   it("keeps recovery locked while an installer from the pre-launch state boundary is running", async () => {


### PR DESCRIPTION
## Summary
- migrate Windows install-local account and runtime data transactionally to the external data layout, preferring only trusted current/relay/persisted sources without merging generations
- preserve account/BYOK model consistency and roll back unsafe category combinations instead of silently starting with unavailable models
- harden direct, silent, relayed, cross-volume and interrupted upgrade recovery, plus installer/uninstaller app-exit handling
- keep macOS paths and startup behavior unchanged

## Verification
- 7 focused Windows migration/relay/NSIS/runtime suites: 152 tests passed
- backend suite: 109 files, 816 tests passed
- backend, frontend and desktop TypeScript checks passed
- packaging guards: 16 tests passed
- real x64 INTL unsigned package built; automatic 1.0.9 to 1.1.0 silent upgrade completed with installer exit 0 and app-verified migration state

## Scope
- one functional commit on top of `v1.1.0`
- excludes package/project version changes, release notes and unrelated docs