### PR TITLE
feat(linux): add one-line CLI installer

### DIFF
--- a/.github/workflows/linux-cli-installer.yml
+++ b/.github/workflows/linux-cli-installer.yml
@@ -1,0 +1,208 @@
+name: Linux CLI installer
+
+on:
+  release:
+    types: [published]
+  pull_request:
+    paths:
+      - ".github/workflows/linux-cli-installer.yml"
+      - "scripts/install.sh"
+      - "scripts/internal/linux/**"
+      - "App/memmy-agent/**"
+      - "Memory/**"
+      - "Migrations/**"
+      - "App/backend/**"
+      - "tests/linux-cli-packaging.test.mjs"
+      - "package.json"
+      - "package-lock.json"
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/linux-cli-installer.yml"
+      - "scripts/install.sh"
+      - "scripts/internal/linux/**"
+      - "App/memmy-agent/**"
+      - "Memory/**"
+      - "Migrations/**"
+      - "App/backend/**"
+      - "tests/linux-cli-packaging.test.mjs"
+      - "package.json"
+      - "package-lock.json"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Version matching package.json (without the v prefix)
+        required: false
+        type: string
+      upload_to_release:
+        description: Upload the verified Linux assets to an existing GitHub Release
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'release' && github.event.release.tag_name || github.sha }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - name: Resolve and verify version
+        id: version
+        env:
+          REQUESTED_VERSION: ${{ github.event_name == 'release' && github.event.release.tag_name || inputs.version }}
+        run: |
+          set -euo pipefail
+          repository_version="$(node -p "require('./package.json').version")"
+          version="${REQUESTED_VERSION:-$repository_version}"
+          version="${version#v}"
+          if [[ "$version" != "$repository_version" ]]; then
+            echo "Requested version $version does not match package.json version $repository_version" >&2
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+      - name: Test Linux launcher and installer contracts
+        run: npm run test:linux-cli
+      - name: Build Linux CLI release assets
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: bash scripts/internal/linux/build-cli-archive.sh --version "$VERSION" --output release-assets
+      - uses: actions/upload-artifact@v4
+        with:
+          name: memmy-linux-cli-assets
+          path: |
+            release-assets/memmy-agent-linux-cli.tar.gz
+            release-assets/memmy-agent-linux-cli.tar.gz.sha256
+            release-assets/install.sh
+          if-no-files-found: error
+
+  install-smoke:
+    needs: build
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-24.04
+            architecture: x64
+          - runner: ubuntu-24.04-arm
+            architecture: arm64
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: memmy-linux-cli-assets
+          path: release-assets
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - name: Install twice and exercise the CLI
+        env:
+          VERSION: ${{ needs.build.outputs.version }}
+          EXPECTED_ARCH: ${{ matrix.architecture }}
+          MEMMY_INSTALL_ROOT: ${{ runner.temp }}/memmy-agent
+          MEMMY_BIN_DIR: ${{ runner.temp }}/bin
+        run: |
+          set -euo pipefail
+          case "$(uname -m)" in
+            x86_64|amd64) actual_arch="x64" ;;
+            aarch64|arm64) actual_arch="arm64" ;;
+            *) echo "Unsupported runner architecture: $(uname -m)" >&2; exit 1 ;;
+          esac
+          [[ "$actual_arch" == "$EXPECTED_ARCH" ]]
+          export MEMMY_VERSION="$VERSION"
+          export MEMMY_RELEASE_BASE_URL="file://$PWD/release-assets"
+          bash release-assets/install.sh
+          bash release-assets/install.sh
+          "$MEMMY_BIN_DIR/memmy" --version
+          "$MEMMY_BIN_DIR/memmy" --help >/dev/null
+          "$MEMMY_BIN_DIR/memmy-memory" health >/dev/null
+          systemctl --user is-enabled --quiet memmy-memory.service
+          if systemctl --user is-enabled --quiet memmy-gateway.service; then
+            echo "Gateway must remain disabled until the first bare memmy onboarding" >&2
+            exit 1
+          fi
+          systemd_verify_output="$(systemd-analyze --user verify \
+            "$HOME/.config/systemd/user/memmy-memory.service" \
+            "$HOME/.config/systemd/user/memmy-gateway.service" 2>&1)" || {
+              printf '%s\n' "$systemd_verify_output" >&2
+              exit 1
+            }
+          if [[ -n "$systemd_verify_output" ]]; then
+            printf '%s\n' "$systemd_verify_output" >&2
+            exit 1
+          fi
+          export MEMMY_SMOKE_SECRET="linux-smoke-${EXPECTED_ARCH}"
+          (
+            cd "$MEMMY_INSTALL_ROOT/current/App/memmy-agent"
+            CONFIG_PATH="$HOME/.memmy/config.yaml" node --input-type=module <<'NODE'
+          import { readFileSync, writeFileSync } from "node:fs";
+          import YAML from "yaml";
+
+          const configPath = process.env.CONFIG_PATH;
+          const config = YAML.parse(readFileSync(configPath, "utf8")) ?? {};
+          config.agents ??= {};
+          config.agents.defaults ??= {};
+          config.agents.defaults.model = "ollama/llama3.2";
+          config.tools ??= {};
+          config.tools.web ??= {};
+          config.tools.web.search ??= {};
+          config.tools.web.search.apiKey = "${MEMMY_SMOKE_SECRET}";
+          config.tools.browser = { enabled: false };
+          writeFileSync(configPath, YAML.stringify(config), "utf8");
+          NODE
+          )
+          set +e
+          timeout --signal=TERM --kill-after=5s 45s \
+            script -qefc "$MEMMY_BIN_DIR/memmy" "$RUNNER_TEMP/memmy-tui.log" </dev/null
+          tui_status=$?
+          set -e
+          if [[ "$tui_status" -ne 0 && "$tui_status" -ne 124 && "$tui_status" -ne 137 ]]; then
+            cat "$RUNNER_TEMP/memmy-tui.log" >&2
+            exit "$tui_status"
+          fi
+          systemctl --user is-enabled --quiet memmy-gateway.service
+          systemctl --user is-active --quiet memmy-gateway.service
+          grep -Fq 'MEMMY_SMOKE_SECRET="linux-smoke-' "$HOME/.memmy/systemd/gateway.env"
+          gateway_pid_before_update="$(systemctl --user show memmy-gateway.service --property=MainPID --value)"
+          bash release-assets/install.sh
+          gateway_pid_after_update="$(systemctl --user show memmy-gateway.service --property=MainPID --value)"
+          [[ "$gateway_pid_after_update" != "$gateway_pid_before_update" ]]
+          systemctl --user is-active --quiet memmy-gateway.service
+          curl --fail --silent --show-error http://127.0.0.1:18970/health >/dev/null
+          "$MEMMY_BIN_DIR/memmy-memory" health >/dev/null
+          systemctl --user stop memmy-gateway.service
+
+  upload:
+    if: ${{ github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.upload_to_release == true) }}
+    needs: [build, install-smoke]
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+      VERSION: ${{ needs.build.outputs.version }}
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: memmy-linux-cli-assets
+          path: release-assets
+      - name: Upload only Linux CLI assets to the existing Release
+        run: |
+          set -euo pipefail
+          gh release view "v$VERSION" --repo "$GITHUB_REPOSITORY" >/dev/null
+          gh release upload "v$VERSION" \
+            release-assets/memmy-agent-linux-cli.tar.gz \
+            release-assets/memmy-agent-linux-cli.tar.gz.sha256 \
+            release-assets/install.sh \
+            --clobber \
+            --repo "$GITHUB_REPOSITORY"

--- a/App/memmy-agent/src/entrypoints/cli/commands.ts
+++ b/App/memmy-agent/src/entrypoints/cli/commands.ts
@@ -78,6 +78,8 @@ import {
 } from "./onboard.js";
 import { StreamRenderer, ThinkingSpinner } from "./stream.js";
 import { prepareStartupMigrations } from "./startup-migrations.js";
+import { parseRootTerminalOptions } from "./root-terminal-options.js";
+import { runLinuxRootTerminal } from "./linux-systemd-gateway.js";
 
 const CLI_TEMPLATES_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../templates");
 
@@ -102,6 +104,37 @@ export type GatewayRuntime = {
   healthServer: http.Server;
   stop: () => Promise<void>;
 };
+
+type GatewayLifecycleProcess = Pick<NodeJS.Process, "on" | "off" | "exit">;
+
+export function installGatewaySignalLifecycle(
+  runtime: GatewayRuntime,
+  lifecycle: GatewayLifecycleProcess = process,
+): void {
+  let stopping = false;
+  const signals: NodeJS.Signals[] = ["SIGHUP", "SIGINT", "SIGTERM"];
+  const remove = () => {
+    for (const signal of signals) lifecycle.off(signal, shutdown);
+  };
+  const shutdown = () => {
+    if (stopping) return;
+    stopping = true;
+    remove();
+    const forceExit = setTimeout(() => lifecycle.exit(1), 10_000);
+    forceExit.unref?.();
+    void runtime.stop().then(
+      () => {
+        clearTimeout(forceExit);
+        lifecycle.exit(0);
+      },
+      () => {
+        clearTimeout(forceExit);
+        lifecycle.exit(1);
+      },
+    );
+  };
+  for (const signal of signals) lifecycle.on(signal, shutdown);
+}
 
 let cliRuntimeLogs = false;
 
