### PR TITLE
fix(desktop): preserve Unicode Windows update paths

### DIFF
--- a/App/shell/desktop/src/main/main.ts
+++ b/App/shell/desktop/src/main/main.ts
@@ -107,6 +107,7 @@ import {
   type WindowsDataMigrationConsistency,
   type WindowsDataLayout
 } from "./windows-data-layout.js";
+import { createWindowsUpdateLauncherFile } from "./windows-update-launcher.js";
 
 let mainWindow: BrowserWindow | null = null;
 let petWindow: BrowserWindow | null = null;
@@ -2666,7 +2667,7 @@ async function installWindowsUpdateInBackground(
     await clearWindowsUpdatePromptMarker().catch(() => undefined);
   }
   await writeFile(helperPath, createWindowsUpdateInstallScript(), { mode: 0o700 });
-  await writeFile(launcherPath, createWindowsUpdateLauncherScript([
+  await writeFile(launcherPath, createWindowsUpdateLauncherFile([
     "powershell.exe",
     "-NoProfile",
     "-ExecutionPolicy",
@@ -2682,7 +2683,7 @@ async function installWindowsUpdateInBackground(
     options.openAfterInstall ? "1" : "0",
     resolvePreparedRequiredUpdatePath(),
     options.expectedVersion ?? ""
-  ]), "utf8");
+  ]));
   await appendFile(logPath, `[${new Date().toISOString()}] queued Memmy Windows update helper "${helperPath}"\n`).catch(() => undefined);
 
   const helper = spawn("wscript.exe", [launcherPath], {
@@ -2699,36 +2700,6 @@ async function installWindowsUpdateInBackground(
     scheduleQuitForManualUpdateInstall();
   }
   return { filePath, opened: false, willQuit: options.quitCurrentApp, background: true };
-}
-
-/**
- * Creates the VBS script that launches the Windows update helper hidden.
- *
- * @param command The PowerShell helper launch command and arguments.
- * @returns The VBS script content.
- */
-function createWindowsUpdateLauncherScript(command: string[]): string {
-  const shellCommand = command.map(quoteWindowsShellArgument).join(" ");
-  return `Set shell = CreateObject("WScript.Shell")
-shell.Run "${escapeVbsString(shellCommand)}", 0, False
-Set fso = CreateObject("Scripting.FileSystemObject")
-On Error Resume Next
-fso.DeleteFile WScript.ScriptFullName, True
-`;
-}
-
-/**
- * Quotes a Windows shell command argument.
- *
- * @param value The argument value.
- * @returns The argument ready to be spliced into the command line.
- */
-function quoteWindowsShellArgument(value: string): string {
-  return `"${value.replace(/"/g, "\\\"")}"`;
-}
-
-function escapeVbsString(value: string): string {
-  return value.replace(/"/g, "\"\"");
 }
 
 function createWindowsUpdateInstallScript(): string {

--- a/App/shell/desktop/src/main/windows-update-launcher.ts
+++ b/App/shell/desktop/src/main/windows-update-launcher.ts
@@ -1,0 +1,34 @@
+/**
+ * Creates the VBS script that launches the Windows update helper hidden.
+ *
+ * @param command The PowerShell helper launch command and arguments.
+ * @returns The VBS script content.
+ */
+const createWindowsUpdateLauncherScript = (command: string[]): string => {
+  const shellCommand = command.map(quoteWindowsShellArgument).join(" ");
+  return `Set shell = CreateObject("WScript.Shell")
+shell.Run "${escapeVbsString(shellCommand)}", 0, False
+Set fso = CreateObject("Scripting.FileSystemObject")
+On Error Resume Next
+fso.DeleteFile WScript.ScriptFullName, True
+`;
+};
+
+/**
+ * Creates a Windows Script Host compatible launcher file.
+ *
+ * Windows Script Host may decode a BOM-less UTF-8 VBS file with the active
+ * system code page, corrupting non-ASCII update paths before PowerShell starts.
+ */
+export const createWindowsUpdateLauncherFile = (command: string[]): Buffer => {
+  const script = createWindowsUpdateLauncherScript(command);
+  return Buffer.from(`\uFEFF${script}`, "utf16le");
+};
+
+const quoteWindowsShellArgument = (value: string): string => {
+  return `"${value.replace(/"/g, "\\\"")}"`;
+};
+
+const escapeVbsString = (value: string): string => {
+  return value.replace(/"/g, "\"\"");
+};

--- a/App/shell/desktop/tests/packaged-runtime-boundary.test.ts
+++ b/App/shell/desktop/tests/packaged-runtime-boundary.test.ts
@@ -1146,7 +1146,8 @@ describe("desktop packaged runtime boundaries", () => {
     expect(mainSource).toContain("launch-win-update-${Date.now()}.vbs");
     expect(mainSource).toContain("install-win-update-${Date.now()}.ps1");
     expect(mainSource).toContain('const helper = spawn("wscript.exe"');
-    expect(mainSource).toContain("function createWindowsUpdateLauncherScript");
+    expect(mainSource).toContain('import { createWindowsUpdateLauncherFile } from "./windows-update-launcher.js"');
+    expect(mainSource).toContain("await writeFile(launcherPath, createWindowsUpdateLauncherFile([");
     expect(mainSource).toContain("$arguments = @('/S', '--updated', '/currentuser', ('/D=' + $appDir))");
     expect(mainSource).toContain("CURRENT_APP_PID");
     expect(mainSource).toContain("OPEN_AFTER_INSTALL");

--- a/App/shell/desktop/tests/windows-update-launcher.test.ts
+++ b/App/shell/desktop/tests/windows-update-launcher.test.ts
@@ -1,0 +1,93 @@
+import { spawnSync } from "node:child_process";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+import { describe, expect, it } from "vitest";
+import { createWindowsUpdateLauncherFile } from "../src/main/windows-update-launcher.js";
+
+describe("Windows update launcher", () => {
+  it("encodes the VBS launcher as UTF-16LE with BOM without losing Chinese paths or arguments", () => {
+    const helperPath = "D:\\测试路径\\Memmy\\data\\Memmy\\updates\\install-win-update.ps1";
+    const installerPath = "D:\\测试路径\\Memmy\\data\\Memmy\\updates\\Memmy-1.1.0.exe";
+    const appPath = "D:\\测试路径\\Memmy\\Memmy.exe";
+    const logPath = "D:\\测试路径\\Memmy\\data\\Memmy\\updates\\win-update-install.log";
+    const markerPath = "D:\\测试路径\\Memmy\\data\\Memmy\\prepared-required-update.json";
+    const command = [
+      "powershell.exe",
+      "-NoProfile",
+      "-ExecutionPolicy",
+      "Bypass",
+      "-WindowStyle",
+      "Hidden",
+      "-File",
+      helperPath,
+      installerPath,
+      appPath,
+      logPath,
+      "4242",
+      "1",
+      markerPath,
+      "1.1.0"
+    ];
+
+    const launcherFile = createWindowsUpdateLauncherFile(command);
+
+    expect([...launcherFile.subarray(0, 2)]).toEqual([0xff, 0xfe]);
+    const decoded = launcherFile.toString("utf16le");
+    expect(decoded.startsWith("\uFEFF")).toBe(true);
+    expect(decoded).toContain('Set shell = CreateObject("WScript.Shell")');
+    expect(decoded).toContain('shell.Run """powershell.exe""');
+    expect(decoded).toContain(', 0, False');
+    expect(decoded).toContain('Set fso = CreateObject("Scripting.FileSystemObject")');
+    expect(decoded).toContain("fso.DeleteFile WScript.ScriptFullName, True");
+    for (const argument of command) {
+      expect(decoded).toContain(argument);
+    }
+  });
+
+  it.runIf(process.platform === "win32")(
+    "launches a PowerShell helper from a Chinese path through cscript",
+    async () => {
+      const root = await mkdtemp(join(tmpdir(), "memmy-vbs-launcher-"));
+      const chineseRoot = join(root, "中文路径");
+      const helperPath = join(chineseRoot, "probe.ps1");
+      const markerPath = join(chineseRoot, "marker.txt");
+      const launcherPath = join(root, "launcher.vbs");
+      try {
+        await mkdir(chineseRoot, { recursive: true });
+        await writeFile(
+          helperPath,
+          'param([string]$Marker)\n[System.IO.File]::WriteAllBytes($Marker, [System.Text.Encoding]::UTF8.GetBytes($PSCommandPath))\n',
+          "utf8"
+        );
+        await writeFile(launcherPath, createWindowsUpdateLauncherFile([
+          "powershell.exe",
+          "-NoProfile",
+          "-ExecutionPolicy",
+          "Bypass",
+          "-WindowStyle",
+          "Hidden",
+          "-File",
+          helperPath,
+          markerPath
+        ]));
+
+        const cscriptPath = join(process.env.SystemRoot ?? "C:\\Windows", "System32", "cscript.exe");
+        const result = spawnSync(cscriptPath, ["//B", "//Nologo", launcherPath], { encoding: "utf8" });
+        expect(result.error).toBeUndefined();
+        expect(result.status).toBe(0);
+
+        let markerContent: string | undefined;
+        for (let attempt = 0; attempt < 100; attempt += 1) {
+          markerContent = await readFile(markerPath, "utf8").catch(() => undefined);
+          if (markerContent) break;
+          await delay(50);
+        }
+        expect(markerContent).toBe(helperPath);
+      } finally {
+        await rm(root, { recursive: true, force: true });
+      }
+    }
+  );
+});


### PR DESCRIPTION
## Summary

- write the temporary Windows update VBS launcher as UTF-16LE with a BOM
- preserve the existing hidden PowerShell launch command, arguments, and self-cleanup behavior
- add regression coverage for the BOM bytes, Chinese paths, full launcher content, and Windows Script Host execution

## Root cause

Windows Script Host can decode a BOM-less UTF-8 VBS file using the active system code page. Paths such as the update helper, installer, application executable, and update log can therefore be corrupted when Memmy is installed under a Chinese directory. The application still exits after queueing the launcher, leaving the old version installed.

## Verification

- `npx vitest run App/shell/desktop/tests/windows-update-launcher.test.ts App/shell/desktop/tests/packaged-runtime-boundary.test.ts` — 66 passed
- `npm run typecheck -w @memmy/desktop` — passed
- Windows `cscript.exe` regression test launches a PowerShell helper from a Chinese path and preserves the path exactly
- manual local-mock E2E: fixed 1.1.0 installed under `D:\测试路径\Memmy` upgraded to 1.1.1
- signed 1.1.0 CN and INTL packages completed and packaged ASAR verification confirmed the UTF-16LE launcher implementation

No dependency or version changes are included.