### PR TITLE
fix(frontend): keep Windows memory refresh clickable

### DIFF
--- a/App/frontend/desktop/src/styles.css
+++ b/App/frontend/desktop/src/styles.css
@@ -3894,6 +3894,10 @@ code {
   margin-bottom: 20px;
 }
 
+body.memmy-platform-windows .memory-panel__header {
+  padding-top: var(--codex-toolbar-height);
+}
+
 .memory-panel__header--single-line {
   align-items: flex-start;
   flex-wrap: wrap;

--- a/App/frontend/desktop/src/theme/tests/style-alignment.test.ts
+++ b/App/frontend/desktop/src/theme/tests/style-alignment.test.ts
@@ -276,6 +276,14 @@ describe("prototype style alignment", () => {
     expect(memorySummaryRule).toContain("-webkit-line-clamp: 2;");
   });
 
+  it("keeps the Windows memory refresh action below the native title-bar overlay", () => {
+    const windowsMemoryHeaderRule = globalCss.match(
+      /body\.memmy-platform-windows \.memory-panel__header\s*\{[^}]*\}/
+    )?.[0] ?? "";
+
+    expect(windowsMemoryHeaderRule).toContain("padding-top: var(--codex-toolbar-height);");
+  });
+
   it("keeps memory drawer IDs selectable inside the window drag area", () => {
     const memoryDrawerBackdropRule = globalCss.match(/\.memory-drawer-backdrop\s*\{[^}]*\}/)?.[0] ?? "";
     const memoryDrawerBackdropCloseRule = globalCss.match(/\.memory-drawer-backdrop__close\s*\{[^}]*\}/)?.[0] ?? "";


### PR DESCRIPTION
## Summary

- Reproduces MEMMY-318 from the attached Windows screenshot.
- Moves the memory list header below the native Windows title-bar overlay.
- Keeps the change Windows-only and adds a focused regression assertion.

## Verification

- Project Harness Bugfix Lite / Standard: passed
- Targeted style-alignment tests: 13 passed
- Harness changed files: exactly 2
