### PR TITLE
fix(release): verify Multipart OSS assets with CRC64

### DIFF
--- a/.github/workflows/github-draft-release-v2.yml
+++ b/.github/workflows/github-draft-release-v2.yml
@@ -395,6 +395,7 @@ jobs:
             "Memmy-$VERSION-darwin-arm64-cn-signed.dmg"
             "Memmy-$VERSION-darwin-arm64-intl-signed.dmg"
           )
+          : > release-assets/OSS_VERIFICATION.jsonl
 
           for artifact in "${artifacts[@]}"; do
             url="$base/$artifact"
@@ -404,12 +405,6 @@ jobs:
               echo "::error title=Installer asset is missing::$artifact was not found at $url. Manual recovery: confirm the packaging/upload workflow finished for version $VERSION, then re-run this workflow." >&2
               exit 1
             fi
-            content_md5="$(awk 'BEGIN { IGNORECASE=1 } /^Content-MD5:/ { gsub("\\r", "", $2); value=$2 } END { print value }' "$headers")"
-            if [[ -z "$content_md5" ]]; then
-              echo "::error title=Installer checksum header missing::OSS did not return Content-MD5 for $artifact. Manual recovery: verify the OSS object metadata or re-upload the installer." >&2
-              exit 1
-            fi
-
             if ! curl --fail --location --retry 5 --retry-all-errors \
               --output "release-assets/$artifact" "$url"; then
               echo "::error title=Installer download failed::Could not download $artifact after retries. Manual recovery: check OSS/CDN availability, then re-run this workflow." >&2
@@ -420,14 +415,16 @@ jobs:
               exit 1
             fi
 
-            expected_md5="$(printf '%s' "$content_md5" | base64 --decode | xxd -p -c 256)"
-            actual_md5="$(md5sum "release-assets/$artifact" | awk '{print $1}')"
-            if [[ "$actual_md5" != "$expected_md5" ]]; then
-              echo "::error title=Installer checksum mismatch::Content-MD5 mismatch for $artifact. Manual recovery: do not publish; rebuild or re-upload the installer, then re-run." >&2
+            if ! integrity="$(node scripts/verify-oss-object-integrity.mjs "$headers" "release-assets/$artifact")"; then
+              echo "::error title=Installer checksum verification failed::$artifact did not match its fail-closed OSS integrity metadata. Normal objects require Content-MD5; Multipart objects require x-oss-hash-crc64ecma. Manual recovery: do not publish; repair or re-upload the object, then re-run." >&2
               exit 1
             fi
+            printf '%s\n' "$integrity" \
+              | jq -c --arg artifact "$artifact" '. + {artifact: $artifact}' \
+              >> release-assets/OSS_VERIFICATION.jsonl
           done
 
+          jq -s '.' release-assets/OSS_VERIFICATION.jsonl > release-assets/OSS_VERIFICATION.json
           (cd release-assets && md5sum Memmy-* > MD5SUMS.txt)
           (cd release-assets && sha256sum Memmy-* > SHA256SUMS.txt)
 
@@ -710,7 +707,7 @@ jobs:
 
           ## Checksums
 
-          Verify downloads with MD5SUMS.txt or SHA256SUMS.txt attached to this release. The workflow also verifies every OSS object against its Content-MD5 header before publishing.
+          Verify downloads with MD5SUMS.txt or SHA256SUMS.txt attached to this release. Before creating the Draft, the workflow verifies Normal OSS objects with Content-MD5 and Multipart objects with OSS CRC-64/XZ.
 
           <!-- doc-agent: source-id=memmy-official-changelog-v2 -->
           <!-- memmy-release-evidence
@@ -793,6 +790,7 @@ jobs:
             --slurpfile compare release-assets/COMPARE.json \
             --slurpfile pullRequests release-assets/PULL_REQUESTS.json \
             --slurpfile artifacts release-assets/ARTIFACTS.json \