@@ -351,7 +384,7 @@ export function resolveTerminalTarget(
     key = standalone || project ? `cli:${crypto.randomUUID()}` : "cli:direct";
     const existing = reload(key);
     if (!existing && !dependencies.hasUsableDefaultModel()) {
-      throw new Error("No usable default model is configured. Run `memmy onboard` first.");
+      throw new Error("No usable default model is configured. Run `memmy onboard --wizard` first.");
     }
     if (existing) {
       binding = readWebuiSessionBinding(existing);
@@ -457,9 +490,9 @@ export async function runRootInteractiveAgent({
   sessionId?: string | null;
   standalone?: boolean;
   project?: string | null;
-} = {}): Promise<unknown> {
+} = {}, runtimeConfig?: Config): Promise<unknown> {
   if (rootInteractiveRunnerForTest) return rootInteractiveRunnerForTest();
-  const loaded = loadRuntimeConfig(null, null);
+  const loaded = runtimeConfig ?? loadRuntimeConfig(null, null);
   const workspace = syncRuntimeWorkspaceTemplates(loaded);
   const target = resolveTerminalTarget({
     sessions: new SessionManager(path.join(workspace, "sessions"), {
@@ -479,31 +512,6 @@ export async function runRootInteractiveAgent({
   printCliRestartNoticeIfNeeded(target.sessionId, true);
   const { runInkInteractiveAgent } = await import("./tui.js");
   return runInkInteractiveAgent(loaded, target.sessionId, target);
-}
-
-function rootTerminalOptions(argv: string[]): {
-  sessionId?: string;
-  standalone?: boolean;
-  project?: string;
-} | null {
-  if (argv.length <= 2) return {};
-  const args = argv.slice(2);
-  const options: { sessionId?: string; standalone?: boolean; project?: string } = {};
-  for (let index = 0; index < args.length; index += 1) {
-    const arg = args[index];
-    if (arg === "--standalone") options.standalone = true;
-    else if (arg === "--session" || arg === "-s") {
-      const value = args[++index];
-      if (!value || value.startsWith("-")) throw new Error("--session requires a sessionId");
-      options.sessionId = value;
-    } else if (arg === "--project") {
-      const value = args[++index];
-      if (!value || value.startsWith("-")) throw new Error("--project requires a path");
-      options.project = value;
-    }
-    else return null;
-  }
-  return options;
 }
 
 export async function runInternalCommand(argv: string[]): Promise<boolean> {
@@ -535,10 +543,18 @@ export async function main(argv: string[] = process.argv): Promise<void> {
     versionCallback(true);
     return;
   }
-  const rootTarget = rootTerminalOptions(argv);
+  const rootTarget = parseRootTerminalOptions(argv);
   if (rootTarget) {
     await prepareStartupMigrations();
-    await runRootInteractiveAgent(rootTarget);
+    if (rootInteractiveRunnerForTest) {
+      await runRootInteractiveAgent(rootTarget);
+      return;
+    }
+    await runLinuxRootTerminal({
+      loadConfig: () => loadRuntimeConfig(null, null),
+      onboardWizard: () => onboard({ wizard: true }),
+      runInteractive: (config) => runRootInteractiveAgent(rootTarget, config),
+    });
     return;
   }
 
@@ -596,7 +612,8 @@ export async function main(argv: string[] = process.argv): Promise<void> {
     .option("-c, --config <path>", "Path to config file")
     .option("-v, --verbose", "Enable verbose runtime logs", false)
     .action(async (opts) => {
-      await gateway(opts);
+      const runtime = await gateway(opts);
+      installGatewaySignalLifecycle(runtime);
     });
 
   app

--- a/App/memmy-agent/src/entrypoints/cli/linux-systemd-gateway.ts
+++ b/App/memmy-agent/src/entrypoints/cli/linux-systemd-gateway.ts
@@ -1,0 +1,611 @@
+import { execFile } from "node:child_process";
+import crypto from "node:crypto";
+import {
+  chmodSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+import { promisify } from "node:util";
+import { mutateRuntimeConfig } from "@memmy/migrations";
+import type { Config } from "../../config/schema.js";
+import { getConfigPath, getRuntimeSubdir } from "../../config/paths.js";
+import { tuiGatewayOptionsFromConfig } from "./tui-gateway-client.js";
+
+const execFileAsync = promisify(execFile);
+const STARTUP_TIMEOUT_MS = 30_000;
+const PROBE_TIMEOUT_MS = 1_500;
+const POLL_INTERVAL_MS = 150;
+const SERVICE_STABILITY_MS = 500;
+const MEMORY_SERVICE_NAME = "memmy-memory.service";
+const SYSTEMD_GATEWAY_ENV = "MEMMY_LINUX_SYSTEMD_GATEWAY";
+
+const PERSISTED_GATEWAY_ENV_KEYS = [
+  "PATH",
+  "SHELL",
+  "LANG",
+  "LC_ALL",
+  "HTTP_PROXY",
+  "HTTPS_PROXY",
+  "ALL_PROXY",
+  "NO_PROXY",
+  "http_proxy",
+  "https_proxy",
+  "all_proxy",
+  "no_proxy",
+  "SSL_CERT_FILE",
+  "NODE_EXTRA_CA_CERTS",
+  "GIT_SSH_COMMAND",
+  "OPENAI_API_KEY",
+  "ANTHROPIC_API_KEY",
+  "GOOGLE_API_KEY",
+  "GEMINI_API_KEY",
+  "GROQ_API_KEY",
+  "GROQ_BASE_URL",
+  "DEEPSEEK_API_KEY",
+  "TAVILY_API_KEY",
+  "BRAVE_API_KEY",
+  "JINA_API_KEY",
+  "KAGI_API_KEY",
+  "OLOSTEP_API_KEY",
+  "SEARXNG_BASE_URL",
+  "OPENAI_TRANSCRIPTION_BASE_URL",
+  "GITHUB_TOKEN",
+  "GH_TOKEN",
+  "AWS_ACCESS_KEY_ID",
+  "AWS_SECRET_ACCESS_KEY",
+  "AWS_SESSION_TOKEN",
+  "AWS_PROFILE",
+  "AWS_REGION",
+  "AWS_DEFAULT_REGION",
+  "AWS_BEARER_TOKEN_BEDROCK",
+  "OAUTH_CLI_KIT_TOKEN_PATH",
+  "OPENAI_CODEX_TOKEN_PATH",
+  "CHATGPT_TOKEN_PATH",
+  "OPENAI_CODEX_ACCESS_TOKEN",
+  "CHATGPT_ACCESS_TOKEN",
+  "OPENAI_CODEX_ACCOUNT_ID",
+  "CHATGPT_ACCOUNT_ID",
+  "MEMMY_AGENT_PATH_APPEND",
+  "MEMMY_AGENT_STREAM_IDLE_TIMEOUT_S",
+  "MEMMY_CLOUD_SERVICE",
+  "MEMMY_APP_EDITION",
+] as const;
+
+export class LinuxSystemdGatewayError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "LinuxSystemdGatewayError";
+  }
+}
+
+export type GatewayProbe =
+  | { status: "ready" }
+  | { status: "unavailable"; detail: string }
+  | { status: "unexpected"; detail: string };
+
+type GatewayEndpoint = {
+  baseUrl: string;
+  bootstrapSecret: string | null;
+};
+
+type MemoryServiceEndpoint = {
+  baseUrl: string;
+  token: string | null;
+};
+
+type LinuxRootTerminalDependencies = {
+  loadConfig: () => Config;
+  onboardWizard: () => Promise<unknown>;
+  runInteractive: (config?: Config) => Promise<unknown>;
+  platform?: NodeJS.Platform;
+  stdinIsTTY?: boolean;
+  stdoutIsTTY?: boolean;
+  systemdGatewayEnabled?: boolean;
+  prepareGatewayConfig?: () => Promise<Config>;
+  refreshMemoryService?: (config: Config) => Promise<void>;
+  prepareGatewayEnvironment?: () => Promise<boolean>;
+  enableGatewayService?: (options?: { restart?: boolean }) => Promise<void>;
+  probeGateway?: (config: Config) => Promise<GatewayProbe>;
+  gatewayServiceMainPid?: () => Promise<number | null>;
+  now?: () => number;
+  sleep?: (milliseconds: number) => Promise<void>;
+  startupTimeoutMs?: number;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function mutableRecord(value: unknown): Record<string, unknown> {
+  return isRecord(value) ? { ...value } : {};
+}
+
+function sleep(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function errorCode(error: unknown): string | null {
+  let current: unknown = error;
+  for (let depth = 0; depth < 4 && isRecord(current); depth += 1) {
+    if (typeof current.code === "string") return current.code;
+    current = current.cause;
+  }
+  return null;
+}
+
+function unavailableNetworkError(error: unknown): boolean {
+  if (error instanceof Error && error.name === "AbortError") return true;
+  return new Set([
+    "ECONNREFUSED",
+    "EHOSTUNREACH",
+    "ENETUNREACH",
+    "ENETDOWN",
+    "ETIMEDOUT",
+  ]).has(errorCode(error) ?? "");
+}
+
+function gatewayEndpoint(config: Config): GatewayEndpoint {
+  const options = tuiGatewayOptionsFromConfig(config, "cli:systemd-probe");
+  return {
+    baseUrl: options.baseUrl,
+    bootstrapSecret: options.bootstrapSecret?.trim() || null,
+  };
+}
+
+function memoryServiceEndpoint(config: Config): MemoryServiceEndpoint {
+  const storage = isRecord(config.memmyMemory.storage) ? config.memmyMemory.storage : {};
+  return {
+    baseUrl: typeof storage.endpoint === "string" && storage.endpoint.trim()
+      ? storage.endpoint.trim()
+      : "http://127.0.0.1:18960",
+    token: typeof storage.token === "string" && storage.token.trim()
+      ? storage.token.trim()
+      : null,
+  };
+}
+
+function validBootstrap(value: unknown): boolean {
+  if (!isRecord(value)) return false;
+  return typeof value.token === "string"
+    && value.token.length > 0
+    && typeof value.ws_path === "string"
+    && value.ws_path.startsWith("/");
+}
+
+export function hasUsableDefaultModel(config: Config): boolean {
+  try {
+    const preset = config.resolvePreset();
+    return Boolean(preset.model.trim() && config.getProviderName(preset.model, { preset }));
+  } catch {
+    return false;
+  }
+}
+
+export async function probeGateway(
+  config: Config,
+  {
+    fetchImpl = fetch,
+    timeoutMs = PROBE_TIMEOUT_MS,
+  }: { fetchImpl?: typeof fetch; timeoutMs?: number } = {},
+): Promise<GatewayProbe> {
+  let endpoint: GatewayEndpoint;
+  try {
+    endpoint = gatewayEndpoint(config);
+  } catch (error) {
+    const detail = errorMessage(error);
+    if (detail.includes("WebSocket Gateway is disabled")) {
+      return { status: "unavailable", detail };
+    }
+    return { status: "unexpected", detail: `invalid Gateway configuration: ${detail}` };
+  }
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetchImpl(`${endpoint.baseUrl}/webui/bootstrap`, {
+      cache: "no-store",
+      headers: endpoint.bootstrapSecret
+        ? { authorization: `Bearer ${endpoint.bootstrapSecret}` }
+        : undefined,
+      signal: controller.signal,
+    });
+    if (!response.ok) {
+      return {
+        status: "unexpected",
+        detail: `bootstrap HTTP ${response.status}`,
+      };
+    }
+    let body: unknown;
+    try {
+      body = await response.json();
+    } catch (error) {
+      return { status: "unexpected", detail: `invalid bootstrap JSON: ${errorMessage(error)}` };
+    }
+    return validBootstrap(body)
+      ? { status: "ready" }
+      : { status: "unexpected", detail: "bootstrap response is incompatible" };
+  } catch (error) {
+    if (unavailableNetworkError(error)) {
+      return { status: "unavailable", detail: errorMessage(error) };
+    }
+    return { status: "unexpected", detail: errorMessage(error) };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export async function probeMemoryServiceAuthentication(
+  config: Config,
+  {
+    fetchImpl = fetch,
+    timeoutMs = PROBE_TIMEOUT_MS,
+  }: { fetchImpl?: typeof fetch; timeoutMs?: number } = {},
+): Promise<GatewayProbe> {
+  const endpoint = memoryServiceEndpoint(config);
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetchImpl(new URL("/api/v1/panel/overview", endpoint.baseUrl), {
+      cache: "no-store",
+      headers: endpoint.token
+        ? { authorization: `Bearer ${endpoint.token}` }
+        : undefined,
+      signal: controller.signal,
+    });
+    if (!response.ok) {
+      return {
+        status: "unexpected",
+        detail: `authenticated Memory HTTP ${response.status}`,
+      };
+    }
+    return { status: "ready" };
+  } catch (error) {
+    if (unavailableNetworkError(error)) {
+      return { status: "unavailable", detail: errorMessage(error) };
+    }
+    return { status: "unexpected", detail: errorMessage(error) };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export async function prepareLinuxGatewayConfig(
+  loadConfig: () => Config,
+  configPath = getConfigPath(),
+): Promise<Config> {
+  await mutateRuntimeConfig(configPath, (root) => {
+    const channels = mutableRecord(root.channels);
+    const websocket = mutableRecord(channels.websocket);
+    const gateway = mutableRecord(root.gateway);
+
+    websocket.enabled = true;
+    websocket.host ??= "127.0.0.1";
+    websocket.port ??= 18980;
+    websocket.tokenTtlS ??= 86_400;
+    websocket.websocketRequiresToken ??= true;
+    websocket.allowFrom ??= ["*"];
+    if (
+      (typeof websocket.tokenIssueSecret !== "string" || !websocket.tokenIssueSecret.trim())
+      && (typeof websocket.token !== "string" || !websocket.token.trim())
+    ) {
+      websocket.tokenIssueSecret = crypto.randomBytes(32).toString("hex");
+    }
+
+    gateway.enabled = true;
+    gateway.host ??= "127.0.0.1";
+    gateway.port ??= 18970;
+
+    channels.websocket = websocket;
+    root.channels = channels;
+    root.gateway = gateway;
+  });
+  return loadConfig();
+}
+
+function environmentFilePath(): string {
+  const configured = process.env.MEMMY_GATEWAY_ENV_FILE?.trim();
+  return configured ? path.resolve(configured) : path.join(getRuntimeSubdir("systemd"), "gateway.env");
+}
+
+function referencedEnvironmentKeys(configText: string): Set<string> {
+  const keys = new Set<string>();
+  for (const match of configText.matchAll(/\$\{([A-Z_][A-Z0-9_]*)(?::[^}]*)?\}/gi)) {
+    keys.add(match[1]);
+  }
+  return keys;
+}
+
+function quoteEnvironmentValue(key: string, value: string): string {
+  if (value.includes("\0") || value.includes("\n") || value.includes("\r")) {
+    throw new LinuxSystemdGatewayError(
+      `Environment variable ${key} contains a newline or NUL and cannot be persisted for systemd.`,
+    );
+  }
+  return `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+}
+
+export async function prepareSystemdGatewayEnvironment(
+  {
+    configPath = getConfigPath(),
+    destination = environmentFilePath(),
+    env = process.env,
+  }: {
+    configPath?: string;
+    destination?: string;
+    env?: NodeJS.ProcessEnv;
+  } = {},
+): Promise<boolean> {
+  let configText = "";
+  try {
+    configText = readFileSync(configPath, "utf8");
+  } catch (error) {
+    throw new LinuxSystemdGatewayError(
+      `Could not read Gateway configuration for systemd environment: ${errorMessage(error)}`,
+    );
+  }
+
+  const keys = referencedEnvironmentKeys(configText);
+  for (const key of PERSISTED_GATEWAY_ENV_KEYS) keys.add(key);
+  const lines = [
+    "# Generated by memmy. Mode 0600; refreshed by each interactive memmy launch.",
+  ];
+  for (const key of [...keys].sort()) {
+    const value = env[key];
+    if (value === undefined) continue;
+    lines.push(`${key}=${quoteEnvironmentValue(key, value)}`);
+  }
+  const content = `${lines.join("\n")}\n`;
+
+  let existing: string | null = null;
+  try {
+    existing = readFileSync(destination, "utf8");
+  } catch {
+    existing = null;
+  }
+  try {
+    mkdirSync(path.dirname(destination), { recursive: true, mode: 0o700 });
+    chmodSync(path.dirname(destination), 0o700);
+    if (existing === content) {
+      chmodSync(destination, 0o600);
+      return false;
+    }
+  } catch (error) {
+    throw new LinuxSystemdGatewayError(
+      `Could not prepare the private Gateway environment directory: ${errorMessage(error)}`,
+    );
+  }
+
+  const temporary = `${destination}.${process.pid}.${Date.now()}.tmp`;
+  try {
+    writeFileSync(temporary, content, { encoding: "utf8", mode: 0o600, flag: "wx" });
+    chmodSync(temporary, 0o600);
+    renameSync(temporary, destination);
+  } catch (error) {
+    rmSync(temporary, { force: true });
+    throw new LinuxSystemdGatewayError(
+      `Could not persist the private Gateway environment file: ${errorMessage(error)}`,
+    );
+  }
+  return true;
+}
+
+export async function enableSystemdGatewayService(
+  { restart = false }: { restart?: boolean } = {},
+): Promise<void> {
+  try {
+    if (restart) {
+      await execFileAsync("systemctl", ["--user", "enable", "memmy-gateway.service"], {
+        timeout: 20_000,
+      });
+      await execFileAsync("systemctl", ["--user", "restart", "memmy-gateway.service"], {
+        timeout: 20_000,
+      });
+    } else {
+      await execFileAsync(
+        "systemctl",
+        ["--user", "enable", "--now", "memmy-gateway.service"],
+        { timeout: 20_000 },
+      );
+    }
+  } catch (error) {
+    const detail = isRecord(error) && typeof error.stderr === "string"
+      ? error.stderr.trim()
+      : errorMessage(error);
+    throw new LinuxSystemdGatewayError(
+      "Could not start memmy-gateway.service with systemd --user"
+      + `${detail ? `: ${detail}` : "."} `
+      + "Install Memmy with the Linux installer and check "
+      + "`systemctl --user status memmy-gateway.service`.",
+    );
+  }
+}
+
+export async function systemdGatewayMainPid(): Promise<number | null> {
+  return systemdServiceMainPid("memmy-gateway.service");
+}
+
+async function systemdServiceMainPid(serviceName: string): Promise<number | null> {
+  try {
+    const { stdout } = await execFileAsync(
+      "systemctl",
+      ["--user", "show", serviceName, "--property=MainPID", "--value"],
+      { timeout: 5_000 },
+    );
+    const pid = Number.parseInt(stdout.trim(), 10);
+    if (!Number.isSafeInteger(pid) || pid <= 1) return null;
+    process.kill(pid, 0);
+    return pid;
+  } catch {
+    return null;
+  }
+}
+
+export async function refreshSystemdMemoryService(config: Config): Promise<void> {
+  try {
+    await execFileAsync("systemctl", ["--user", "restart", MEMORY_SERVICE_NAME], {
+      timeout: 20_000,
+    });
+  } catch (error) {
+    const detail = isRecord(error) && typeof error.stderr === "string"
+      ? error.stderr.trim()
+      : errorMessage(error);
+    throw new LinuxSystemdGatewayError(
+      `Could not restart ${MEMORY_SERVICE_NAME} after onboarding${detail ? `: ${detail}` : "."}`,
+    );
+  }
+
+  const deadline = Date.now() + STARTUP_TIMEOUT_MS;
+  let lastDetail = "connection refused";
+  while (Date.now() < deadline) {
+    const result = await probeMemoryServiceAuthentication(config);
+    if (result.status === "ready") {
+      const firstPid = await systemdServiceMainPid(MEMORY_SERVICE_NAME);
+      if (firstPid !== null) {
+        await sleep(SERVICE_STABILITY_MS);
+        const secondPid = await systemdServiceMainPid(MEMORY_SERVICE_NAME);
+        if (secondPid === firstPid) return;
+      }
+      lastDetail = `${MEMORY_SERVICE_NAME} has no stable MainPID`;
+    } else {
+      lastDetail = result.detail;
+      if (result.status === "unexpected") {
+        throw new LinuxSystemdGatewayError(
+          `Memory service rejected the post-onboarding configuration (${result.detail}).`,
+        );
+      }
+    }
+    await sleep(POLL_INTERVAL_MS);
+  }
+
+  throw new LinuxSystemdGatewayError(
+    `${MEMORY_SERVICE_NAME} did not become authenticated and ready after onboarding `
+    + `(${lastDetail}). Check \`systemctl --user status ${MEMORY_SERVICE_NAME}\` and `
+    + `\`journalctl --user -u ${MEMORY_SERVICE_NAME}\`.`,
+  );
+}
+
+async function waitForGatewayReady(
+  config: Config,
+  dependencies: Pick<
+    LinuxRootTerminalDependencies,
+    "probeGateway" | "now" | "sleep" | "startupTimeoutMs" | "gatewayServiceMainPid"
+  >,
+): Promise<void> {
+  const probe = dependencies.probeGateway ?? ((candidate) => probeGateway(candidate));
+  const now = dependencies.now ?? Date.now;
+  const wait = dependencies.sleep ?? sleep;
+  const serviceMainPid = dependencies.gatewayServiceMainPid ?? systemdGatewayMainPid;
+  const deadline = now() + (dependencies.startupTimeoutMs ?? STARTUP_TIMEOUT_MS);
+  let lastDetail = "connection refused";
+
+  while (now() < deadline) {
+    const result = await probe(config);
+    if (result.status === "ready") {
+      const firstPid = await serviceMainPid();
+      if (firstPid !== null) {
+        await wait(SERVICE_STABILITY_MS);
+        const secondPid = await serviceMainPid();
+        if (secondPid === firstPid) return;
+      }
+      lastDetail = "memmy-gateway.service has no stable MainPID";
+      continue;
+    }
+    lastDetail = result.detail;
+    if (result.status === "unexpected") {
+      throw new LinuxSystemdGatewayError(
+        `Gateway endpoint is occupied, incompatible, or rejected authentication (${result.detail}).`,
+      );
+    }
+    await wait(POLL_INTERVAL_MS);
+  }
+
+  throw new LinuxSystemdGatewayError(
+    "memmy-gateway.service did not become ready"
+    + ` (${lastDetail}). Check \`systemctl --user status memmy-gateway.service\` and `
+    + "`journalctl --user -u memmy-gateway.service`.",
+  );
+}
+
+export async function runLinuxRootTerminal(
+  dependencies: LinuxRootTerminalDependencies,
+): Promise<unknown> {
+  const platform = dependencies.platform ?? process.platform;
+  const stdinIsTTY = dependencies.stdinIsTTY ?? Boolean(process.stdin.isTTY);
+  const stdoutIsTTY = dependencies.stdoutIsTTY ?? Boolean(process.stdout.isTTY);
+  const systemdGatewayEnabled = dependencies.systemdGatewayEnabled
+    ?? process.env[SYSTEMD_GATEWAY_ENV] === "1";
+  if (platform !== "linux" || !stdinIsTTY || !stdoutIsTTY || !systemdGatewayEnabled) {
+    return dependencies.runInteractive();
+  }
+
+  let config = dependencies.loadConfig();
+  let onboarded = false;
+  if (!hasUsableDefaultModel(config)) {
+    await dependencies.onboardWizard();
+    onboarded = true;
+    config = dependencies.loadConfig();
+    if (!hasUsableDefaultModel(config)) {
+      throw new LinuxSystemdGatewayError(
+        "No usable default model was saved. Run `memmy onboard --wizard` to finish configuration.",
+      );
+    }
+  }
+
+  const probe = dependencies.probeGateway ?? ((candidate) => probeGateway(candidate));
+  const serviceMainPid = dependencies.gatewayServiceMainPid ?? systemdGatewayMainPid;
+  let result = await probe(config);
+  let servicePid = await serviceMainPid();
+  let restart = false;
+
+  if (result.status === "ready" && servicePid === null) {
+    throw new LinuxSystemdGatewayError(
+      "A compatible Gateway is already running outside memmy-gateway.service. "
+      + "Stop that Gateway before starting the installed Memmy CLI.",
+    );
+  }
+  if (result.status === "unexpected" && servicePid === null) {
+    throw new LinuxSystemdGatewayError(
+      `Gateway endpoint is occupied, incompatible, or rejected authentication (${result.detail}).`,
+    );
+  }
+
+  if (result.status !== "ready") {
+    config = dependencies.prepareGatewayConfig
+      ? await dependencies.prepareGatewayConfig()
+      : await prepareLinuxGatewayConfig(dependencies.loadConfig);
+    restart = servicePid !== null;
+    result = await probe(config);
+    servicePid = await serviceMainPid();
+    if (result.status === "ready" && servicePid === null) {
+      throw new LinuxSystemdGatewayError(
+        "A compatible Gateway is already running outside memmy-gateway.service. "
+        + "Stop that Gateway before starting the installed Memmy CLI.",
+      );
+    }
+    if (result.status === "unexpected" && servicePid === null) {
+      throw new LinuxSystemdGatewayError(
+        `Gateway endpoint is occupied, incompatible, or rejected authentication (${result.detail}).`,
+      );
+    }
+  }
+
+  if (onboarded) {
+    await (dependencies.refreshMemoryService ?? refreshSystemdMemoryService)(config);
+  }
+
+  const environmentChanged = dependencies.prepareGatewayEnvironment
+    ? await dependencies.prepareGatewayEnvironment()
+    : await prepareSystemdGatewayEnvironment();
+  restart ||= environmentChanged || result.status === "unexpected";
+  await (dependencies.enableGatewayService ?? enableSystemdGatewayService)({ restart });
+  await waitForGatewayReady(config, dependencies);
+
+  return dependencies.runInteractive(config);
+}

--- a/App/memmy-agent/src/entrypoints/cli/root-terminal-options.ts
+++ b/App/memmy-agent/src/entrypoints/cli/root-terminal-options.ts
@@ -1,0 +1,36 @@
+export type RootTerminalOptions = {
+  sessionId?: string;
+  standalone?: boolean;
+  project?: string;
+};
+
+export function parseRootTerminalOptions(argv: string[]): RootTerminalOptions | null {
+  if (argv.length <= 2) return {};
+
+  const args = argv.slice(2);
+  const options: RootTerminalOptions = {};
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "--standalone") {
+      options.standalone = true;
+    } else if (arg === "--session" || arg === "-s") {
+      const value = args[++index];
+      if (!value || value.startsWith("-")) throw new Error("--session requires a sessionId");
+      options.sessionId = value;
+    } else if (arg === "--project") {
+      const value = args[++index];
+      if (!value || value.startsWith("-")) throw new Error("--project requires a path");
+      options.project = value;
+    } else {
+      return null;
+    }
+  }
+
+  const selected = Number(Boolean(options.sessionId))
+    + Number(Boolean(options.standalone))
+    + Number(Boolean(options.project));
+  if (selected > 1) {
+    throw new Error("--session, --standalone, and --project are mutually exclusive");
+  }
+  return options;
+}

--- a/App/memmy-agent/src/main.ts
+++ b/App/memmy-agent/src/main.ts
@@ -3,14 +3,14 @@
 import "./load-env.js";
 import { main } from "./entrypoints/cli/commands.js";
 import { ConfigError } from "./config/loader.js";
+import { LinuxSystemdGatewayError } from "./entrypoints/cli/linux-systemd-gateway.js";
 
 try {
   await main();
 } catch (error) {
-  if (!(error instanceof ConfigError)) throw error;
-  // Config load/validation failures are expected user-facing errors (bad YAML, invalid
-  // field, missing env var reference) — report them as a concise fatal message instead of
-  // an unhandled-rejection stack trace, and exit non-zero so scripts can detect the failure.
+  if (!(error instanceof ConfigError) && !(error instanceof LinuxSystemdGatewayError)) throw error;
+  // Config validation and Linux systemd Gateway failures are expected user-facing errors.
+  // Report them concisely and exit non-zero so scripts can detect the failure.
   console.error(`memmy: ${error.message}`);
   process.exitCode = 1;
 }

--- a/App/memmy-agent/tests/entrypoints/cli/gateway-lifecycle.test.ts
+++ b/App/memmy-agent/tests/entrypoints/cli/gateway-lifecycle.test.ts
@@ -1,0 +1,44 @@
+import { EventEmitter } from "node:events";
+import { describe, expect, it, vi } from "vitest";
+import {
+  installGatewaySignalLifecycle,
+  type GatewayRuntime,
+} from "../../../src/entrypoints/cli/commands.js";
+
+describe("Gateway signal lifecycle", () => {
+  it("stops the runtime once before exiting successfully on SIGTERM", async () => {
+    const lifecycle = new EventEmitter() as EventEmitter & {
+      exit: ReturnType<typeof vi.fn>;
+    };
+    lifecycle.exit = vi.fn();
+    const stop = vi.fn(async () => undefined);
+    const runtime = { stop } as unknown as GatewayRuntime;
+
+    installGatewaySignalLifecycle(runtime, lifecycle as never);
+    lifecycle.emit("SIGTERM");
+    lifecycle.emit("SIGTERM");
+
+    await vi.waitFor(() => {
+      expect(stop).toHaveBeenCalledTimes(1);
+      expect(lifecycle.exit).toHaveBeenCalledWith(0);
+    });
+  });
+
+  it("exits unsuccessfully when graceful shutdown fails", async () => {
+    const lifecycle = new EventEmitter() as EventEmitter & {
+      exit: ReturnType<typeof vi.fn>;
+    };
+    lifecycle.exit = vi.fn();
+    const runtime = {
+      stop: vi.fn(async () => {
+        throw new Error("flush failed");
+      }),
+    } as unknown as GatewayRuntime;
+
+    installGatewaySignalLifecycle(runtime, lifecycle as never);
+    lifecycle.emit("SIGINT");
+
+    await vi.waitFor(() => expect(lifecycle.exit).toHaveBeenCalledWith(1));
+  });
+
+});

--- a/App/memmy-agent/tests/entrypoints/cli/linux-systemd-gateway.test.ts
+++ b/App/memmy-agent/tests/entrypoints/cli/linux-systemd-gateway.test.ts
@@ -1,0 +1,392 @@
+import {
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import YAML from "yaml";
+import { Config } from "../../../src/config/schema.js";
+import {
+  hasUsableDefaultModel,
+  prepareLinuxGatewayConfig,
+  prepareSystemdGatewayEnvironment,
+  probeGateway,
+  probeMemoryServiceAuthentication,
+  runLinuxRootTerminal,
+  type GatewayProbe,
+} from "../../../src/entrypoints/cli/linux-systemd-gateway.js";
+
+const temporaryRoots: string[] = [];
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+function configured(): Config {
+  return new Config({
+    agents: { defaults: { model: "ollama/llama3.2" } },
+    channels: {
+      websocket: {
+        enabled: true,
+        host: "127.0.0.1",
+        port: 18980,
+        tokenIssueSecret: "secret",
+      },
+    },
+  });
+}
+
+function bootstrapResponse(status = 200): Response {
+  return new Response(JSON.stringify({
+    token: "gateway-token",
+    ws_path: "/",
+    expires_in: 300,
+    model_name: "test-model",
+    model_selection: null,
+    tool_names: [],
+  }), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function refused(): TypeError {
+  const error = new TypeError("fetch failed") as TypeError & { cause?: NodeJS.ErrnoException };
+  error.cause = Object.assign(new Error("connect ECONNREFUSED"), { code: "ECONNREFUSED" });
+  return error;
+}
+
+describe("Linux systemd Gateway probing", () => {
+  it("uses the configured bootstrap secret and accepts only a compatible response", async () => {
+    const fetchImpl = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+      expect(init?.headers).toEqual({ authorization: "Bearer secret" });
+      return bootstrapResponse();
+    }) as unknown as typeof fetch;
+
+    await expect(probeGateway(configured(), { fetchImpl })).resolves.toEqual({ status: "ready" });
+  });
+
+  it("distinguishes a refused connection from authentication and protocol conflicts", async () => {
+    const unavailableFetch = vi.fn(async () => {
+      throw refused();
+    }) as unknown as typeof fetch;
+    const unauthorizedFetch = vi.fn(
+      async () => new Response("Unauthorized", { status: 401 }),
+    ) as unknown as typeof fetch;
+    const invalidFetch = vi.fn(async () => new Response("{}", {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    })) as unknown as typeof fetch;
+
+    await expect(probeGateway(configured(), { fetchImpl: unavailableFetch })).resolves.toMatchObject({
+      status: "unavailable",
+    });
+    await expect(probeGateway(configured(), { fetchImpl: unauthorizedFetch })).resolves.toEqual({
+      status: "unexpected",
+      detail: "bootstrap HTTP 401",
+    });
+    await expect(probeGateway(configured(), { fetchImpl: invalidFetch })).resolves.toEqual({
+      status: "unexpected",
+      detail: "bootstrap response is incompatible",
+    });
+  });
+
+  it("treats a disabled WebSocket channel as requiring service configuration", async () => {
+    await expect(probeGateway(new Config(), {
+      fetchImpl: vi.fn() as unknown as typeof fetch,
+    })).resolves.toMatchObject({
+      status: "unavailable",
+      detail: expect.stringContaining("WebSocket Gateway is disabled"),
+    });
+  });
+
+  it("treats a probe timeout as temporarily unavailable", async () => {
+    const timedOutFetch = vi.fn(async (_input: string | URL | Request, init?: RequestInit) => {
+      await new Promise((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => {
+          reject(new DOMException("timed out", "AbortError"));
+        });
+      });
+      return bootstrapResponse();
+    }) as unknown as typeof fetch;
+
+    await expect(probeGateway(configured(), {
+      fetchImpl: timedOutFetch,
+      timeoutMs: 1,
+    })).resolves.toMatchObject({ status: "unavailable" });
+  });
+});
+
+describe("Linux systemd Memory authentication probing", () => {
+  it("uses the configured Memory token and rejects a stale service token", async () => {
+    const config = new Config({
+      memmyMemory: {
+        storage: {
+          endpoint: "http://127.0.0.1:18960",
+          token: "current-memory-token",
+        },
+      },
+    });
+    const readyFetch = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+      expect(init?.headers).toEqual({ authorization: "Bearer current-memory-token" });
+      return new Response("{}", { status: 200 });
+    }) as unknown as typeof fetch;
+    const staleFetch = vi.fn(async () => new Response("Unauthorized", {
+      status: 401,
+    })) as unknown as typeof fetch;
+
+    await expect(probeMemoryServiceAuthentication(config, { fetchImpl: readyFetch }))
+      .resolves.toEqual({ status: "ready" });
+    await expect(probeMemoryServiceAuthentication(config, { fetchImpl: staleFetch }))
+      .resolves.toEqual({
+        status: "unexpected",
+        detail: "authenticated Memory HTTP 401",
+      });
+  });
+});
+
+describe("Linux systemd Gateway configuration", () => {
+  it("enables localhost defaults without overwriting custom endpoints", async () => {
+    const root = mkdtempSync(join(tmpdir(), "memmy-linux-systemd-config-"));
+    temporaryRoots.push(root);
+    const configPath = join(root, "config.yaml");
+    writeFileSync(configPath, YAML.stringify({
+      channels: { websocket: { enabled: false, host: "127.0.0.2", port: 29999 } },
+      gateway: { enabled: false, host: "127.0.0.3", port: 29998 },
+      futureSection: { keep: true },
+    }));
+    const load = () => new Config(YAML.parse(readFileSync(configPath, "utf8")));
+
+    const result = await prepareLinuxGatewayConfig(load, configPath);
+    const saved = YAML.parse(readFileSync(configPath, "utf8"));
+
+    expect(saved).toMatchObject({
+      channels: {
+        websocket: {
+          enabled: true,
+          host: "127.0.0.2",
+          port: 29999,
+          websocketRequiresToken: true,
+        },
+      },
+      gateway: { enabled: true, host: "127.0.0.3", port: 29998 },
+      futureSection: { keep: true },
+    });
+    expect(saved.channels.websocket.tokenIssueSecret).toMatch(/^[a-f0-9]{64}$/);
+    expect((result.channels as unknown as { websocket: Record<string, unknown> }).websocket)
+      .toMatchObject({ host: "127.0.0.2", port: 29999 });
+  });
+
+  it("persists referenced credentials and runtime PATH in a private environment file", async () => {
+    const root = mkdtempSync(join(tmpdir(), "memmy-linux-systemd-env-"));
+    temporaryRoots.push(root);
+    const configPath = join(root, "config.yaml");
+    const destination = join(root, "private", "gateway.env");
+    writeFileSync(configPath, [
+      "providers:",
+      "  custom:",
+      "    apiKey: ${CUSTOM_PROVIDER_TOKEN}",
+      "    apiBase: ${CUSTOM_API_BASE:https://fallback.invalid}",
+      "",
+    ].join("\n"));
+    const env = {
+      PATH: "/home/test/bin:/usr/bin",
+      CUSTOM_PROVIDER_TOKEN: 'secret with spaces and "quotes"',
+      OPENAI_API_KEY: "implicit-openai-key",
+    };
+
+    await expect(prepareSystemdGatewayEnvironment({
+      configPath,
+      destination,
+      env,
+    })).resolves.toBe(true);
+    const saved = readFileSync(destination, "utf8");
+    expect(saved).toContain('PATH="/home/test/bin:/usr/bin"');
+    expect(saved).toContain('CUSTOM_PROVIDER_TOKEN="secret with spaces and \\"quotes\\""');
+    expect(saved).toContain('OPENAI_API_KEY="implicit-openai-key"');
+    expect(saved).not.toContain("CUSTOM_API_BASE=");
+    expect(statSync(destination).mode & 0o777).toBe(0o600);
+
+    await expect(prepareSystemdGatewayEnvironment({
+      configPath,
+      destination,
+      env,
+    })).resolves.toBe(false);
+  });
+
+  it("rejects multiline values instead of emitting an injectable EnvironmentFile", async () => {
+    const root = mkdtempSync(join(tmpdir(), "memmy-linux-systemd-env-invalid-"));
+    temporaryRoots.push(root);
+    const configPath = join(root, "config.yaml");
+    writeFileSync(configPath, "apiKey: ${CUSTOM_PROVIDER_TOKEN}\n");
+
+    await expect(prepareSystemdGatewayEnvironment({
+      configPath,
+      destination: join(root, "gateway.env"),
+      env: { CUSTOM_PROVIDER_TOKEN: "first\nsecond" },
+    })).rejects.toThrow("contains a newline or NUL");
+  });
+});
+
+describe("Linux systemd Gateway root terminal flow", () => {
+  it("runs onboarding, enables the user service, waits for readiness, and leaves it running", async () => {
+    let current = new Config();
+    let serviceRunning = false;
+    const prepared = configured();
+    const order: string[] = [];
+    const probes: GatewayProbe[] = [
+      { status: "unavailable", detail: "disabled" },
+      { status: "unavailable", detail: "connection refused" },
+      { status: "unavailable", detail: "starting" },
+      { status: "ready" },
+    ];
+
+    await runLinuxRootTerminal({
+      platform: "linux",
+      stdinIsTTY: true,
+      stdoutIsTTY: true,
+      systemdGatewayEnabled: true,
+      loadConfig: () => current,
+      onboardWizard: async () => {
+        order.push("wizard");
+        current = configured();
+      },
+      prepareGatewayConfig: async () => {
+        order.push("prepare");
+        current = prepared;
+        return prepared;
+      },
+      refreshMemoryService: async (config) => {
+        order.push("memory");
+        expect(config).toBe(prepared);
+      },
+      prepareGatewayEnvironment: async () => {
+        order.push("environment");
+        return true;
+      },
+      enableGatewayService: async (options) => {
+        order.push(`systemd:${String(options?.restart)}`);
+        serviceRunning = true;
+      },
+      probeGateway: vi.fn(async (): Promise<GatewayProbe> => probes.shift() ?? { status: "ready" }),
+      gatewayServiceMainPid: vi.fn(async () => serviceRunning ? 123 : null),
+      sleep: async () => undefined,
+      runInteractive: async (config) => {
+        order.push("tui");
+        expect(config).toBe(prepared);
+        return null;
+      },
+    });
+
+    expect(order).toEqual([
+      "wizard",
+      "prepare",
+      "memory",
+      "environment",
+      "systemd:true",
+      "tui",
+    ]);
+  });
+
+  it("keeps systemd ownership and restarts when the persisted environment changes", async () => {
+    const config = configured();
+    const prepareGatewayConfig = vi.fn(async () => config);
+    const refreshMemoryService = vi.fn(async () => undefined);
+    const enableGatewayService = vi.fn(async () => undefined);
+    const runInteractive = vi.fn(async () => null);
+
+    await runLinuxRootTerminal({
+      platform: "linux",
+      stdinIsTTY: true,
+      stdoutIsTTY: true,
+      systemdGatewayEnabled: true,
+      loadConfig: () => config,
+      onboardWizard: vi.fn(),
+      prepareGatewayConfig,
+      refreshMemoryService,
+      prepareGatewayEnvironment: async () => true,
+      enableGatewayService,
+      probeGateway: vi.fn(async (): Promise<GatewayProbe> => ({ status: "ready" })),
+      gatewayServiceMainPid: vi.fn(async () => 456),
+      sleep: async () => undefined,
+      runInteractive,
+    });
+
+    expect(prepareGatewayConfig).not.toHaveBeenCalled();
+    expect(refreshMemoryService).not.toHaveBeenCalled();
+    expect(enableGatewayService).toHaveBeenCalledWith({ restart: true });
+    expect(runInteractive).toHaveBeenCalledWith(config);
+  });
+
+  it("refuses to take over a compatible Gateway not owned by the user service", async () => {
+    const enableGatewayService = vi.fn(async () => undefined);
+
+    await expect(runLinuxRootTerminal({
+      platform: "linux",
+      stdinIsTTY: true,
+      stdoutIsTTY: true,
+      systemdGatewayEnabled: true,
+      loadConfig: configured,
+      onboardWizard: vi.fn(),
+      prepareGatewayEnvironment: async () => false,
+      enableGatewayService,
+      probeGateway: vi.fn(async (): Promise<GatewayProbe> => ({ status: "ready" })),
+      gatewayServiceMainPid: vi.fn(async () => null),
+      runInteractive: vi.fn(async () => null),
+    })).rejects.toThrow("already running outside memmy-gateway.service");
+
+    expect(enableGatewayService).not.toHaveBeenCalled();
+  });
+
+  it("does not start over an incompatible or unauthorized external endpoint", async () => {
+    const enableGatewayService = vi.fn(async () => undefined);
+
+    await expect(runLinuxRootTerminal({
+      platform: "linux",
+      stdinIsTTY: true,
+      stdoutIsTTY: true,
+      systemdGatewayEnabled: true,
+      loadConfig: configured,
+      onboardWizard: vi.fn(),
+      prepareGatewayEnvironment: async () => false,
+      enableGatewayService,
+      probeGateway: vi.fn(async (): Promise<GatewayProbe> => ({
+        status: "unexpected",
+        detail: "bootstrap HTTP 401",
+      })),
+      gatewayServiceMainPid: vi.fn(async () => null),
+      runInteractive: vi.fn(async () => null),
+    })).rejects.toThrow("occupied, incompatible, or rejected authentication");
+
+    expect(enableGatewayService).not.toHaveBeenCalled();
+  });
+
+  it("leaves source-built Linux, non-Linux, and non-TTY invocations unchanged", async () => {
+    const loadConfig = vi.fn(configured);
+    const runInteractive = vi.fn(async () => null);
+
+    await runLinuxRootTerminal({
+      platform: "linux",
+      stdinIsTTY: true,
+      stdoutIsTTY: true,
+      systemdGatewayEnabled: false,
+      loadConfig,
+      onboardWizard: vi.fn(),
+      runInteractive,
+    });
+
+    expect(loadConfig).not.toHaveBeenCalled();
+    expect(runInteractive).toHaveBeenCalledWith();
+  });
+
+  it("detects whether a usable model is configured", () => {
+    expect(hasUsableDefaultModel(configured())).toBe(true);
+    expect(hasUsableDefaultModel(new Config())).toBe(false);
+  });
+});

--- a/App/memmy-agent/tests/entrypoints/cli/root-terminal-options.test.ts
+++ b/App/memmy-agent/tests/entrypoints/cli/root-terminal-options.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseRootTerminalOptions,
+  type RootTerminalOptions,
+} from "../../../src/entrypoints/cli/root-terminal-options.js";
+
+const argv = (...args: string[]): string[] => ["node", "memmy", ...args];
+
+describe("parseRootTerminalOptions", () => {
+  it.each<[string[], RootTerminalOptions]>([
+    [argv(), {}],
+    [argv("--standalone"), { standalone: true }],
+    [argv("--session", "cli:one"), { sessionId: "cli:one" }],
+    [argv("-s", "cli:short"), { sessionId: "cli:short" }],
+    [argv("--project", "/tmp/project"), { project: "/tmp/project" }],
+  ])("recognizes root terminal arguments: %j", (input, expected) => {
+    expect(parseRootTerminalOptions(input)).toEqual(expected);
+  });
+
+  it.each([
+    [argv("--session"), "--session requires a sessionId"],
+    [argv("-s"), "--session requires a sessionId"],
+    [argv("--session", "--standalone"), "--session requires a sessionId"],
+    [argv("--project"), "--project requires a path"],
+    [argv("--project", "--standalone"), "--project requires a path"],
+  ])("rejects a missing root option value: %j", (input, message) => {
+    expect(() => parseRootTerminalOptions(input)).toThrow(message);
+  });
+
+  it.each([
+    { input: argv("--standalone", "--session", "cli:one") },
+    { input: argv("--standalone", "--project", "/tmp/project") },
+    { input: argv("--session", "cli:one", "--project", "/tmp/project") },
+  ])("rejects mutually exclusive root terminal options: $input", ({ input }) => {
+    expect(() => parseRootTerminalOptions(input)).toThrow(
+      "--session, --standalone, and --project are mutually exclusive",
+    );
+  });
+
+  it.each([
+    { input: argv("--help") },
+    { input: argv("-h") },
+    { input: argv("--version") },
+    { input: argv("-V") },
+    { input: argv("gateway") },
+    { input: argv("onboard", "--wizard") },
+  ])("leaves help, version, and subcommands to Commander: $input", ({ input }) => {
+    expect(parseRootTerminalOptions(input)).toBeNull();
+  });
+});

--- a/App/memmy-agent/tests/entrypoints/cli/terminal-target.test.ts
+++ b/App/memmy-agent/tests/entrypoints/cli/terminal-target.test.ts
@@ -102,6 +102,15 @@ describe("terminal target resolution", () => {
     })).toThrow("mutually exclusive");
   });
 
+  it("directs an unconfigured terminal session to the interactive wizard", () => {
+    const { dependencies } = makeLoop();
+    dependencies.hasUsableDefaultModel = () => false;
+
+    expect(() => resolveTerminalTarget(dependencies, { standalone: true })).toThrow(
+      "No usable default model is configured. Run `memmy onboard --wizard` first.",
+    );
+  });
+
   it("accepts project paths, reuses the registered canonical root, and fixes each binding", () => {
     const { root, dependencies } = makeLoop();
     const projectPath = path.join(root, "code", "memmy");

--- a/Memory/src/cli/commands.ts
+++ b/Memory/src/cli/commands.ts
@@ -471,6 +471,7 @@ function setupOptions(parsed: ParsedArgs): {
   agentRoot?: string;
   assetRoot?: string;
   skipAgentSkills?: boolean;
+  generateTokenIfMissing?: boolean;
 } {
   return {
     home: optionString(parsed.options, "home"),
@@ -485,7 +486,8 @@ function setupOptions(parsed: ParsedArgs): {
     agents: optionValues(parsed.options, "agent"),
     agentRoot: optionString(parsed.options, "agent-root"),
     assetRoot: optionString(parsed.options, "asset-root"),
-    skipAgentSkills: optionBoolean(parsed.options, "skip-agent-skills")
+    skipAgentSkills: optionBoolean(parsed.options, "skip-agent-skills"),
+    generateTokenIfMissing: optionBoolean(parsed.options, "generate-token-if-missing")
   };
 }
 

--- a/Memory/src/cli/setup.ts
+++ b/Memory/src/cli/setup.ts
@@ -7,6 +7,7 @@ import {
   symlinkSync,
   unlinkSync
 } from "node:fs";
+import crypto from "node:crypto";
 import { dirname, join, resolve } from "node:path";
 import { asRecord, expandHome, optionalString } from "./config.js";
 import {
@@ -29,6 +30,7 @@ export interface MemoryCliSetupOptions {
   agentRoot?: string;
   assetRoot?: string;
   skipAgentSkills?: boolean;
+  generateTokenIfMissing?: boolean;
 }
 
 export async function initMemoryCli(options: MemoryCliSetupOptions = {}): Promise<Record<string, unknown>> {
@@ -41,7 +43,12 @@ export async function initMemoryCli(options: MemoryCliSetupOptions = {}): Promis
     mkdirSync(home, { recursive: true });
     mkdirSync(dirname(configPath), { recursive: true });
     await mutateRuntimeConfig(configPath, (config) => {
-      setupMemoryConfig(config, { dbPath, endpoint, token: options.token });
+      setupMemoryConfig(config, {
+        dbPath,
+        endpoint,
+        token: options.token,
+        generateTokenIfMissing: options.generateTokenIfMissing,
+      });
     });
   }
 
@@ -57,6 +64,7 @@ export async function initMemoryCli(options: MemoryCliSetupOptions = {}): Promis
     agentInstallations = await installMemmyMemorySkillForAgents(requestedAgents, {
       agentRoot: options.agents?.length ? options.agentRoot : undefined,
       assetRoot: options.assetRoot,
+      memmyConfigPath: configPath,
       dryRun: options.dryRun,
       skipUnavailable: !options.agents?.length
     });
@@ -122,6 +130,7 @@ function setupMemoryConfig(
     dbPath: string;
     endpoint: string;
     token?: string;
+    generateTokenIfMissing?: boolean;
   }
 ): void {
   const app = asRecord(config.app);
@@ -131,7 +140,8 @@ function setupMemoryConfig(
     appUserId,
     dbPath: options.dbPath,
     endpoint: options.endpoint,
-    token: options.token
+    token: options.token,
+    generateTokenIfMissing: options.generateTokenIfMissing,
   });
 }
 
@@ -142,12 +152,17 @@ function setupMemmyMemoryConfig(
     dbPath: string;
     endpoint: string;
     token?: string;
+    generateTokenIfMissing?: boolean;
   }
 ): Record<string, unknown> {
   const roleRouting = asRecord(existing.roleRouting);
   const embedding = asRecord(existing.embedding);
   const storage = asRecord(existing.storage);
   const algorithm = asRecord(existing.algorithm);
+  const existingToken = optionalString(storage.token);
+  const token = options.token
+    ?? existingToken
+    ?? (options.generateTokenIfMissing ? crypto.randomBytes(32).toString("hex") : undefined);
   validateEmbeddingForSetup(embedding);
   const memmyMemory: Record<string, unknown> = {
     ...existing,
@@ -164,7 +179,7 @@ function setupMemmyMemoryConfig(
       backend: "sqlite",
       sqlitePath: options.dbPath,
       endpoint: options.endpoint,
-      ...(options.token !== undefined ? { token: options.token } : {})
+      ...(token !== undefined ? { token } : {})
     },
     algorithm: {
       ...algorithm,

--- a/Memory/src/cli/skill-writer/index.ts
+++ b/Memory/src/cli/skill-writer/index.ts
@@ -1,7 +1,7 @@
 import { cp, mkdir, readFile, rename, rm, stat, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { basename, dirname, join, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 export const SUPPORTED_MEMMY_AGENT_IDS = ["codex", "cursor", "claude", "opencode", "openclaw", "hermes"] as const;
 export type MemmyAgentId = typeof SUPPORTED_MEMMY_AGENT_IDS[number];
@@ -14,6 +14,7 @@ export interface AgentSkillInstallOptions {
 
 export interface AgentSkillBatchInstallOptions extends AgentSkillInstallOptions {
   skipUnavailable?: boolean;
+  memmyConfigPath?: string;
 }
 
 export interface AgentSkillInstallResult {
@@ -66,6 +67,11 @@ export async function installMemmyMemorySkillForAgents(
   agents: string[],
   options: AgentSkillBatchInstallOptions = {}
 ): Promise<AgentSkillInstallResult[]> {
+  if (process.env.MEMMY_AGENT_INTEGRATION_ROOT?.trim() && options.agentRoot && !options.dryRun) {
+    throw new Error(
+      "--agent-root cannot be combined with packaged Hook/plugin integration; use the agent's configured home",
+    );
+  }
   const results = await Promise.all(
     normalizeAgentIds(agents).map(async (agent) => {
       if (options.skipUnavailable && !(await isExistingDirectory(targetForAgent(agent, options.agentRoot).root))) {
@@ -74,7 +80,52 @@ export async function installMemmyMemorySkillForAgents(
       return installMemmyMemorySkillForAgent(agent, options);
     })
   );
-  return results.filter((result): result is AgentSkillInstallResult => result !== null);
+  const installed = results.filter((result): result is AgentSkillInstallResult => result !== null);
+  await installPackagedAgentIntegrations(installed, options);
+  return installed;
+}
+
+type PackagedIntegrationTarget = {
+  installPlugin?: (targetId: string) => Promise<void>;
+};
+
+type PackagedIntegrationRegistry = {
+  get: (targetId: string) => PackagedIntegrationTarget | undefined;
+};
+
+type PackagedIntegrationModule = {
+  createBuiltinSkillTargetRegistry: (memmyConfigPath?: string) => PackagedIntegrationRegistry;
+};
+
+async function installPackagedAgentIntegrations(
+  installed: AgentSkillInstallResult[],
+  options: AgentSkillBatchInstallOptions,
+): Promise<void> {
+  const integrationRoot = process.env.MEMMY_AGENT_INTEGRATION_ROOT?.trim();
+  if (!integrationRoot || options.dryRun || installed.length === 0) return;
+
+  const modulePath = join(
+    resolve(expandHome(integrationRoot)),
+    "services",
+    "builtin-skill-target-registry.js",
+  );
+  if (!(await pathExists(modulePath))) {
+    throw new Error(`packaged agent integration registry not found: ${modulePath}`);
+  }
+
+  const integrationModule = await import(pathToFileURL(modulePath).href) as PackagedIntegrationModule;
+  if (typeof integrationModule.createBuiltinSkillTargetRegistry !== "function") {
+    throw new Error(`invalid packaged agent integration registry: ${modulePath}`);
+  }
+  const registry = integrationModule.createBuiltinSkillTargetRegistry(options.memmyConfigPath);
+  for (const result of installed) {
+    const targetId = result.agent === "claude" ? "claude_code" : result.agent;
+    const target = registry.get(targetId);
+    if (!target?.installPlugin) {
+      throw new Error(`packaged Hook/plugin integration is unavailable for ${result.agent}`);
+    }
+    await target.installPlugin(targetId);
+  }
 }
 
 export async function installMemmyMemorySkillForAgent(

--- a/Memory/tests/cli-setup.test.ts
+++ b/Memory/tests/cli-setup.test.ts
@@ -76,6 +76,118 @@ describe("memmy-memory CLI setup commands", () => {
     expect(existsSync(dbPath)).toBe(false);
   });
 
+  it("generates an authentication token only when explicitly requested", async () => {
+    const root = tempRoot();
+    const configPath = join(root, "config.yaml");
+    createAllAgentRoots(root);
+    setEnv("HOME", root);
+
+    await runCommand({
+      argv: [
+        "init",
+        "--home", root,
+        "--config", configPath,
+        "--db", join(root, "memory.sqlite"),
+        "--skip-agent-skills",
+        "--generate-token-if-missing"
+      ]
+    });
+
+    const saved = YAML.parse(readFileSync(configPath, "utf8"));
+    expect(saved.memmyMemory.storage.token).toMatch(/^[a-f0-9]{64}$/);
+    expect(existsSync(join(root, ".codex", "skills", "memmy-memory"))).toBe(false);
+  });
+
+  it("preserves an existing authentication token when initialization is repeated", async () => {
+    const root = tempRoot();
+    const configPath = join(root, "config.yaml");
+    writeFileSync(configPath, [
+      "memmyMemory:",
+      "  storage:",
+      "    token: keep-this-token",
+      ""
+    ].join("\n"));
+    createAllAgentRoots(root);
+    setEnv("HOME", root);
+
+    await runCommand({
+      argv: [
+        "init",
+        "--home", root,
+        "--config", configPath,
+        "--db", join(root, "memory.sqlite"),
+        "--skip-agent-skills",
+        "--generate-token-if-missing"
+      ]
+    });
+
+    const saved = YAML.parse(readFileSync(configPath, "utf8"));
+    expect(saved.memmyMemory.storage.token).toBe("keep-this-token");
+  });
+
+  it("uses packaged Hook/plugin integration only after an explicit agent init", async () => {
+    const root = tempRoot();
+    const integrationRoot = join(root, "integration-runtime");
+    const markerPath = join(root, "plugin-installed.json");
+    mkdirSync(join(integrationRoot, "services"), { recursive: true });
+    writeFileSync(join(integrationRoot, "package.json"), JSON.stringify({ type: "module" }));
+    writeFileSync(
+      join(integrationRoot, "services", "builtin-skill-target-registry.js"),
+      [
+        "import { writeFile } from 'node:fs/promises';",
+        "export function createBuiltinSkillTargetRegistry(configPath) {",
+        "  return {",
+        "    get(targetId) {",
+        "      return {",
+        "        async installPlugin(installedTargetId) {",
+        "          await writeFile(process.env.MEMMY_TEST_PLUGIN_MARKER, JSON.stringify({ configPath, targetId, installedTargetId }));",
+        "        }",
+        "      };",
+        "    },",
+        "  };",
+        "}",
+        "",
+      ].join("\n"),
+    );
+    createAllAgentRoots(root);
+    setEnv("HOME", root);
+    setEnv("MEMMY_AGENT_INTEGRATION_ROOT", integrationRoot);
+    setEnv("MEMMY_TEST_PLUGIN_MARKER", markerPath);
+    const configPath = join(root, "config.yaml");
+
+    await runCommand({
+      argv: [
+        "init",
+        "--home", root,
+        "--config", configPath,
+        "--db", join(root, "memory.sqlite"),
+        "--agent", "codex",
+      ],
+    });
+
+    expect(JSON.parse(readFileSync(markerPath, "utf8"))).toEqual({
+      configPath,
+      targetId: "codex",
+      installedTargetId: "codex",
+    });
+  });
+
+  it("does not load packaged agent integrations during installer-style initialization", async () => {
+    const root = tempRoot();
+    setEnv("HOME", root);
+    setEnv("MEMMY_AGENT_INTEGRATION_ROOT", join(root, "missing-integration-runtime"));
+
+    await expect(runCommand({
+      argv: [
+        "init",
+        "--home", root,
+        "--config", join(root, "config.yaml"),
+        "--db", join(root, "memory.sqlite"),
+        "--skip-agent-skills",
+      ],
+    })).resolves.toMatchObject({ ok: true });
+  });
+
   it("renders init results as a human-friendly success message", async () => {
     const root = tempRoot();
     createAllAgentRoots(root);

--- a/README.md
+++ b/README.md
@@ -137,6 +137,24 @@ Compared with "personal AI Agents" like Hermes and OpenClaw, what sets
 
 ### Option 2: `memmy` CLI (Agent Runtime)
 
+On Linux x64 or arm64 with Node.js 22 or newer and an available systemd user session:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/MemTensor/memmy-agent/main/scripts/install.sh | bash
+memmy
+```
+
+The installer enables the local Memory Service immediately as `memmy-memory.service`. The first bare `memmy` invocation opens the model setup wizard when needed, then enables `memmy-gateway.service`, waits for it to become ready, and enters the TUI. Both are `systemd --user` services bound to localhost and remain available after the TUI or terminal exits. They start again on later logins; the installer does not enable linger. Only the installer launcher activates this service management, so source-built Linux CLIs keep their existing behavior.
+
+Before starting or reconnecting to the Gateway, `memmy` refreshes a private `~/.memmy/systemd/gateway.env` file (mode `0600`) with configuration-referenced environment variables, common Provider credentials, and the terminal `PATH`. If those values change, the next bare `memmy` invocation restarts the user service with the new environment.
+
+```bash
+systemctl --user status memmy-memory.service
+systemctl --user status memmy-gateway.service
+```
+
+The installer initializes Memory without changing Codex, Claude Code, Cursor, or other agents. Run `memmy-memory init` (all detected agents) or `memmy-memory init --agent <agent>` when you explicitly want to install the Memory Skill and the supported Hook/plugin for an agent.
+
 ```bash
 memmy onboard                              # Initialize ~/.memmy/config.yaml and the workspace
 memmy status                               # Check config, workspace, model, and provider status

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -139,6 +139,24 @@ Memmy 不只是一个聊天界面，而是一套运行在本地的 AI Agent 
 
 ### 方式二：`memmy` CLI（Agent Runtime）
 
+Linux x64 或 arm64（需 Node.js 22 或更高版本，并且 systemd 用户会话可用）可一行安装：
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/MemTensor/memmy-agent/main/scripts/install.sh | bash
+memmy
+```
+
+安装器会立即启用本地 Memory Service（`memmy-memory.service`）。首次裸执行 `memmy` 时，如尚未配置模型，会在当前终端进入配置向导；保存后启用 `memmy-gateway.service`，等待就绪并进入 TUI。二者均为只绑定本机地址的 `systemd --user` 服务，退出 TUI 或关闭终端不会停止；以后登录时会自动启动。安装器不会启用 linger。只有安装器生成的 launcher 会启用这套服务管理，源码构建的 Linux CLI 保持原有行为。
+
+启动或重新连接 Gateway 前，`memmy` 会把配置引用的环境变量、常用 Provider 凭据和终端 `PATH` 刷新到权限为 `0600` 的私有文件 `~/.memmy/systemd/gateway.env`。这些值发生变化后，下次裸执行 `memmy` 会使用新环境重启用户服务。
+
+```bash
+systemctl --user status memmy-memory.service
+systemctl --user status memmy-gateway.service
+```
+
+安装阶段只初始化 Memory 基础配置，不会修改 Codex、Claude Code、Cursor 等外部 Agent。需要接入时，由用户明确执行 `memmy-memory init`（接入检测到的 Agent）或 `memmy-memory init --agent <agent>` 安装对应的 Memory Skill 及受支持的 Hook/插件。
+
 ```bash
 memmy onboard                              # 初始化 ~/.memmy/config.yaml 和 workspace
 memmy status                               # 查看配置、workspace、模型、provider 状态

--- a/docs/cn/start/getting-started.mdx
+++ b/docs/cn/start/getting-started.mdx
@@ -16,6 +16,17 @@ icon: Rocket
 
 ## 快速设置
 
+Linux x64 或 arm64 的纯终端用户需先安装 Node.js 22 或更高版本，并确认 systemd 用户会话可用，然后执行：
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/MemTensor/memmy-agent/main/scripts/install.sh | bash
+memmy
+```
+
+安装器会以 `memmy-memory.service` 启动本地 Memory Service。如果尚未配置可用模型，首次裸执行 `memmy` 会打开现有配置向导；保存后启用 `memmy-gateway.service`，等待就绪并进入 TUI。两个 `systemd --user` 服务都不会因退出 TUI 或关闭终端而停止，并会在以后登录时自动启动；安装器不启用 linger。安装器 launcher 还会刷新权限为 `0600` 的私有文件 `~/.memmy/systemd/gateway.env`，确保配置引用的凭据和终端 `PATH` 对常驻 Gateway 可用。
+
+可用 `systemctl --user status memmy-memory.service` 和 `systemctl --user status memmy-gateway.service` 查看状态。安装器不会修改外部 Agent；只有用户明确执行 `memmy-memory init` 或 `memmy-memory init --agent <agent>` 时，才安装对应的 Memory 集成。
+
 下载并安装 Memmy 桌面应用。首次启动会自动完成：
 
 1. 设置 `MEMMY_HOME` 和 `MEMMY_CONFIG`。

--- a/docs/en/start/getting-started.mdx
+++ b/docs/en/start/getting-started.mdx
@@ -16,6 +16,17 @@ icon: Rocket
 
 ## Quick Setup
 
+For a terminal-only installation on Linux x64 or arm64, install Node.js 22 or newer and make sure a systemd user session is available, then run:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/MemTensor/memmy-agent/main/scripts/install.sh | bash
+memmy
+```
+
+The installer starts the local Memory Service as `memmy-memory.service`. If no usable model is configured, the first bare `memmy` command opens the existing wizard. After saving, it enables `memmy-gateway.service`, waits for readiness, and continues into the TUI. Both `systemd --user` services stay running when the TUI or terminal exits and start again on later logins; linger is not enabled. The installer launcher also refreshes a private `~/.memmy/systemd/gateway.env` file (mode `0600`) so configuration-referenced credentials and the terminal `PATH` remain available to the persistent Gateway.
+
+Use `systemctl --user status memmy-memory.service` and `systemctl --user status memmy-gateway.service` to inspect them. The installer does not modify external agents. Run `memmy-memory init` or `memmy-memory init --agent <agent>` explicitly to install Memory integration for an agent.
+
 Download and install the Memmy desktop app. On first launch it automatically:
 
 1. Sets `MEMMY_HOME` and `MEMMY_CONFIG`.

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "test": "npm run test:release-workflow && npm run test:packaging-guards && npm run memory:test && npm run workspace:test && npm run agent:test:tui-cursor",
     "test:release-workflow": "vitest run tests/release-workflow.test.ts tests/oss-crc64.test.mjs",
     "test:packaging-guards": "vitest run tests/package-version-guard.test.mjs tests/packaged-runtime-config.test.mjs tests/package-logging.test.mjs",
+    "test:linux-cli": "vitest run tests/linux-cli-packaging.test.mjs && npm --prefix App/memmy-agent exec vitest run tests/entrypoints/cli/linux-systemd-gateway.test.ts tests/entrypoints/cli/gateway-lifecycle.test.ts tests/entrypoints/cli/root-terminal-options.test.ts tests/entrypoints/cli/terminal-target.test.ts && npm --prefix Memory test -- tests/cli-setup.test.ts",
     "serve": "npm run memory:serve",
     "serve:local": "npm run memory:serve:local",
     "serve:dev": "npm run memory:serve:dev",

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,431 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPOSITORY="${MEMMY_GITHUB_REPOSITORY:-MemTensor/memmy-agent}"
+ARCHIVE_NAME="memmy-agent-linux-cli.tar.gz"
+CHECKSUM_NAME="$ARCHIVE_NAME.sha256"
+INSTALL_ROOT="${MEMMY_INSTALL_ROOT:-$HOME/.local/share/memmy-agent}"
+BIN_DIR="${MEMMY_BIN_DIR:-$HOME/.local/bin}"
+MEMMY_HOME_DIR="${MEMMY_HOME:-$HOME/.memmy}"
+CONFIG_PATH="${MEMMY_CONFIG:-$MEMMY_HOME_DIR/config.yaml}"
+WORKSPACE_DIR="${MEMMY_AGENT_WORKSPACE:-$MEMMY_HOME_DIR/workspace}"
+MEMORY_DB_PATH="${MEMMY_MEMORY_DB:-$MEMMY_HOME_DIR/memory-service/memory.sqlite}"
+SYSTEMD_USER_DIR="${MEMMY_SYSTEMD_USER_DIR:-$HOME/.config/systemd/user}"
+MEMORY_UNIT="$SYSTEMD_USER_DIR/memmy-memory.service"
+GATEWAY_UNIT="$SYSTEMD_USER_DIR/memmy-gateway.service"
+GATEWAY_ENV_FILE="$MEMMY_HOME_DIR/systemd/gateway.env"
+
+fail() {
+  printf 'memmy installer: %s\n' "$*" >&2
+  exit 1
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || fail "required command not found: $1"
+}
+
+if [ "$(uname -s)" != "Linux" ]; then
+  fail "this installer supports Linux only"
+fi
+
+case "$(uname -m)" in
+  x86_64|amd64)
+    PLATFORM_ARCH="x64"
+    ;;
+  aarch64|arm64)
+    PLATFORM_ARCH="arm64"
+    ;;
+  *)
+    fail "unsupported Linux architecture: $(uname -m) (expected x86_64 or arm64)"
+    ;;
+esac
+
+for command_name in node npm curl tar systemctl; do
+  require_command "$command_name"
+done
+if ! command -v sha256sum >/dev/null 2>&1 && ! command -v shasum >/dev/null 2>&1; then
+  fail "required SHA-256 tool not found (install sha256sum or shasum)"
+fi
+
+NODE_MAJOR="$(node -p 'Number(process.versions.node.split(".")[0])')" \
+  || fail "could not determine Node.js version"
+if [ "$NODE_MAJOR" -lt 22 ]; then
+  fail "Node.js 22 or newer is required (found $(node --version))"
+fi
+NODE_BIN="$(command -v node)"
+case "$NODE_BIN" in
+  /*) ;;
+  *) NODE_BIN="$(cd "$(dirname "$NODE_BIN")" && pwd)/$(basename "$NODE_BIN")" ;;
+esac
+
+if ! systemctl --user show-environment >/dev/null 2>&1; then
+  fail "systemd --user is required and no user service manager is available"
+fi
+
+VERSION="${MEMMY_VERSION:-}"
+if [ -z "$VERSION" ]; then
+  LATEST_URL="$(curl --fail --silent --show-error --location \
+    --output /dev/null --write-out '%{url_effective}' \
+    "https://github.com/$REPOSITORY/releases/latest")" \
+    || fail "could not resolve the latest GitHub Release"
+  VERSION="${LATEST_URL##*/}"
+fi
+VERSION="${VERSION#v}"
+if [[ ! "$VERSION" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+  fail "invalid release version: $VERSION"
+fi
+
+if [ -n "${MEMMY_RELEASE_BASE_URL:-}" ]; then
+  ASSET_BASE="${MEMMY_RELEASE_BASE_URL%/}"
+else
+  ASSET_BASE="https://github.com/$REPOSITORY/releases/download/v$VERSION"
+fi
+
+mkdir -p "$INSTALL_ROOT/releases" "$BIN_DIR"
+WORK_DIR="$(mktemp -d "$INSTALL_ROOT/.install.XXXXXX")"
+CONFIG_EXISTED="false"
+CONFIG_BACKUP="$WORK_DIR/config.before-install"
+if [ -f "$CONFIG_PATH" ]; then
+  cp -p "$CONFIG_PATH" "$CONFIG_BACKUP"
+  CONFIG_EXISTED="true"
+fi
+restore_config() {
+  if [ "$CONFIG_EXISTED" = "true" ]; then
+    mkdir -p "$(dirname "$CONFIG_PATH")"
+    cp -p "$CONFIG_BACKUP" "$CONFIG_PATH"
+  else
+    rm -f "$CONFIG_PATH"
+  fi
+}
+cleanup() {
+  rm -rf "$WORK_DIR"
+}
+trap cleanup EXIT
+
+ARCHIVE_PATH="$WORK_DIR/$ARCHIVE_NAME"
+CHECKSUM_PATH="$WORK_DIR/$CHECKSUM_NAME"
+printf 'Downloading Memmy Agent %s for Linux %s...\n' "$VERSION" "$PLATFORM_ARCH"
+curl --fail --silent --show-error --location --retry 3 --retry-all-errors \
+  --output "$ARCHIVE_PATH" "$ASSET_BASE/$ARCHIVE_NAME" \
+  || fail "download failed: $ASSET_BASE/$ARCHIVE_NAME"
+curl --fail --silent --show-error --location --retry 3 --retry-all-errors \
+  --output "$CHECKSUM_PATH" "$ASSET_BASE/$CHECKSUM_NAME" \
+  || fail "checksum download failed: $ASSET_BASE/$CHECKSUM_NAME"
+
+if command -v sha256sum >/dev/null 2>&1; then
+  (cd "$WORK_DIR" && sha256sum --check "$CHECKSUM_NAME") \
+    || fail "SHA-256 verification failed"
+else
+  EXPECTED_SHA256="$(awk '{print $1; exit}' "$CHECKSUM_PATH")"
+  ACTUAL_SHA256="$(shasum -a 256 "$ARCHIVE_PATH" | awk '{print $1}')"
+  [ "$EXPECTED_SHA256" = "$ACTUAL_SHA256" ] || fail "SHA-256 verification failed"
+fi
+
+while IFS= read -r archive_entry; do
+  case "$archive_entry" in
+    /*|../*|*/../*|*/..)
+      fail "archive contains an unsafe path: $archive_entry"
+      ;;
+  esac
+done < <(tar -tzf "$ARCHIVE_PATH")
+
+PAYLOAD_DIR="$WORK_DIR/payload"
+mkdir -p "$PAYLOAD_DIR"
+tar -xzf "$ARCHIVE_PATH" --no-same-owner --no-same-permissions -C "$PAYLOAD_DIR"
+
+AGENT_DIR="$PAYLOAD_DIR/App/memmy-agent"
+[ -f "$PAYLOAD_DIR/package.json" ] || fail "archive is missing package.json"
+[ -f "$PAYLOAD_DIR/package-lock.json" ] || fail "archive is missing package-lock.json"
+[ -f "$AGENT_DIR/package.json" ] || fail "archive is missing App/memmy-agent/package.json"
+[ -f "$AGENT_DIR/package-lock.json" ] || fail "archive is missing App/memmy-agent/package-lock.json"
+[ -f "$AGENT_DIR/dist/main.js" ] || fail "archive is missing the Memmy CLI entrypoint"
+[ -f "$PAYLOAD_DIR/Memory/dist/src/server/index.js" ] \
+  || fail "archive is missing the Memory service entrypoint"
+[ -f "$PAYLOAD_DIR/Memory/dist/src/cli/index.js" ] \
+  || fail "archive is missing the memmy-memory CLI entrypoint"
+[ -f "$PAYLOAD_DIR/App/backend/dist/src/services/builtin-skill-target-registry.js" ] \
+  || fail "archive is missing the existing agent Hook/plugin integration registry"
+[ -f "$PAYLOAD_DIR/App/backend/dist/src/adapters/outbound/skill-writer/templates/memmy-resume-hook.js" ] \
+  || fail "archive is missing the existing agent Hook template"
+[ -f "$PAYLOAD_DIR/App/backend/dist/src/adapters/outbound/skill-writer/templates/memmy-opencode-plugin.js" ] \
+  || fail "archive is missing the existing native plugin template"
+[ -f "$PAYLOAD_DIR/resources/embedding-models/Xenova/all-MiniLM-L6-v2/onnx/model_quantized.onnx" ] \
+  || fail "archive is missing the bundled embedding model"
+
+printf 'Installing Memory production dependencies for this Linux machine...\n'
+(cd "$PAYLOAD_DIR" && npm ci --omit=dev --workspace @memmy/memory \
+  --include-workspace-root=false --no-audit --no-fund) \
+  || fail "Memory dependency installation failed; the previous Memmy installation is unchanged"
+printf 'Installing Agent production dependencies for this Linux machine...\n'
+(cd "$AGENT_DIR" && npm ci --omit=dev --no-audit --no-fund) \
+  || fail "Agent dependency installation failed; the previous Memmy installation is unchanged"
+
+mkdir -p "$MEMMY_HOME_DIR" "$(dirname "$CONFIG_PATH")" "$(dirname "$MEMORY_DB_PATH")" "$WORKSPACE_DIR"
+chmod 0700 "$MEMMY_HOME_DIR" "$(dirname "$MEMORY_DB_PATH")" "$WORKSPACE_DIR"
+
+MEMORY_INIT_ARGS=(
+  init
+  --home "$MEMMY_HOME_DIR"
+  --config "$CONFIG_PATH"
+  --endpoint "http://127.0.0.1:18960"
+  --db "$MEMORY_DB_PATH"
+  --skip-agent-skills
+  --generate-token-if-missing
+)
+if ! "$NODE_BIN" "$PAYLOAD_DIR/Memory/dist/src/cli/index.js" "${MEMORY_INIT_ARGS[@]}" >/dev/null; then
+  restore_config
+  fail "could not initialize the local Memory configuration"
+fi
+chmod 0600 "$CONFIG_PATH"
+
+RELEASE_DIR="$INSTALL_ROOT/releases/$VERSION-$(date +%s)-$$"
+mv "$PAYLOAD_DIR" "$RELEASE_DIR"
+
+PREVIOUS_RELEASE=""
+if [ -L "$INSTALL_ROOT/current" ]; then
+  PREVIOUS_RELEASE="$(readlink "$INSTALL_ROOT/current")"
+fi
+MEMORY_WAS_ACTIVE="false"
+if systemctl --user is-active --quiet memmy-memory.service >/dev/null 2>&1; then
+  MEMORY_WAS_ACTIVE="true"
+fi
+GATEWAY_WAS_ACTIVE="false"
+if systemctl --user is-active --quiet memmy-gateway.service >/dev/null 2>&1; then
+  GATEWAY_WAS_ACTIVE="true"
+fi
+CURRENT_LINK="$INSTALL_ROOT/.current.$$"
+ln -s "$RELEASE_DIR" "$CURRENT_LINK"
+mv -Tf "$CURRENT_LINK" "$INSTALL_ROOT/current"
+
+LAUNCHER_TEMP="$BIN_DIR/.memmy.$$"
+{
+  printf '#!/usr/bin/env bash\n'
+  printf 'set -euo pipefail\n'
+  printf 'MEMMY_INSTALL_ROOT=%q\n' "$INSTALL_ROOT"
+  printf 'export MEMMY_HOME=%q\n' "$MEMMY_HOME_DIR"
+  printf 'export MEMMY_CONFIG=%q\n' "$CONFIG_PATH"
+  printf 'export MEMMY_AGENT_WORKSPACE=%q\n' "$WORKSPACE_DIR"
+  printf 'export MEMMY_GATEWAY_ENV_FILE=%q\n' "$GATEWAY_ENV_FILE"
+  printf 'export MEMMY_LINUX_SYSTEMD_GATEWAY=1\n'
+  printf 'exec %q "$MEMMY_INSTALL_ROOT/current/App/memmy-agent/dist/main.js" "$@"\n' "$NODE_BIN"
+} > "$LAUNCHER_TEMP"
+chmod 0755 "$LAUNCHER_TEMP"
+mv -f "$LAUNCHER_TEMP" "$BIN_DIR/memmy"
+
+MEMORY_LAUNCHER_TEMP="$BIN_DIR/.memmy-memory.$$"
+{
+  printf '#!/usr/bin/env bash\n'
+  printf 'set -euo pipefail\n'
+  printf 'MEMMY_INSTALL_ROOT=%q\n' "$INSTALL_ROOT"
+  printf 'export MEMMY_HOME=%q\n' "$MEMMY_HOME_DIR"
+  printf 'export MEMMY_CONFIG=%q\n' "$CONFIG_PATH"
+  printf 'export MEMMY_AGENT_INTEGRATION_ROOT="$MEMMY_INSTALL_ROOT/current/App/backend/dist/src"\n'
+  printf 'exec %q "$MEMMY_INSTALL_ROOT/current/Memory/dist/src/cli/index.js" "$@"\n' "$NODE_BIN"
+} > "$MEMORY_LAUNCHER_TEMP"
+chmod 0755 "$MEMORY_LAUNCHER_TEMP"
+mv -f "$MEMORY_LAUNCHER_TEMP" "$BIN_DIR/memmy-memory"
+
+systemd_quote() {
+  local value="$1"
+  value="${value//\\/\\\\}"
+  value="${value//\"/\\\"}"
+  value="${value//%/%%}"
+  printf '"%s"' "$value"
+}
+
+systemd_environment_file_path() {
+  local value="$1"
+  case "$value" in
+    *$'\n'*|*$'\r'*)
+      fail "Gateway environment file path contains a newline"
+      ;;
+  esac
+  # EnvironmentFile parses its path as a raw value rather than a quoted word.
+  # Preserve spaces, but escape '%' so it is not expanded as a specifier.
+  value="${value//%/%%}"
+  printf '%s' "$value"
+}
+
+mkdir -p "$SYSTEMD_USER_DIR"
+
+MEMORY_UNIT_TEMP="$SYSTEMD_USER_DIR/.memmy-memory.service.$$"
+{
+  printf '[Unit]\n'
+  printf 'Description=Memmy Memory Service\n\n'
+  printf '[Service]\n'
+  printf 'Type=simple\n'
+  printf 'Environment=%s\n' "$(systemd_quote "MEMMY_HOME=$MEMMY_HOME_DIR")"
+  printf 'Environment=%s\n' "$(systemd_quote "MEMMY_CONFIG=$CONFIG_PATH")"
+  printf 'Environment=%s\n' "$(systemd_quote "MEMMY_EMBEDDING_MODEL_ROOT=$INSTALL_ROOT/current/resources/embedding-models")"
+  printf 'ExecStart=%s %s --config %s --host 127.0.0.1 --port 18960 --db %s\n' \
+    "$(systemd_quote "$NODE_BIN")" \
+    "$(systemd_quote "$INSTALL_ROOT/current/Memory/dist/src/server/index.js")" \
+    "$(systemd_quote "$CONFIG_PATH")" \
+    "$(systemd_quote "$MEMORY_DB_PATH")"
+  printf 'Restart=on-failure\n'
+  printf 'RestartSec=3s\n'
+  printf 'TimeoutStopSec=15s\n'
+  printf 'UMask=0077\n\n'
+  printf '[Install]\n'
+  printf 'WantedBy=default.target\n'
+} > "$MEMORY_UNIT_TEMP"
+chmod 0644 "$MEMORY_UNIT_TEMP"
+mv -f "$MEMORY_UNIT_TEMP" "$MEMORY_UNIT"
+
+GATEWAY_UNIT_TEMP="$SYSTEMD_USER_DIR/.memmy-gateway.service.$$"
+{
+  printf '[Unit]\n'
+  printf 'Description=Memmy Agent Gateway\n'
+  printf 'Wants=memmy-memory.service\n'
+  printf 'After=memmy-memory.service\n'
+  printf 'StartLimitIntervalSec=60s\n'
+  printf 'StartLimitBurst=5\n\n'
+  printf '[Service]\n'
+  printf 'Type=simple\n'
+  printf 'Environment=%s\n' "$(systemd_quote "MEMMY_HOME=$MEMMY_HOME_DIR")"
+  printf 'Environment=%s\n' "$(systemd_quote "MEMMY_CONFIG=$CONFIG_PATH")"
+  printf 'Environment=%s\n' "$(systemd_quote "MEMMY_AGENT_WORKSPACE=$WORKSPACE_DIR")"
+  printf 'Environment=%s\n' "$(systemd_quote "MEMMY_GATEWAY_ENV_FILE=$GATEWAY_ENV_FILE")"
+  # EnvironmentFile does not unquote paths like Environment=/ExecStart= do. The
+  # optional-file prefix and absolute path must therefore both remain unquoted.
+  printf 'EnvironmentFile=-%s\n' "$(systemd_environment_file_path "$GATEWAY_ENV_FILE")"
+  printf 'Environment=MEMMY_MEMORY_URL=http://127.0.0.1:18960\n'
+  printf 'Environment=MEMORY_SERVICE_URL=http://127.0.0.1:18960\n'
+  printf 'ExecStart=%s %s gateway --config %s --workspace %s\n' \
+    "$(systemd_quote "$NODE_BIN")" \
+    "$(systemd_quote "$INSTALL_ROOT/current/App/memmy-agent/dist/main.js")" \
+    "$(systemd_quote "$CONFIG_PATH")" \
+    "$(systemd_quote "$WORKSPACE_DIR")"
+  printf 'Restart=on-failure\n'
+  printf 'RestartSec=3s\n'
+  printf 'TimeoutStopSec=15s\n'
+  printf 'UMask=0077\n\n'
+  printf '[Install]\n'
+  printf 'WantedBy=default.target\n'
+} > "$GATEWAY_UNIT_TEMP"
+chmod 0644 "$GATEWAY_UNIT_TEMP"
+mv -f "$GATEWAY_UNIT_TEMP" "$GATEWAY_UNIT"
+
+rollback_current_release() {
+  restore_config
+  if [ -n "$PREVIOUS_RELEASE" ]; then
+    local rollback_link="$INSTALL_ROOT/.rollback.$$"
+    ln -s "$PREVIOUS_RELEASE" "$rollback_link"
+    mv -Tf "$rollback_link" "$INSTALL_ROOT/current"
+    systemctl --user restart memmy-memory.service >/dev/null 2>&1 || true
+    if [ "$GATEWAY_WAS_ACTIVE" = "true" ]; then
+      systemctl --user restart memmy-gateway.service >/dev/null 2>&1 || true
+    fi
+  else
+    systemctl --user disable --now memmy-memory.service >/dev/null 2>&1 || true
+    unlink "$INSTALL_ROOT/current" >/dev/null 2>&1 || true
+  fi
+}
+
+if ! systemctl --user daemon-reload; then
+  rollback_current_release
+  fail "could not reload the systemd user manager"
+fi
+if ! systemctl --user enable --now memmy-memory.service; then
+  rollback_current_release
+  fail "could not enable and start memmy-memory.service"
+fi
+if [ "$MEMORY_WAS_ACTIVE" = "true" ]; then
+  if ! systemctl --user restart memmy-memory.service; then
+    rollback_current_release
+    fail "could not restart memmy-memory.service after update"
+  fi
+fi
+MEMORY_READY="false"
+for ((_attempt = 1; _attempt <= 200; _attempt++)); do
+  MEMORY_PID_BEFORE="$(systemctl --user show memmy-memory.service --property=MainPID --value 2>/dev/null || true)"
+  if [[ "$MEMORY_PID_BEFORE" =~ ^[1-9][0-9]*$ ]] \
+    && [ "$MEMORY_PID_BEFORE" -gt 1 ] \
+    && kill -0 "$MEMORY_PID_BEFORE" >/dev/null 2>&1 \
+    && "$BIN_DIR/memmy-memory" health >/dev/null 2>&1; then
+    sleep 0.25
+    MEMORY_PID_AFTER="$(systemctl --user show memmy-memory.service --property=MainPID --value 2>/dev/null || true)"
+    if [ "$MEMORY_PID_AFTER" = "$MEMORY_PID_BEFORE" ] \
+      && kill -0 "$MEMORY_PID_AFTER" >/dev/null 2>&1; then
+      MEMORY_READY="true"
+      break
+    fi
+  fi
+  sleep 0.15
+done
+if [ "$MEMORY_READY" != "true" ]; then
+  rollback_current_release
+  fail "memmy-memory.service did not become healthy; check systemctl --user status memmy-memory.service"
+fi
+if [ "$GATEWAY_WAS_ACTIVE" = "true" ] && [ -f "$GATEWAY_ENV_FILE" ]; then
+  if ! systemctl --user restart memmy-gateway.service; then
+    rollback_current_release
+    fail "could not restart memmy-gateway.service after update"
+  fi
+  GATEWAY_READY="false"
+  GATEWAY_LAST_PID=""
+  GATEWAY_STABLE_SAMPLES=0
+  for ((_attempt = 1; _attempt <= 200; _attempt++)); do
+    GATEWAY_PID="$(systemctl --user show memmy-gateway.service --property=MainPID --value 2>/dev/null || true)"
+    if systemctl --user is-active --quiet memmy-gateway.service >/dev/null 2>&1 \
+      && [[ "$GATEWAY_PID" =~ ^[1-9][0-9]*$ ]] \
+      && [ "$GATEWAY_PID" -gt 1 ] \
+      && kill -0 "$GATEWAY_PID" >/dev/null 2>&1; then
+      if [ "$GATEWAY_PID" = "$GATEWAY_LAST_PID" ]; then
+        GATEWAY_STABLE_SAMPLES=$((GATEWAY_STABLE_SAMPLES + 1))
+      else
+        GATEWAY_LAST_PID="$GATEWAY_PID"
+        GATEWAY_STABLE_SAMPLES=0
+      fi
+      if [ "$GATEWAY_STABLE_SAMPLES" -ge 14 ]; then
+        GATEWAY_READY="true"
+        break
+      fi
+    else
+      GATEWAY_LAST_PID=""
+      GATEWAY_STABLE_SAMPLES=0
+    fi
+    sleep 0.15
+  done
+  if [ "$GATEWAY_READY" != "true" ]; then
+    rollback_current_release
+    fail "memmy-gateway.service did not become stable after update; check systemctl --user status memmy-gateway.service"
+  fi
+fi
+
+PATH_UPDATED="false"
+case ":$PATH:" in
+  *":$BIN_DIR:"*)
+    ;;
+  *)
+    if [ "$BIN_DIR" = "$HOME/.local/bin" ]; then
+      PROFILE_PATH="$HOME/.profile"
+      PATH_LINE='export PATH="$HOME/.local/bin:$PATH"'
+      if [ ! -f "$PROFILE_PATH" ] || ! grep -Fqx "$PATH_LINE" "$PROFILE_PATH"; then
+        printf '\n%s\n' "$PATH_LINE" >> "$PROFILE_PATH"
+      fi
+      PATH_UPDATED="true"
+    fi
+    ;;
+esac
+
+trap - EXIT
+rm -rf "$WORK_DIR"
+
+# Keep the current release and at most one previous release for manual rollback.
+for old_release in "$INSTALL_ROOT"/releases/*; do
+  [ -d "$old_release" ] || continue
+  if [ "$old_release" != "$RELEASE_DIR" ] && [ "$old_release" != "$PREVIOUS_RELEASE" ]; then
+    rm -rf "$old_release"
+  fi
+done
+
+printf 'Memmy Agent %s installed successfully.\n' "$VERSION"
+if [ "$PATH_UPDATED" = "true" ]; then
+  printf 'Open a new terminal, or run: export PATH="$HOME/.local/bin:$PATH"\n'
+elif ! command -v memmy >/dev/null 2>&1; then
+  printf 'Add %s to PATH, then run memmy.\n' "$BIN_DIR"
+fi
+printf 'Memory service: systemctl --user status memmy-memory.service\n'
+printf 'Gateway service: systemctl --user status memmy-gateway.service\n'
+printf 'Start Memmy with: memmy\n'

--- a/scripts/internal/linux/build-cli-archive.sh
+++ b/scripts/internal/linux/build-cli-archive.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+VERSION="$(node -p "require('$REPO_ROOT/package.json').version")"
+OUTPUT_DIR="$REPO_ROOT/release-assets"
+ARCHIVE_NAME="memmy-agent-linux-cli.tar.gz"
+
+usage() {
+  printf '%s\n' \
+    "Usage: build-cli-archive.sh [--version X.Y.Z] [--output DIR]" \
+    "" \
+    "Builds the architecture-neutral Memmy Agent Linux CLI archive."
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --version)
+      [ "$#" -ge 2 ] || { echo "--version requires a value" >&2; exit 1; }
+      VERSION="$2"
+      shift 2
+      ;;
+    --output)
+      [ "$#" -ge 2 ] || { echo "--output requires a directory" >&2; exit 1; }
+      OUTPUT_DIR="$2"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+ROOT_VERSION="$(node -p "require('$REPO_ROOT/package.json').version")"
+if [ "$VERSION" != "$ROOT_VERSION" ]; then
+  echo "Requested version $VERSION does not match repository version $ROOT_VERSION" >&2
+  exit 1
+fi
+
+if [ "${MEMMY_LINUX_CLI_SKIP_BUILD:-0}" != "1" ]; then
+  rm -rf \
+    "$REPO_ROOT/App/memmy-agent/dist" \
+    "$REPO_ROOT/App/backend/dist" \
+    "$REPO_ROOT/Memory/dist" \
+    "$REPO_ROOT/Migrations/dist" \
+    "$REPO_ROOT/App/backend/local-api-contracts/dist"
+  npm --prefix "$REPO_ROOT/Migrations" run build
+  npm --prefix "$REPO_ROOT/App/backend/local-api-contracts" run build
+  npm --prefix "$REPO_ROOT/App/backend" run build
+  npm --prefix "$REPO_ROOT/Memory" run build
+  npm --prefix "$REPO_ROOT/App/memmy-agent" run build
+fi
+
+for required in \
+  "$REPO_ROOT/App/memmy-agent/dist/main.js" \
+  "$REPO_ROOT/Memory/dist/src/server/index.js" \
+  "$REPO_ROOT/Memory/dist/src/cli/index.js" \
+  "$REPO_ROOT/App/backend/dist/src/analytics/analytics-transport.js" \
+  "$REPO_ROOT/App/backend/dist/src/services/builtin-skill-target-registry.js" \
+  "$REPO_ROOT/Migrations/dist/index.js" \
+  "$REPO_ROOT/App/backend/local-api-contracts/dist/index.js"; do
+  if [ ! -f "$required" ]; then
+    echo "Required build output is missing: $required" >&2
+    exit 1
+  fi
+done
+
+BUILD_DIR="$(mktemp -d "${TMPDIR:-/tmp}/memmy-linux-cli.XXXXXX")"
+cleanup() {
+  rm -rf "$BUILD_DIR"
+}
+trap cleanup EXIT
+
+PAYLOAD_DIR="$BUILD_DIR/payload"
+mkdir -p \
+  "$PAYLOAD_DIR/App/memmy-agent" \
+  "$PAYLOAD_DIR/App/backend/dist/src/analytics" \
+  "$PAYLOAD_DIR/App/backend/dist/src/adapters/outbound" \
+  "$PAYLOAD_DIR/App/backend/dist/src/services" \
+  "$PAYLOAD_DIR/App/backend/local-api-contracts" \
+  "$PAYLOAD_DIR/Memory" \
+  "$PAYLOAD_DIR/Migrations" \
+  "$OUTPUT_DIR"
+
+cp "$REPO_ROOT/package.json" "$PAYLOAD_DIR/package.json"
+cp "$REPO_ROOT/package-lock.json" "$PAYLOAD_DIR/package-lock.json"
+cp "$REPO_ROOT/App/memmy-agent/package.json" "$PAYLOAD_DIR/App/memmy-agent/package.json"
+cp "$REPO_ROOT/App/memmy-agent/package-lock.json" "$PAYLOAD_DIR/App/memmy-agent/package-lock.json"
+cp -R "$REPO_ROOT/App/memmy-agent/dist" "$PAYLOAD_DIR/App/memmy-agent/dist"
+cp "$REPO_ROOT/App/backend/package.json" "$PAYLOAD_DIR/App/backend/package.json"
+cp -R "$REPO_ROOT/App/backend/dist/src/adapters/outbound/skill-writer" \
+  "$PAYLOAD_DIR/App/backend/dist/src/adapters/outbound/skill-writer"
+cp "$REPO_ROOT/App/backend/dist/src/adapters/outbound/agent-paths.js" \
+  "$PAYLOAD_DIR/App/backend/dist/src/adapters/outbound/agent-paths.js"
+cp "$REPO_ROOT/App/backend/dist/src/project-version.js" \
+  "$PAYLOAD_DIR/App/backend/dist/src/project-version.js"
+cp "$REPO_ROOT/App/backend/dist/src/analytics/analytics-transport.js" \
+  "$PAYLOAD_DIR/App/backend/dist/src/analytics/analytics-transport.js"
+cp "$REPO_ROOT/App/backend/dist/src/services/builtin-skill-target-registry.js" \
+  "$PAYLOAD_DIR/App/backend/dist/src/services/builtin-skill-target-registry.js"
+cp "$REPO_ROOT/Memory/package.json" "$PAYLOAD_DIR/Memory/package.json"
+cp -R "$REPO_ROOT/Memory/dist" "$PAYLOAD_DIR/Memory/dist"
+cp "$REPO_ROOT/Migrations/package.json" "$PAYLOAD_DIR/Migrations/package.json"
+cp -R "$REPO_ROOT/Migrations/dist" "$PAYLOAD_DIR/Migrations/dist"
+cp "$REPO_ROOT/App/backend/local-api-contracts/package.json" \
+  "$PAYLOAD_DIR/App/backend/local-api-contracts/package.json"
+cp -R "$REPO_ROOT/App/backend/local-api-contracts/dist" \
+  "$PAYLOAD_DIR/App/backend/local-api-contracts/dist"
+
+node --input-type=module - "$PAYLOAD_DIR/package.json" <<'NODE'
+import { readFileSync, writeFileSync } from "node:fs";
+
+const manifestPath = process.argv[2];
+const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+manifest.workspaces = [
+  "Memory",
+  "Migrations",
+  "App/backend/local-api-contracts"
+];
+writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
+NODE
+
+node "$REPO_ROOT/scripts/internal/shared/prepare-embedding-model.mjs" \
+  "$PAYLOAD_DIR/resources/embedding-models"
+
+find "$PAYLOAD_DIR" -type f \( \
+  -name '*.d.ts' -o \
+  -name '*.d.ts.map' -o \
+  -name '*.js.map' \
+\) -delete
+
+ARCHIVE_PATH="$OUTPUT_DIR/$ARCHIVE_NAME"
+# macOS tar otherwise records Apple extended attributes as LIBARCHIVE pax
+# headers, which produce thousands of warnings when GNU tar extracts on Linux.
+COPYFILE_DISABLE=1 tar --no-xattrs -czf "$ARCHIVE_PATH" -C "$PAYLOAD_DIR" .
+
+if command -v sha256sum >/dev/null 2>&1; then
+  ARCHIVE_SHA256="$(sha256sum "$ARCHIVE_PATH" | awk '{print $1}')"
+elif command -v shasum >/dev/null 2>&1; then
+  ARCHIVE_SHA256="$(shasum -a 256 "$ARCHIVE_PATH" | awk '{print $1}')"
+else
+  echo "Neither sha256sum nor shasum is available" >&2
+  exit 1
+fi
+printf '%s  %s\n' "$ARCHIVE_SHA256" "$ARCHIVE_NAME" > "$ARCHIVE_PATH.sha256"
+cp "$REPO_ROOT/scripts/install.sh" "$OUTPUT_DIR/install.sh"
+
+printf 'Linux CLI archive: %s\n' "$ARCHIVE_PATH"
+printf 'SHA-256: %s\n' "$ARCHIVE_PATH.sha256"

--- a/tests/linux-cli-packaging.test.mjs
+++ b/tests/linux-cli-packaging.test.mjs
@@ -1,0 +1,454 @@
+import { createHash } from "node:crypto";
+import { spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  existsSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  readlinkSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+const installerPath = path.join(repoRoot, "scripts", "install.sh");
+const builderPath = path.join(repoRoot, "scripts", "internal", "linux", "build-cli-archive.sh");
+const linuxWorkflowPath = path.join(repoRoot, ".github", "workflows", "linux-cli-installer.yml");
+const desktopReleaseWorkflowPath = path.join(
+  repoRoot,
+  ".github",
+  "workflows",
+  "github-draft-release-v2.yml",
+);
+const temporaryRoots = [];
+
+function temporaryRoot(prefix) {
+  const root = mkdtempSync(path.join(tmpdir(), prefix));
+  temporaryRoots.push(root);
+  return root;
+}
+
+function sha256(target) {
+  return createHash("sha256").update(readFileSync(target)).digest("hex");
+}
+
+function cleanNpmLifecycleEnv(overrides = {}) {
+  const entries = Object.entries(process.env).filter(([key]) => (
+    !key.toLowerCase().startsWith("npm_") && key !== "INIT_CWD"
+  ));
+  return { ...Object.fromEntries(entries), ...overrides };
+}
+
+function makeInstallerFixture(root) {
+  const release = path.join(root, "release");
+  const payload = path.join(root, "payload");
+  const agent = path.join(payload, "App", "memmy-agent");
+  const backend = path.join(payload, "App", "backend");
+  const memory = path.join(payload, "Memory");
+  const migrations = path.join(payload, "Migrations");
+  const contracts = path.join(payload, "App", "backend", "local-api-contracts");
+  const model = path.join(
+    payload,
+    "resources",
+    "embedding-models",
+    "Xenova",
+    "all-MiniLM-L6-v2",
+  );
+  const archive = path.join(release, "memmy-agent-linux-cli.tar.gz");
+  mkdirSync(path.join(agent, "dist"), { recursive: true });
+  mkdirSync(path.join(backend, "dist", "src", "services"), { recursive: true });
+  mkdirSync(
+    path.join(backend, "dist", "src", "adapters", "outbound", "skill-writer", "templates"),
+    { recursive: true },
+  );
+  mkdirSync(path.join(memory, "dist", "src", "server"), { recursive: true });
+  mkdirSync(path.join(memory, "dist", "src", "cli"), { recursive: true });
+  mkdirSync(path.join(migrations, "dist"), { recursive: true });
+  mkdirSync(path.join(contracts, "dist"), { recursive: true });
+  mkdirSync(path.join(model, "onnx"), { recursive: true });
+  mkdirSync(release, { recursive: true });
+  writeFileSync(path.join(payload, "package.json"), JSON.stringify({
+    name: "memmy-linux-fixture",
+    version: "9.9.9",
+    private: true,
+    workspaces: ["Memory", "Migrations", "App/backend/local-api-contracts"],
+  }, null, 2));
+  writeFileSync(path.join(agent, "package.json"), JSON.stringify({
+    name: "memmy-agent",
+    version: "9.9.9",
+    type: "module",
+    bin: { memmy: "dist/main.js" },
+  }, null, 2));
+  writeFileSync(path.join(backend, "package.json"), JSON.stringify({
+    name: "@memmy/backend",
+    version: "0.0.0",
+    type: "module",
+  }, null, 2));
+  writeFileSync(
+    path.join(backend, "dist", "src", "services", "builtin-skill-target-registry.js"),
+    "export function createBuiltinSkillTargetRegistry() { return { get() { return undefined; } }; }\n",
+  );
+  writeFileSync(
+    path.join(backend, "dist", "src", "adapters", "outbound", "skill-writer", "templates", "memmy-resume-hook.js"),
+    "export const fixture = true;\n",
+  );
+  writeFileSync(
+    path.join(backend, "dist", "src", "adapters", "outbound", "skill-writer", "templates", "memmy-opencode-plugin.js"),
+    "export const fixture = true;\n",
+  );
+  const lock = spawnSync("npm", [
+    "install",
+    "--package-lock-only",
+    "--ignore-scripts",
+    "--no-audit",
+    "--no-fund",
+  ], { cwd: agent, encoding: "utf8", env: cleanNpmLifecycleEnv() });
+  expect(lock.status, lock.stderr).toBe(0);
+  writeFileSync(
+    path.join(agent, "dist", "main.js"),
+    "if (process.argv.includes('--version')) console.log('9.9.9');\n",
+  );
+  writeFileSync(path.join(memory, "package.json"), JSON.stringify({
+    name: "@memmy/memory",
+    version: "9.9.9",
+    type: "module",
+  }, null, 2));
+  writeFileSync(path.join(migrations, "package.json"), JSON.stringify({
+    name: "@memmy/migrations",
+    version: "0.0.0",
+    type: "module",
+  }, null, 2));
+  writeFileSync(path.join(contracts, "package.json"), JSON.stringify({
+    name: "@memmy/local-api-contracts",
+    version: "0.0.0",
+    type: "module",
+  }, null, 2));
+  const rootLock = spawnSync("npm", [
+    "install",
+    "--package-lock-only",
+    "--ignore-scripts",
+    "--no-audit",
+    "--no-fund",
+  ], { cwd: payload, encoding: "utf8", env: cleanNpmLifecycleEnv() });
+  expect(rootLock.status, rootLock.stderr).toBe(0);
+  writeFileSync(path.join(memory, "dist", "src", "server", "index.js"), "setInterval(() => {}, 1000);\n");
+  writeFileSync(path.join(memory, "dist", "src", "cli", "index.js"), [
+    "import fs from 'node:fs';",
+    "const args = process.argv.slice(2);",
+    "if (args[0] === 'init') {",
+    "  const index = args.indexOf('--config');",
+    "  if (index >= 0) fs.writeFileSync(args[index + 1], 'memmyMemory:\\n  storage:\\n    token: fixture-token\\n');",
+    "}",
+    "if (args.includes('--version')) console.log('9.9.9');",
+    "",
+  ].join("\n"));
+  writeFileSync(path.join(migrations, "dist", "index.js"), "export {};\n");
+  writeFileSync(path.join(contracts, "dist", "index.js"), "export {};\n");
+  writeFileSync(path.join(model, "config.json"), "{}\n");
+  writeFileSync(path.join(model, "tokenizer.json"), "{}\n");
+  writeFileSync(path.join(model, "tokenizer_config.json"), "{}\n");
+  writeFileSync(path.join(model, "onnx", "model_quantized.onnx"), "fixture\n");
+  const tar = spawnSync("tar", ["-czf", archive, "-C", payload, "."], { encoding: "utf8" });
+  expect(tar.status, tar.stderr).toBe(0);
+  writeFileSync(`${archive}.sha256`, `${sha256(archive)}  ${path.basename(archive)}\n`);
+  return release;
+}
+
+function fakeLinuxTools(root) {
+  const tools = path.join(root, "tools");
+  mkdirSync(tools, { recursive: true });
+  const uname = path.join(tools, "uname");
+  writeFileSync(uname, [
+    "#!/usr/bin/env bash",
+    "case \"$1\" in",
+    "  -s) printf 'Linux\\n' ;;",
+    "  -m) printf 'x86_64\\n' ;;",
+    "  *) printf 'Linux\\n' ;;",
+    "esac",
+    "",
+  ].join("\n"));
+  chmodSync(uname, 0o755);
+  const npm = path.join(tools, "npm");
+  writeFileSync(npm, [
+    "#!/usr/bin/env bash",
+    "if [ \"${MEMMY_FIXTURE_NPM_FAIL:-0}\" = \"1\" ]; then exit 42; fi",
+    "exit 0",
+    "",
+  ].join("\n"));
+  chmodSync(npm, 0o755);
+  const systemctl = path.join(tools, "systemctl");
+  writeFileSync(systemctl, [
+    "#!/usr/bin/env bash",
+    "if [ -n \"${MEMMY_FIXTURE_SYSTEMCTL_LOG:-}\" ]; then printf '%s\\n' \"$*\" >> \"$MEMMY_FIXTURE_SYSTEMCTL_LOG\"; fi",
+    "if [ \"${MEMMY_FIXTURE_SYSTEMCTL_FAIL:-0}\" = \"1\" ] && [ \"${1:-}\" = \"--user\" ] && [ \"${2:-}\" = \"daemon-reload\" ]; then exit 43; fi",
+    "if [ \"${1:-}\" = \"--user\" ] && [ \"${2:-}\" = \"show\" ] && [[ \"$*\" == *\"MainPID\"* ]]; then printf '%s\\n' \"$MEMMY_FIXTURE_MAIN_PID\"; exit 0; fi",
+    "if [ \"${1:-}\" = \"--user\" ] && [ \"${2:-}\" = \"is-enabled\" ]; then exit 1; fi",
+    "if [ \"${1:-}\" = \"--user\" ] && [ \"${2:-}\" = \"is-active\" ]; then exit 1; fi",
+    "exit 0",
+    "",
+  ].join("\n"));
+  chmodSync(systemctl, 0o755);
+  const mv = path.join(tools, "mv");
+  writeFileSync(mv, [
+    "#!/usr/bin/env bash",
+    "if [ \"${1:-}\" = \"-Tf\" ]; then",
+    "  /bin/rm -f \"$3\"",
+    "  exec /bin/mv -f \"$2\" \"$3\"",
+    "fi",
+    "exec /bin/mv \"$@\"",
+    "",
+  ].join("\n"));
+  chmodSync(mv, 0o755);
+  return tools;
+}
+
+function runInstaller(home, release, tools, overrides = {}) {
+  return spawnSync("bash", [installerPath], {
+    encoding: "utf8",
+    env: cleanNpmLifecycleEnv({
+      HOME: home,
+      MEMMY_VERSION: "9.9.9",
+      MEMMY_RELEASE_BASE_URL: pathToFileURL(release).href.replace(/\/$/, ""),
+      MEMMY_FIXTURE_MAIN_PID: String(process.pid),
+      PATH: `${tools}${path.delimiter}${process.env.PATH ?? ""}`,
+      ...overrides,
+    }),
+  });
+}
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe("Linux CLI package boundary", () => {
+  it("keeps the archive runtime-only and the installer architecture-neutral", () => {
+    const builder = readFileSync(builderPath, "utf8");
+    const installer = readFileSync(installerPath, "utf8");
+
+    expect(builder).toContain("App/memmy-agent/dist/main.js");
+    expect(builder).toContain("Memory/dist/src/server/index.js");
+    expect(builder).toContain("Memory/dist/src/cli/index.js");
+    expect(builder).toContain("builtin-skill-target-registry.js");
+    expect(builder).toContain("analytics-transport.js");
+    expect(builder).toContain("skill-writer");
+    expect(builder).toContain("prepare-embedding-model.mjs");
+    expect(builder).toContain("COPYFILE_DISABLE=1 tar --no-xattrs -czf");
+    expect(builder).toContain("Migrations/dist/index.js");
+    expect(builder).toContain("local-api-contracts/dist/index.js");
+    expect(builder).not.toContain("App/shell/desktop");
+    expect(builder).not.toContain("App/frontend/desktop");
+    expect(installer).toContain('(cd "$AGENT_DIR" && npm ci --omit=dev');
+    expect(installer).toContain("npm ci --omit=dev --workspace @memmy/memory");
+    expect(installer).toContain('--home "$MEMMY_HOME_DIR"');
+    expect(installer).toContain("--generate-token-if-missing");
+    expect(installer).toContain("systemctl --user enable --now memmy-memory.service");
+    expect(installer).toContain("systemctl --user restart memmy-memory.service");
+    expect(installer).toContain("memmy-gateway.service did not become stable after update");
+    expect(installer).toContain("memmy-gateway.service");
+    expect(installer).toContain("MEMMY_LINUX_SYSTEMD_GATEWAY=1");
+    expect(installer).toContain("MEMMY_GATEWAY_ENV_FILE=");
+    expect(installer).toContain("EnvironmentFile=");
+    expect(installer).toContain("gateway --config %s --workspace %s");
+    expect(installer).toContain("x86_64|amd64");
+    expect(installer).toContain("aarch64|arm64");
+    expect(installer).toContain("Node.js 22 or newer is required");
+    expect(installer).not.toMatch(/nohup|disown|pkill|killall|enable-linger/);
+  });
+
+  it("builds an archive with compiled CLI packages and no desktop payload", () => {
+    const output = temporaryRoot("memmy-linux-archive-");
+    const modelSource = path.join(output, "model-source", "Xenova", "all-MiniLM-L6-v2");
+    mkdirSync(path.join(modelSource, "onnx"), { recursive: true });
+    for (const file of ["config.json", "tokenizer.json", "tokenizer_config.json"]) {
+      writeFileSync(path.join(modelSource, file), "{}\n");
+    }
+    writeFileSync(path.join(modelSource, "onnx", "model_quantized.onnx"), "fixture\n");
+    const result = spawnSync("bash", [builderPath, "--output", output], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      env: cleanNpmLifecycleEnv({ MEMMY_EMBEDDING_MODEL_SOURCE_DIR: path.dirname(path.dirname(modelSource)) }),
+    });
+    expect(result.status, result.stderr).toBe(0);
+
+    const archive = path.join(output, "memmy-agent-linux-cli.tar.gz");
+    const listing = spawnSync("tar", ["-tzf", archive], { encoding: "utf8" });
+    expect(listing.status, listing.stderr).toBe(0);
+    expect(listing.stdout).toContain("App/memmy-agent/dist/main.js");
+    expect(listing.stdout).toContain("Memory/dist/src/server/index.js");
+    expect(listing.stdout).toContain("Memory/dist/src/cli/index.js");
+    expect(listing.stdout).toContain("App/backend/dist/src/services/builtin-skill-target-registry.js");
+    expect(listing.stdout).toContain("App/backend/dist/src/analytics/analytics-transport.js");
+    expect(listing.stdout).toContain("App/backend/dist/src/adapters/outbound/skill-writer/templates/memmy-resume-hook.js");
+    expect(listing.stdout).toContain("App/backend/dist/src/adapters/outbound/skill-writer/templates/memmy-opencode-plugin.js");
+    expect(listing.stdout).toContain("resources/embedding-models/Xenova/all-MiniLM-L6-v2/onnx/model_quantized.onnx");
+    expect(listing.stdout).toContain("Migrations/dist/index.js");
+    expect(listing.stdout).toContain("App/backend/local-api-contracts/dist/index.js");
+    expect(listing.stdout).not.toMatch(/electron|\.dmg|\.exe|App\/frontend|App\/shell/i);
+    expect(listing.stdout).not.toMatch(/node_modules|App\/memmy-agent\/src\/|Memory\/src\/(?!server|cli)/);
+    expect(existsSync(`${archive}.sha256`)).toBe(true);
+    expect(existsSync(path.join(output, "install.sh"))).toBe(true);
+
+    const extracted = path.join(output, "extracted");
+    mkdirSync(extracted);
+    const extract = spawnSync("tar", ["-xzf", archive, "-C", extracted], { encoding: "utf8" });
+    expect(extract.status, extract.stderr).toBe(0);
+    const installDryRun = spawnSync("npm", [
+      "ci",
+      "--omit=dev",
+      "--dry-run",
+      "--ignore-scripts",
+      "--no-audit",
+      "--no-fund",
+    ], {
+      cwd: path.join(extracted, "App", "memmy-agent"),
+      encoding: "utf8",
+      env: cleanNpmLifecycleEnv(),
+    });
+    expect(installDryRun.status, installDryRun.stderr).toBe(0);
+    const memoryInstallDryRun = spawnSync("npm", [
+      "ci",
+      "--omit=dev",
+      "--workspace",
+      "@memmy/memory",
+      "--include-workspace-root=false",
+      "--dry-run",
+      "--ignore-scripts",
+      "--no-audit",
+      "--no-fund",
+    ], {
+      cwd: extracted,
+      encoding: "utf8",
+      env: cleanNpmLifecycleEnv(),
+    });
+    expect(memoryInstallDryRun.status, memoryInstallDryRun.stderr).toBe(0);
+
+    rmSync(path.join(extracted, "node_modules"), { recursive: true, force: true });
+    symlinkSync(path.join(repoRoot, "node_modules"), path.join(extracted, "node_modules"));
+    const integrationModuleUrl = pathToFileURL(path.join(
+      extracted,
+      "App",
+      "backend",
+      "dist",
+      "src",
+      "services",
+      "builtin-skill-target-registry.js",
+    )).href;
+    const integrationImport = spawnSync("node", [
+      "--input-type=module",
+      "--eval",
+      [
+        `const module = await import(${JSON.stringify(integrationModuleUrl)});`,
+        `const registry = module.createBuiltinSkillTargetRegistry(${JSON.stringify(path.join(extracted, "config.yaml"))});`,
+        "if (typeof registry.get('codex')?.installPlugin !== 'function') process.exit(2);",
+        "if (typeof registry.get('opencode')?.installPlugin !== 'function') process.exit(3);",
+      ].join("\n"),
+    ], { cwd: extracted, encoding: "utf8" });
+    expect(integrationImport.status, integrationImport.stderr).toBe(0);
+  }, 120_000);
+
+  it("keeps Linux publication isolated from the desktop Draft Release", () => {
+    const linuxWorkflow = readFileSync(linuxWorkflowPath, "utf8");
+    const desktopWorkflow = readFileSync(desktopReleaseWorkflowPath, "utf8");
+
+    expect(linuxWorkflow).toContain("ubuntu-24.04-arm");
+    expect(linuxWorkflow).toContain("types: [published]");
+    expect(linuxWorkflow).toContain("needs: [build, install-smoke]");
+    expect(linuxWorkflow).toContain("gh release upload");
+    expect(linuxWorkflow).toContain("MEMMY_SMOKE_SECRET");
+    expect(linuxWorkflow).toContain("systemctl --user is-active --quiet memmy-gateway.service");
+    expect(linuxWorkflow).not.toMatch(/gh release (create|delete)/);
+    expect(desktopWorkflow).not.toContain("memmy-agent-linux-cli");
+    expect(desktopWorkflow).not.toContain("scripts/install.sh");
+  });
+});
+
+describe("Linux one-line installer transaction", () => {
+  it("installs, repeats PATH setup idempotently, and preserves the prior version on checksum failure", () => {
+    const root = temporaryRoot("memmy-linux-installer-");
+    const home = path.join(root, "home");
+    mkdirSync(home, { recursive: true });
+    const release = makeInstallerFixture(root);
+    const tools = fakeLinuxTools(root);
+    const systemctlLog = path.join(root, "systemctl.log");
+
+    const first = runInstaller(home, release, tools, { MEMMY_FIXTURE_SYSTEMCTL_LOG: systemctlLog });
+    expect(first.status, first.stderr).toBe(0);
+    const launcher = path.join(home, ".local", "bin", "memmy");
+    expect(existsSync(launcher)).toBe(true);
+    const version = spawnSync(launcher, ["--version"], { encoding: "utf8" });
+    expect(version.status, version.stderr).toBe(0);
+    expect(version.stdout.trim()).toBe("9.9.9");
+    const memoryLauncher = path.join(home, ".local", "bin", "memmy-memory");
+    expect(existsSync(memoryLauncher)).toBe(true);
+    expect(readFileSync(memoryLauncher, "utf8")).toContain("MEMMY_AGENT_INTEGRATION_ROOT=");
+    expect(spawnSync(memoryLauncher, ["health"], { encoding: "utf8" }).status).toBe(0);
+    const memoryUnit = readFileSync(
+      path.join(home, ".config", "systemd", "user", "memmy-memory.service"),
+      "utf8",
+    );
+    expect(memoryUnit).toContain("ExecStart=");
+    expect(memoryUnit).toContain("/current/Memory/dist/src/server/index.js");
+    expect(memoryUnit).toContain("Restart=on-failure");
+    expect(memoryUnit).toContain("UMask=0077");
+    expect(memoryUnit).toContain("WantedBy=default.target");
+    const gatewayUnit = readFileSync(
+      path.join(home, ".config", "systemd", "user", "memmy-gateway.service"),
+      "utf8",
+    );
+    expect(gatewayUnit).toContain("Wants=memmy-memory.service");
+    expect(gatewayUnit).toContain("/current/App/memmy-agent/dist/main.js");
+    expect(gatewayUnit).toContain("After=memmy-memory.service");
+    expect(gatewayUnit).toContain(
+      `EnvironmentFile=-${path.join(home, ".memmy", "systemd", "gateway.env")}`,
+    );
+    expect(gatewayUnit).not.toMatch(/^EnvironmentFile=.*"/m);
+    expect(gatewayUnit).toContain("Restart=on-failure");
+    expect(gatewayUnit).toContain("StartLimitIntervalSec=60s");
+    expect(gatewayUnit).toContain("StartLimitBurst=5");
+    expect(gatewayUnit).toContain("UMask=0077");
+    expect(readFileSync(systemctlLog, "utf8")).toContain("--user enable --now memmy-memory.service");
+    expect(readFileSync(systemctlLog, "utf8")).not.toContain("--user enable --now memmy-gateway.service");
+    expect(readFileSync(launcher, "utf8")).toContain("MEMMY_LINUX_SYSTEMD_GATEWAY=1");
+    expect(readFileSync(launcher, "utf8")).toContain("MEMMY_GATEWAY_ENV_FILE=");
+
+    const second = runInstaller(home, release, tools, { MEMMY_FIXTURE_SYSTEMCTL_LOG: systemctlLog });
+    expect(second.status, second.stderr).toBe(0);
+    const profileLines = readFileSync(path.join(home, ".profile"), "utf8")
+      .split(/\r?\n/)
+      .filter((line) => line === 'export PATH="$HOME/.local/bin:$PATH"');
+    expect(profileLines).toHaveLength(1);
+
+    const current = path.join(home, ".local", "share", "memmy-agent", "current");
+    const beforeFailure = readlinkSync(current);
+    const npmFailed = runInstaller(home, release, tools, { MEMMY_FIXTURE_NPM_FAIL: "1" });
+    expect(npmFailed.status).not.toBe(0);
+    expect(npmFailed.stderr).toContain("Memory dependency installation failed");
+    expect(readlinkSync(current)).toBe(beforeFailure);
+
+    const configPath = path.join(home, ".memmy", "config.yaml");
+    const configBeforeSystemdFailure = "sentinel: preserve-on-rollback\n";
+    writeFileSync(configPath, configBeforeSystemdFailure);
+    const systemdFailed = runInstaller(home, release, tools, {
+      MEMMY_FIXTURE_SYSTEMCTL_FAIL: "1",
+    });
+    expect(systemdFailed.status).not.toBe(0);
+    expect(systemdFailed.stderr).toContain("could not reload the systemd user manager");
+    expect(readFileSync(configPath, "utf8")).toBe(configBeforeSystemdFailure);
+    expect(readlinkSync(current)).toBe(beforeFailure);
+
+    writeFileSync(
+      path.join(release, "memmy-agent-linux-cli.tar.gz.sha256"),
+      `0000000000000000000000000000000000000000000000000000000000000000  memmy-agent-linux-cli.tar.gz\n`,
+    );
+    const failed = runInstaller(home, release, tools);
+    expect(failed.status).not.toBe(0);
+    expect(failed.stderr).toContain("SHA-256 verification failed");
+    expect(readlinkSync(current)).toBe(beforeFailure);
+  }, 60_000);
+});


### PR DESCRIPTION
Adds a one-line Linux CLI installer with systemd services, x64/arm64 packaging, release automation, docs, and tests.

Tested: `npm run test:linux-cli`