### PR TITLE
fix(frontend): avoid Windows memory drawer controls

### DIFF
--- a/App/frontend/desktop/src/styles.css
+++ b/App/frontend/desktop/src/styles.css
@@ -5055,6 +5055,10 @@ code {
   -webkit-app-region: no-drag;
 }
 
+body.memmy-platform-windows .memory-drawer {
+  padding-top: var(--codex-toolbar-height);
+}
+
 .memory-drawer,
 .memory-drawer * {
   -webkit-app-region: no-drag;

--- a/App/frontend/desktop/src/theme/tests/style-alignment.test.ts
+++ b/App/frontend/desktop/src/theme/tests/style-alignment.test.ts
@@ -276,6 +276,14 @@ describe("prototype style alignment", () => {
     expect(memorySummaryRule).toContain("-webkit-line-clamp: 2;");
   });
 
+  it("keeps the Windows memory drawer close action below the native title-bar overlay", () => {
+    const windowsMemoryDrawerRule = globalCss.match(
+      /body\.memmy-platform-windows \.memory-drawer\s*\{[^}]*\}/
+    )?.[0] ?? "";
+
+    expect(windowsMemoryDrawerRule).toContain("padding-top: var(--codex-toolbar-height);");
+  });
+
   it("keeps memory drawer IDs selectable inside the window drag area", () => {
     const memoryDrawerBackdropRule = globalCss.match(/\.memory-drawer-backdrop\s*\{[^}]*\}/)?.[0] ?? "";
     const memoryDrawerBackdropCloseRule = globalCss.match(/\.memory-drawer-backdrop__close\s*\{[^}]*\}/)?.[0] ?? "";


### PR DESCRIPTION
## Summary
- move the Windows memory detail drawer below the native title-bar overlay
- keep the drawer close action clickable without conflicting with the native window close control
- add a CSS regression assertion for the Windows-only offset

## Verification
- reproduced with a failing regression test before the fix
- targeted Vitest: 13/13 passed
- Project Harness Bugfix Lite, T1 / Standard: passed
