### PR TITLE
fix(mac): exit fullscreen before tray hide (MEMMY-362)

### DIFF
--- a/App/shell/desktop/src/main/main.ts
+++ b/App/shell/desktop/src/main/main.ts
@@ -3765,10 +3765,23 @@ function applyMainWindowActionResolution(
   }
 
   if (resolution === "hide") {
-    if (process.platform === "win32") {
-      syncMenuBarTray(true);
+    const hideWindow = () => {
+      if (targetWindow.isDestroyed()) {
+        return;
+      }
+      if (process.platform === "win32") {
+        syncMenuBarTray(true);
+      }
+      targetWindow.hide();
+    };
+
+    if (isWindowFullScreenLike(targetWindow)) {
+      waitForWindowToLeaveFullScreen(targetWindow, hideWindow);
+      leaveWindowFullScreen(targetWindow);
+      return;
     }
-    targetWindow.hide();
+
+    hideWindow();
     return;
   }
 

--- a/App/shell/desktop/tests/window-mode.test.ts
+++ b/App/shell/desktop/tests/window-mode.test.ts
@@ -367,7 +367,7 @@ describe("desktop pet window mode", () => {
     expect(source).toContain("setPetWindowMode(true);");
     expect(source).toContain('resolution === "quit"');
     expect(source).toContain("app.quit();");
-    expect(source).toContain('if (process.platform === "win32") {\n      syncMenuBarTray(true);\n    }\n    targetWindow.hide();');
+    expect(source).toContain('if (process.platform === "win32") {\n        syncMenuBarTray(true);\n      }');
     expect(source).toContain("targetWindow.hide();");
     expect(source).toContain("targetWindow.minimize();");
     expect(source).toContain("targetWindow.close();");
@@ -375,5 +375,17 @@ describe("desktop pet window mode", () => {
     expect(source).toContain("mainWindow.show();");
     expect(source).toContain("mainWindow.focus();");
     expect(source).toContain("activateMainWindow();");
+  });
+
+  it("exits macOS fullscreen before hiding the main window for the tray close action", () => {
+    const source = readFileSync(mainSourcePath, "utf8");
+    const hideBranchStart = source.indexOf('if (resolution === "hide")');
+    const hideBranchEnd = source.indexOf("\n  replayMainWindowAction", hideBranchStart);
+    const hideBranch = source.slice(hideBranchStart, hideBranchEnd);
+
+    expect(hideBranch).toContain("if (isWindowFullScreenLike(targetWindow))");
+    expect(hideBranch).toContain("waitForWindowToLeaveFullScreen(targetWindow");
+    expect(hideBranch).toContain("leaveWindowFullScreen(targetWindow);");
+    expect(hideBranch).toContain("targetWindow.hide();");
   });
 });


### PR DESCRIPTION
## Summary

Fixes MEMMY-362 on macOS: hiding the window while it is in a fullscreen-like state could leave the app in an unusable black-screen state.

## Root cause

The tray-hide path hid the window before the fullscreen transition had completed. On macOS, that ordering can leave the native window/fullscreen state inconsistent.

## Changes

- Wait for the window to leave fullscreen before hiding it when the requested resolution is `hide`.
- Keep the existing Windows tray-hide behavior unchanged.
- Add a regression test covering the fullscreen-like window path and the normal hide path.

## Verification

- Reproduced the failing regression case before the fix.
- Desktop Shell test suite: **220 passed, 106 skipped**.
- Full Project Harness gate: passed with current commit evidence.
- Working tree was clean at delivery.

## Risk and rollback

Low risk and isolated to the desktop shell window-hide flow. If rollback is required, revert commit `4ca431f7b5da1300cda695c59c1ceec8dedc1d54`.

## Harness evidence

- Harness task: `bugfix-2026-09-02-a8f31a5f-f3342950`
- Evidence fingerprint: `74ec96ada03158d2c73ac78b0d06cee480c09b2521228faa4ebc9cc55716ebf3`
- Review handoff is bound to this PR and commit.
