### PR TITLE
fix(analytics): route app launch through cloud

### DIFF
--- a/App/frontend/desktop/src/analytics/gtag-init.ts
+++ b/App/frontend/desktop/src/analytics/gtag-init.ts
@@ -16,15 +16,15 @@ const MEASUREMENT_ID = (import.meta.env.MEMMY_GA4_MEASUREMENT_ID as string | und
 
 let initialized = false;
 
-export function initGtag(): void {
+export function initGtag(measurementId = MEASUREMENT_ID): void {
   if (initialized) return;
   void initializeDesktopAnalyticsContext();
-  if (!MEASUREMENT_ID) {
+  if (!measurementId) {
     console.log("[analytics] initGtag skipped: MEMMY_GA4_MEASUREMENT_ID not set");
     return;
   }
   initialized = true;
-  console.log("[analytics] initGtag starting, MEASUREMENT_ID:", MEASUREMENT_ID);
+  console.log("[analytics] initGtag starting, MEASUREMENT_ID:", measurementId);
 
   window.dataLayer = window.dataLayer || [];
   // eslint-disable-next-line prefer-rest-params
@@ -32,12 +32,12 @@ export function initGtag(): void {
 
   window.gtag("js", new Date());
   const configOptions = resolveGtagConfigOptions();
-  window.gtag("config", MEASUREMENT_ID, configOptions);
+  window.gtag("config", measurementId, configOptions);
   console.log("[analytics] gtag config:", configOptions);
 
   const script = document.createElement("script");
   script.async = true;
-  script.src = `https://www.googletagmanager.com/gtag/js?id=${MEASUREMENT_ID}`;
+  script.src = `https://www.googletagmanager.com/gtag/js?id=${measurementId}`;
   document.head.appendChild(script);
   console.log("[analytics] gtag.js script injection started:", script.src);
 
@@ -48,7 +48,12 @@ export function initGtag(): void {
   // After the script finishes loading, obtain the client_id and pass it to the main process for later use
   script.onload = () => {
     console.log("[analytics] gtag.js script loaded successfully");
-    window.gtag("get", MEASUREMENT_ID, "client_id", (clientId: unknown) => {
+    // This browser-side event opens the GA4 session and enables the automatic
+    // session_start / first_visit events. Product app_launch goes through cloud.
+    window.gtag("event", "app_init");
+    console.log("[analytics] app_init sent via gtag");
+
+    window.gtag("get", measurementId, "client_id", (clientId: unknown) => {
       if (typeof clientId === "string" && clientId) {
         // Memory gate for Desktop → cloud UI events (do not read shared file here).
         setDesktopAnalyticsClientId(clientId);
@@ -57,13 +62,10 @@ export function initGtag(): void {
           appEnv: resolveAnalyticsAppEnv(),
           appEdition: resolveAnalyticsAppEdition()
         });
-        console.log("[analytics] gtag client_id ready:", clientId);
       }
     });
 
-    // app_launch stays on gtag so GA4 can auto-collect session_start/first_visit.
-    window.gtag("event", "app_launch");
-    console.log("[analytics] app_launch sent via gtag");
+    trackCloudAnalyticsEvent("app_launch");
   };
 }
 
@@ -87,7 +89,7 @@ async function initializeDesktopAnalyticsContext(): Promise<void> {
 
 /**
  * Desktop UI events go through cloud `/api/analytics/events`.
- * Kept as `gtagEvent` for call-site compatibility; only `app_launch` uses gtag directly.
+ * Kept as `gtagEvent` for call-site compatibility; app_init is emitted directly during setup.
  */
 export function gtagEvent(
   name: string,

--- a/App/frontend/desktop/src/analytics/tests/gtag-init.test.ts
+++ b/App/frontend/desktop/src/analytics/tests/gtag-init.test.ts
@@ -1,0 +1,58 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const analyticsMocks = vi.hoisted(() => ({
+  setDesktopAnalyticsClientId: vi.fn(),
+  setDesktopAnalyticsContext: vi.fn(),
+  trackCloudAnalyticsEvent: vi.fn(),
+}));
+
+vi.mock("../cloud-analytics.js", () => analyticsMocks);
+
+describe("gtag initialization", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    document.head.innerHTML = "";
+    window.dataLayer = [];
+    Reflect.deleteProperty(window, "gtag");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("uses app_init to open the GA session and sends app_launch through cloud without a session id", async () => {
+    const { initGtag } = await import("../gtag-init.js");
+    const appendChild = vi
+      .spyOn(document.head, "appendChild")
+      .mockImplementation((node) => node);
+
+    initGtag("G-TEST");
+
+    const injectedScript = appendChild.mock.calls[0]?.[0] as HTMLScriptElement | undefined;
+    expect(injectedScript?.src).toBe("https://www.googletagmanager.com/gtag/js?id=G-TEST");
+
+    injectedScript?.dispatchEvent(new Event("load"));
+
+    const commands = window.dataLayer.map((entry) => Array.from(entry));
+    expect(commands).toContainEqual(["event", "app_init"]);
+    expect(commands).not.toContainEqual(["event", "app_launch"]);
+
+    const clientIdCommand = commands.find(
+      ([command, , field]) => command === "get" && field === "client_id"
+    );
+    const sessionIdCommand = commands.find(
+      ([command, , field]) => command === "get" && field === "session_id"
+    );
+    expect(clientIdCommand).toBeDefined();
+    expect(sessionIdCommand).toBeUndefined();
+
+    const clientIdCallback = clientIdCommand?.[3] as ((value: unknown) => void) | undefined;
+    clientIdCallback?.("client-123");
+
+    expect(analyticsMocks.setDesktopAnalyticsClientId).toHaveBeenCalledWith("client-123");
+    expect(analyticsMocks.trackCloudAnalyticsEvent).toHaveBeenCalledWith("app_launch");
+  });
+});


### PR DESCRIPTION
Keep a dedicated gtag bootstrap event for GA4 automatic sessions while persisting app launches through the cloud analytics pipeline.