### PR TITLE
fix(frontend): prune stale model assignments on delete

### DIFF
--- a/App/frontend/desktop/src/state/model-workspace.ts
+++ b/App/frontend/desktop/src/state/model-workspace.ts
@@ -494,14 +494,14 @@ export function deleteModelConnection(
   const next = cloneCatalog(workspace.catalog);
   const provider = next.providers.find((item) => item.provider === connection.provider && !item.accountManaged);
   if (!provider) return { workspace, error: "connection_not_found" };
-  const removedIds = provider.models.filter((item) => item.endpointId === connection.endpointId).map((item) => item.presetId);
   provider.endpoints = provider.endpoints.filter((item) => item.endpointId !== connection.endpointId);
   provider.models = provider.models.filter((item) => item.endpointId !== connection.endpointId);
   if (!provider.endpoints.length || !provider.models.length) {
     next.providers = next.providers.filter((item) => item !== provider);
   }
-  clearAssignmentReferences(next.modelAssignments.byok, removedIds);
-  clearAssignmentReferences(next.modelAssignments.account, removedIds);
+  const remainingIds = new Set(next.providers.flatMap((item) => item.models.map((model) => model.presetId)));
+  pruneInvalidAssignmentReferences(next.modelAssignments.byok, remainingIds);
+  pruneInvalidAssignmentReferences(next.modelAssignments.account, remainingIds);
   refreshEffectiveCandidates(next);
   return { workspace: createModelWorkspace(next), error: null };
 }
@@ -783,12 +783,13 @@ function replaceIds(current: string[], oldIds: string[], nextIds: string[]): str
   return unique([...kept, ...nextIds]);
 }
 
-function clearAssignmentReferences(assignment: ModelAssignment, removedIds: string[]): void {
-  const removed = new Set(removedIds);
-  assignment.agent.candidates = assignment.agent.candidates.filter((id) => !removed.has(id));
-  if (assignment.agent.default && removed.has(assignment.agent.default)) assignment.agent.default = assignment.agent.candidates[0] ?? null;
+function pruneInvalidAssignmentReferences(assignment: ModelAssignment, validIds: ReadonlySet<string>): void {
+  assignment.agent.candidates = assignment.agent.candidates.filter((id) => validIds.has(id));
+  if (!assignment.agent.default || !assignment.agent.candidates.includes(assignment.agent.default)) {
+    assignment.agent.default = assignment.agent.candidates[0] ?? null;
+  }
   for (const key of ["memorySummary", "memoryEvolution", "embedding", "asr", "imageGeneration"] as const) {
-    if (assignment[key] && removed.has(assignment[key]!)) assignment[key] = null;
+    if (assignment[key] && !validIds.has(assignment[key]!)) assignment[key] = null;
   }
 }
 

--- a/App/frontend/desktop/src/state/tests/model-workspace.test.ts
+++ b/App/frontend/desktop/src/state/tests/model-workspace.test.ts
@@ -443,6 +443,50 @@ describe("canonical model workspace adapter", () => {
     expect(Object.values(raw.modelPresets ?? {})).not.toContainEqual(expect.objectContaining({ provider: "dashscope" }));
   });
 
+  it("真实 Backend catalog：删除共享配置时同时清理账号空间的失效平台 preset 引用", async () => {
+    const file = catalogFixture();
+    const empty = await readModelConfigCatalog(file);
+    let workspace = createModelWorkspace(empty);
+    const created = upsertByokPreset(workspace, {
+      provider: "openai",
+      endpoint: "https://api.openai.com/v1",
+      protocol: "openai-chat-completions",
+      apiKey: "test-api-key",
+      model: "gpt-4o",
+      capabilities: ["agent"]
+    });
+    workspace = assignCatalogPreset(created.workspace, "byok", "agent", created.presetId);
+    workspace = assignCatalogPreset(workspace, "account", "agent", created.presetId);
+    const createdCatalog = await persistModelCatalogMutation(modelConfigInput(workspace), {
+      read: () => readModelConfigCatalog(file),
+      write: (input) => writeModelConfigCatalog(file, input)
+    }, empty);
+    const byokPresetId = createdCatalog.modelAssignments.byok.agent.default!;
+    const staleAccountPresetId = "memmy-account-946b1209029f-agent";
+    const raw = YAML.parse(readFileSync(file, "utf8")) as any;
+    raw.modelAssignments.account = {
+      ownerAccountId: "owner-a",
+      agent: { candidates: [staleAccountPresetId, byokPresetId], default: staleAccountPresetId },
+      memorySummary: null,
+      memoryEvolution: null,
+      embedding: null,
+      asr: null,
+      imageGeneration: null
+    };
+    writeFileSync(file, YAML.stringify(raw), "utf8");
+
+    const base = await readModelConfigCatalog(file);
+    const connection = createModelWorkspace(base).spaces.account.connections.find((item) => item.provider === "openai")!;
+    const deleted = deleteModelConnection(createModelWorkspace(base), "account", connection.id);
+    const saved = await persistModelCatalogMutation(modelConfigInput(deleted.workspace), {
+      read: () => readModelConfigCatalog(file),
+      write: (input) => writeModelConfigCatalog(file, input)
+    }, base);
+
+    expect(saved.providers.some((provider) => provider.provider === "openai")).toBe(false);
+    expect(saved.modelAssignments.account.agent).toEqual({ candidates: [], default: null });
+  });
+
   it("真实 Backend catalog：删除遇到不可见 Key 并发轮换时拒绝重放", async () => {
     const file = catalogFixture();
     const base = await deletionCatalogFixture(file);


### PR DESCRIPTION
## Summary
- prune assignment references against the presets that still exist after deleting a model connection
- repair the Agent default when its referenced preset is removed or already stale
- cover the screenshot failure with a real backend catalog regression test

## Verification
- reproduced before the fix with: account assignment references missing preset memmy-account-946b1209029f-agent
- targeted model-workspace Vitest: 26/26 passed
- Project Harness Bugfix Lite, T1 / Standard: passed