+            --slurpfile ossIntegrity release-assets/OSS_VERIFICATION.json \
             '{
               schema: "memmy.release.evidence.v2",
               schemaVersion: 2,
@@ -837,7 +835,8 @@ jobs:
               releaseNotesSource: $releaseNotesSource,
               releaseNotesNeedsReview: $releaseNotesNeedsReview,
               artifactManifest: "SHA256SUMS.txt",
-              artifacts: $artifacts[0]
+              artifacts: $artifacts[0],
+              ossIntegrity: $ossIntegrity[0]
             }' > release-assets/RELEASE_EVIDENCE.json
 
           {
@@ -866,6 +865,7 @@ jobs:
             release-assets/TARGET_COMMIT_METADATA.json
             release-assets/COMPARE.json
             release-assets/PULL_REQUESTS.json
+            release-assets/OSS_VERIFICATION.json
             release-assets/RELEASE_EVIDENCE.json
             release-assets/MD5SUMS.txt
             release-assets/SHA256SUMS.txt

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "lint": "npm run memory:lint && npm run workspace:lint",
     "typecheck": "npm run memory:lint && npm run workspace:typecheck",
     "test": "npm run test:release-workflow && npm run test:packaging-guards && npm run memory:test && npm run workspace:test && npm run agent:test:tui-cursor",
-    "test:release-workflow": "vitest run tests/release-workflow.test.ts",
+    "test:release-workflow": "vitest run tests/release-workflow.test.ts tests/oss-crc64.test.mjs",
     "test:packaging-guards": "vitest run tests/package-version-guard.test.mjs tests/packaged-runtime-config.test.mjs",
     "serve": "npm run memory:serve",
     "serve:local": "npm run memory:serve:local",

--- a/scripts/internal/shared/oss-crc64.mjs
+++ b/scripts/internal/shared/oss-crc64.mjs
@@ -1,0 +1,49 @@
+import { createReadStream } from "node:fs";
+
+const MASK_64 = 0xffffffffffffffffn;
+const REFLECTED_POLYNOMIAL = 0xc96c5795d7870f42n;
+
+const TABLE = Array.from({ length: 256 }, (_, byte) => {
+  let value = BigInt(byte);
+  for (let bit = 0; bit < 8; bit += 1) {
+    value = (value & 1n) === 1n
+      ? (value >> 1n) ^ REFLECTED_POLYNOMIAL
+      : value >> 1n;
+  }
+  return value & MASK_64;
+});
+
+function updateCrc64Xz(state, bytes) {
+  let next = state;
+  for (const byte of bytes) {
+    const index = Number((next ^ BigInt(byte)) & 0xffn);
+    next = TABLE[index] ^ (next >> 8n);
+  }
+  return next & MASK_64;
+}
+
+export function crc64Xz(bytes) {
+  if (!(bytes instanceof Uint8Array)) {
+    throw new TypeError("CRC64/XZ input must be a Uint8Array or Buffer");
+  }
+  return (updateCrc64Xz(MASK_64, bytes) ^ MASK_64) & MASK_64;
+}
+
+export async function crc64XzFile(path) {
+  let state = MASK_64;
+  for await (const chunk of createReadStream(path)) {
+    state = updateCrc64Xz(state, chunk);
+  }
+  return (state ^ MASK_64) & MASK_64;
+}
+
+export function parseUnsignedCrc64(value) {
+  if (typeof value !== "string" || !/^(?:0|[1-9][0-9]{0,19})$/.test(value)) {
+    throw new Error("Expected CRC64 must be an unsigned decimal integer");
+  }
+  const parsed = BigInt(value);
+  if (parsed > MASK_64) {
+    throw new Error("Expected CRC64 exceeds the unsigned 64-bit range");
+  }
+  return parsed;
+}

--- a/scripts/internal/shared/oss-object-integrity.mjs
+++ b/scripts/internal/shared/oss-object-integrity.mjs
@@ -1,0 +1,150 @@
+import { createHash } from "node:crypto";
+import { createReadStream } from "node:fs";
+import { lstat } from "node:fs/promises";
+import { crc64XzFile, parseUnsignedCrc64 } from "./oss-crc64.mjs";
+
+const TRACKED_HEADERS = new Set([
+  "content-length",
+  "content-md5",
+  "etag",
+  "x-oss-hash-crc64ecma",
+  "x-oss-object-type",
+]);
+
+export function parseFinalOssHeadHeaders(source) {
+  if (typeof source !== "string") {
+    throw new Error("OSS HEAD response must be text");
+  }
+
+  const blocks = [];
+  let current = null;
+  for (const rawLine of source.split(/\r?\n/)) {
+    const statusMatch = /^HTTP\/\S+\s+(\d{3})(?:\s|$)/i.exec(rawLine);
+    if (statusMatch) {
+      current = { status: Number(statusMatch[1]), headers: new Map() };
+      blocks.push(current);
+      continue;
+    }
+    if (!current || !rawLine) continue;
+    const separator = rawLine.indexOf(":");
+    if (separator < 1) continue;
+    const name = rawLine.slice(0, separator).trim().toLowerCase();
+    if (!TRACKED_HEADERS.has(name)) continue;
+    const values = current.headers.get(name) ?? [];
+    values.push(rawLine.slice(separator + 1).trim());
+    current.headers.set(name, values);
+  }
+
+  const finalBlock = blocks.at(-1);
+  if (!finalBlock) {
+    throw new Error("OSS HEAD response does not contain an HTTP status line");
+  }
+  if (finalBlock.status < 200 || finalBlock.status >= 300) {
+    throw new Error(`OSS final HEAD response has unexpected HTTP status ${finalBlock.status}`);
+  }
+
+  const value = (name) => {
+    const values = finalBlock.headers.get(name) ?? [];
+    if (values.length > 1) {
+      throw new Error(`OSS final HEAD response contains duplicate ${name} headers`);
+    }
+    return values[0] ?? "";
+  };
+
+  return {
+    status: finalBlock.status,
+    contentLength: value("content-length"),
+    contentMd5: value("content-md5"),
+    crc64: value("x-oss-hash-crc64ecma"),
+    etag: value("etag"),
+    objectType: value("x-oss-object-type"),
+  };
+}
+
+async function md5File(path) {
+  const hash = createHash("md5");
+  for await (const chunk of createReadStream(path)) {
+    hash.update(chunk);
+  }
+  return hash.digest();
+}
+
+function parseContentMd5(value) {
+  if (!/^[A-Za-z0-9+/]{22}==$/.test(value)) {
+    throw new Error("Normal OSS object is missing a canonical Content-MD5 value");
+  }
+  const decoded = Buffer.from(value, "base64");
+  if (decoded.length !== 16 || decoded.toString("base64") !== value) {
+    throw new Error("Normal OSS object returned an invalid Content-MD5 value");
+  }
+  return decoded;
+}
+
+function parseContentLength(value) {
+  if (!/^(?:0|[1-9][0-9]*)$/.test(value)) {
+    throw new Error("OSS object is missing a valid Content-Length value");
+  }
+  const parsed = BigInt(value);
+  if (parsed <= 0n) {
+    throw new Error("OSS installer object must be non-empty");
+  }
+  return parsed;
+}
+
+export async function verifyOssObjectIntegrity(headersText, path) {
+  const metadata = parseFinalOssHeadHeaders(headersText);
+  const expectedSize = parseContentLength(metadata.contentLength);
+  const file = await lstat(path);
+  if (file.isSymbolicLink() || !file.isFile()) {
+    throw new Error("Downloaded OSS installer must be a regular, non-symbolic-link file");
+  }
+  const actualSize = BigInt(file.size);
+  if (actualSize !== expectedSize) {
+    throw new Error(`OSS Content-Length mismatch: expected ${expectedSize}, actual ${actualSize}`);
+  }
+
+  if (metadata.objectType === "Normal") {
+    const expected = parseContentMd5(metadata.contentMd5);
+    const actual = await md5File(path);
+    if (!actual.equals(expected)) {
+      throw new Error(
+        `Content-MD5 mismatch: expected ${expected.toString("hex")}, actual ${actual.toString("hex")}`,
+      );
+    }
+    return {
+      objectType: metadata.objectType,
+      method: "content-md5",
+      expected: expected.toString("hex"),
+      actual: actual.toString("hex"),
+      size: file.size,
+      etag: metadata.etag,
+    };
+  }
+
+  if (metadata.objectType === "Multipart") {
+    let expected;
+    try {
+      expected = parseUnsignedCrc64(metadata.crc64);
+    } catch (error) {
+      throw new Error(
+        `Multipart OSS object is missing a valid x-oss-hash-crc64ecma value: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+    const actual = await crc64XzFile(path);
+    if (actual !== expected) {
+      throw new Error(`CRC64/XZ mismatch: expected ${expected}, actual ${actual}`);
+    }
+    return {
+      objectType: metadata.objectType,
+      method: "crc64-xz",
+      expected: expected.toString(10),
+      actual: actual.toString(10),
+      size: file.size,
+      etag: metadata.etag,
+    };
+  }
+
+  throw new Error(
+    `Unsupported OSS object type '${metadata.objectType || "missing"}'; expected Normal or Multipart`,
+  );
+}

--- a/scripts/verify-oss-object-integrity.mjs
+++ b/scripts/verify-oss-object-integrity.mjs
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+
+import { readFile } from "node:fs/promises";
+import { verifyOssObjectIntegrity } from "./internal/shared/oss-object-integrity.mjs";
+
+const [headersPath, filePath, ...extra] = process.argv.slice(2);
+if (!headersPath || !filePath || extra.length > 0) {
+  console.error(
+    "Usage: node scripts/verify-oss-object-integrity.mjs <head-response-file> <downloaded-file>",
+  );
+  process.exit(2);
+}
+
+try {
+  const headers = await readFile(headersPath, "utf8");
+  const result = await verifyOssObjectIntegrity(headers, filePath);
+  process.stdout.write(`${JSON.stringify(result)}\n`);
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+}

--- a/tests/oss-crc64.test.mjs
+++ b/tests/oss-crc64.test.mjs
@@ -1,0 +1,215 @@
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  crc64Xz,
+  crc64XzFile,
+  parseUnsignedCrc64,
+} from "../scripts/internal/shared/oss-crc64.mjs";
+import {
+  parseFinalOssHeadHeaders,
+  verifyOssObjectIntegrity,
+} from "../scripts/internal/shared/oss-object-integrity.mjs";
+
+const repoRoot = resolve(import.meta.dirname, "..");
+const verifierPath = resolve(repoRoot, "scripts/verify-oss-object-integrity.mjs");
+const temporaryDirectories = [];
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe("OSS CRC64/XZ verification", () => {
+  it("matches the CRC-64/XZ check vector used by OSS", () => {
+    expect(crc64Xz(Buffer.alloc(0))).toBe(0n);
+    expect(crc64Xz(Buffer.from("a", "ascii"))).toBe(0x330284772e652b05n);
+    expect(crc64Xz(Buffer.from("123456789", "ascii"))).toBe(0x995dc9bbdf1939fan);
+    expect(() => crc64Xz("123456789")).toThrow("Uint8Array or Buffer");
+  });
+
+  it("produces the same checksum while streaming a file", async () => {
+    const directory = mkdtempSync(resolve(tmpdir(), "memmy-oss-crc64-"));
+    temporaryDirectories.push(directory);
+    const path = resolve(directory, "payload.bin");
+    const payload = Buffer.alloc(256 * 1024 + 37);
+    for (let index = 0; index < payload.length; index += 1) {
+      payload[index] = (index * 31 + 17) & 0xff;
+    }
+    writeFileSync(path, payload);
+
+    await expect(crc64XzFile(path)).resolves.toBe(crc64Xz(payload));
+  });
+
+  it("validates unsigned decimal CRC64 metadata", () => {
+    expect(parseUnsignedCrc64("0")).toBe(0n);
+    expect(parseUnsignedCrc64("18446744073709551615")).toBe(0xffffffffffffffffn);
+    expect(() => parseUnsignedCrc64("-1")).toThrow("unsigned decimal integer");
+    expect(() => parseUnsignedCrc64("01")).toThrow("unsigned decimal integer");
+    expect(() => parseUnsignedCrc64("18446744073709551616")).toThrow("unsigned 64-bit range");
+  });
+
+  it("parses only the final HTTP response block and rejects duplicate integrity headers", () => {
+    const parsed = parseFinalOssHeadHeaders([
+      "HTTP/1.1 302 Found",
+      "Content-MD5: redirect-value",
+      "content-md5: duplicate-redirect-value",
+      "Location: https://example.invalid/final",
+      "",
+      "HTTP/2 200",
+      "content-length: 12",
+      "content-md5: AAAAAAAAAAAAAAAAAAAAAA==",
+      "etag: final-etag",
+      "x-oss-object-type: Normal",
+      "",
+    ].join("\r\n"));
+    expect(parsed).toMatchObject({
+      status: 200,
+      contentLength: "12",
+      contentMd5: "AAAAAAAAAAAAAAAAAAAAAA==",
+      etag: "final-etag",
+      objectType: "Normal",
+    });
+
+    expect(() => parseFinalOssHeadHeaders([
+      "HTTP/1.1 200 OK",
+      "Content-MD5: AAAAAAAAAAAAAAAAAAAAAA==",
+      "content-md5: AAAAAAAAAAAAAAAAAAAAAA==",
+      "x-oss-object-type: Normal",
+      "",
+    ].join("\n"))).toThrow("duplicate content-md5");
+
+    expect(() => parseFinalOssHeadHeaders([
+      "HTTP/1.1 503 Service Unavailable",
+      "Content-Length: 0",
+      "",
+    ].join("\r\n"))).toThrow("unexpected HTTP status 503");
+  });
+
+  it("verifies Normal objects with Content-MD5", async () => {
+    const directory = mkdtempSync(resolve(tmpdir(), "memmy-oss-normal-"));
+    temporaryDirectories.push(directory);
+    const path = resolve(directory, "payload.bin");
+    const payload = Buffer.from("normal-release-asset", "utf8");
+    writeFileSync(path, payload);
+    const contentMd5 = createHash("md5").update(payload).digest("base64");
+    const headers = [
+      "HTTP/1.1 200 OK",
+      `Content-Length: ${payload.length}`,
+      `Content-MD5: ${contentMd5}`,
+      "ETag: normal-etag",
+      "x-oss-object-type: Normal",
+      "",
+    ].join("\r\n");
+
+    await expect(verifyOssObjectIntegrity(headers, path)).resolves.toMatchObject({
+      objectType: "Normal",
+      method: "content-md5",
+      size: payload.length,
+    });
+  });
+
+  it("requires and verifies CRC64/XZ for Multipart objects even if MD5 is present", async () => {
+    const directory = mkdtempSync(resolve(tmpdir(), "memmy-oss-crc64-cli-"));
+    temporaryDirectories.push(directory);
+    const path = resolve(directory, "payload.bin");
+    const payload = Buffer.from("release-asset", "utf8");
+    writeFileSync(path, payload);
+    const checksum = crc64Xz(payload).toString(10);
+    const headers = [
+      "HTTP/1.1 200 OK",
+      `Content-Length: ${payload.length}`,
+      "Content-MD5: AAAAAAAAAAAAAAAAAAAAAA==",
+      `x-oss-hash-crc64ecma: ${checksum}`,
+      "ETag: multipart-etag-21",
+      "x-oss-object-type: Multipart",
+      "",
+    ].join("\r\n");
+    const headersPath = resolve(directory, "headers.txt");
+    writeFileSync(headersPath, headers);
+
+    await expect(verifyOssObjectIntegrity(headers, path)).resolves.toMatchObject({
+      objectType: "Multipart",
+      method: "crc64-xz",
+      expected: checksum,
+      actual: checksum,
+      size: payload.length,
+    });
+
+    const matched = spawnSync(process.execPath, [verifierPath, headersPath, path], {
+      encoding: "utf8",
+    });
+    expect(matched.status, matched.stderr).toBe(0);
+    expect(JSON.parse(matched.stdout)).toMatchObject({ method: "crc64-xz", actual: checksum });
+
+    writeFileSync(headersPath, headers.replace(checksum, "1"));
+    const mismatched = spawnSync(process.execPath, [verifierPath, headersPath, path], {
+      encoding: "utf8",
+    });
+    expect(mismatched.status).toBe(1);
+    expect(mismatched.stderr).toContain("CRC64/XZ mismatch");
+  });
+
+  it("fails closed for missing Multipart CRC64 and unknown object types", async () => {
+    const directory = mkdtempSync(resolve(tmpdir(), "memmy-oss-metadata-"));
+    temporaryDirectories.push(directory);
+    const path = resolve(directory, "payload.bin");
+    writeFileSync(path, "payload");
+    const base = ["HTTP/1.1 200 OK", "Content-Length: 7"];
+    const validMd5 = createHash("md5").update("payload").digest("base64");
+
+    await expect(verifyOssObjectIntegrity([
+      ...base,
+      `Content-MD5: ${validMd5}`,
+      "x-oss-object-type: Multipart",
+      "",
+    ].join("\r\n"), path)).rejects.toThrow("missing a valid x-oss-hash-crc64ecma");
+
+    await expect(verifyOssObjectIntegrity([
+      ...base,
+      `Content-MD5: ${validMd5}`,
+      "x-oss-object-type: Appendable",
+      "",
+    ].join("\r\n"), path)).rejects.toThrow("Unsupported OSS object type");
+
+    await expect(verifyOssObjectIntegrity([
+      ...base,
+      "Content-MD5: AAAAAAAAAAAAAAAAAAAAAA==",
+      "x-oss-object-type: Normal",
+      "",
+    ].join("\r\n"), path)).rejects.toThrow("Content-MD5 mismatch");
+
+    await expect(verifyOssObjectIntegrity([
+      ...base,
+      "x-oss-hash-crc64ecma: 1",
+      "x-oss-object-type: Normal",
+      "",
+    ].join("\r\n"), path)).rejects.toThrow("missing a canonical Content-MD5");
+
+    await expect(verifyOssObjectIntegrity([
+      ...base,
+      "Content-MD5: AAAAAAAAAAAAAAAAAAAAAA==",
+      "x-oss-hash-crc64ecma: 18446744073709551616",
+      "x-oss-object-type: Multipart",
+      "",
+    ].join("\r\n"), path)).rejects.toThrow("unsigned 64-bit range");
+
+    await expect(verifyOssObjectIntegrity([
+      ...base,
+      `Content-MD5: ${validMd5}`,
+      "",
+    ].join("\r\n"), path)).rejects.toThrow("Unsupported OSS object type 'missing'");
+
+    await expect(verifyOssObjectIntegrity([
+      "HTTP/1.1 200 OK",
+      "Content-Length: 8",
+      `Content-MD5: ${validMd5}`,
+      "x-oss-object-type: Normal",
+      "",
+    ].join("\r\n"), path)).rejects.toThrow("Content-Length mismatch");
+  });
+});

--- a/tests/release-workflow.test.ts
+++ b/tests/release-workflow.test.ts
@@ -9,8 +9,10 @@ const repoRoot = resolve(import.meta.dirname, "..");
 const legacyWorkflowPath = resolve(repoRoot, ".github/workflows/github-release.yml");
 const draftWorkflowPath = resolve(repoRoot, ".github/workflows/github-draft-release-v2.yml");
 const releaseCompareScriptPath = resolve(repoRoot, "scripts/build-release-compare.mjs");
+const ossIntegrityScriptPath = resolve(repoRoot, "scripts/internal/shared/oss-object-integrity.mjs");
 const draftSource = readFileSync(draftWorkflowPath, "utf8");
 const releaseCompareSource = readFileSync(releaseCompareScriptPath, "utf8");
+const ossIntegritySource = readFileSync(ossIntegrityScriptPath, "utf8");
 const draftWorkflow = YAML.parse(draftSource);
 const draftJob = draftWorkflow.jobs.release;
 const draftSteps = draftJob.steps as Array<Record<string, unknown>>;
@@ -356,22 +358,27 @@ describe("GitHub Draft Release v2 workflow", () => {
     expect(draftSource).not.toContain("Publish release as latest");
   });
 
-  it("downloads all four OSS artifacts and verifies Content-MD5", () => {
+  it("downloads all four OSS artifacts and verifies Normal MD5 or Multipart CRC64", () => {
     expect(draftSteps.find((step) => step.name === "Download and verify OSS artifacts")?.if).toBe(
       "${{ steps.release.outputs.preflight_level == 'full' }}",
     );
     const download = draftScript("Download and verify OSS artifacts");
     expect(download).toContain("curl --fail --location --retry 5 --retry-all-errors");
-    expect(download).toContain("Content-MD5");
+    expect(download).toContain("verify-oss-object-integrity.mjs");
+    expect(download).toContain("OSS_VERIFICATION.json");
     expect(download).toContain("Installer asset is missing");
-    expect(download).toContain("Installer checksum header missing");
     expect(download).toContain("Installer download failed");
-    expect(download).toContain("Installer checksum mismatch");
+    expect(download).toContain("Installer checksum verification failed");
     expect(download).toContain('[[ ! -s "release-assets/$artifact" ]]');
     expect(download).toContain("Installer download is empty");
     expect(download.match(/Memmy-\$VERSION-/g)).toHaveLength(4);
     expect(download).toContain("MD5SUMS.txt");
     expect(download).toContain("SHA256SUMS.txt");
+    expect(ossIntegritySource).toContain('metadata.objectType === "Normal"');
+    expect(ossIntegritySource).toContain('metadata.objectType === "Multipart"');
+    expect(ossIntegritySource).toContain("Content-MD5 mismatch");
+    expect(ossIntegritySource).toContain("CRC64/XZ mismatch");
+    expect(draftSource).toContain("ossIntegrity: $ossIntegrity[0]");
   });
 
   it("does not expect a nonexistent head_commit in GitHub Compare metadata", () => {


### PR DESCRIPTION
## Summary

- keep Normal OSS release assets fail-closed on canonical `Content-MD5`
- verify Multipart assets with OSS `x-oss-hash-crc64ecma` using streaming CRC-64/XZ
- parse only the final HEAD response block and reject duplicate, missing, malformed, unsupported, empty, symlink, size-mismatched, or checksum-mismatched inputs
- record object type, integrity method, expected/actual checksum, size, and ETag in `OSS_VERIFICATION.json` and `RELEASE_EVIDENCE.json`

## Regression proof

- the new workflow expectation failed against the old Content-MD5-only implementation before this fix
- release workflow and CRC tests: 27/27 passed
- packaging guards: 15/15 passed
- full lint and workflow shell syntax passed
- Project Harness Full/T3: `verificationPassed=true`, no failed evidence, exact HEAD `770047ce`
- independent review: no P0-P3 findings

## Real OSS verification

The committed verifier downloaded and validated all four current v1.1.0 Multipart installers against OSS CRC-64/XZ. A separate root-session check also matched the Windows CN package byte-for-byte against CRC metadata.

## Scope

This PR changes release verification and audit evidence only. It does not create or publish a tag/Release and does not modify the active `release/v1.1.0` branch. After merge, main must be integrated into the release branch and its Harness evidence refreshed before v1.1.0 is merged.