### PR TITLE
fix(desktop): refine update status controls

### DIFF
--- a/App/frontend/desktop/src/pages/app-frame.tsx
+++ b/App/frontend/desktop/src/pages/app-frame.tsx
@@ -63,7 +63,7 @@ import {
   Wand2
 } from "./memory/memory-prototype-icons.js";
 import { SETTINGS_NAV_ITEMS, type SettingsTabId } from "./settings-nav.js";
-import { Check, CheckCheck, ChevronDown, ChevronRight, ChevronsDownUp, ChevronsUpDown, Download, Folder, FolderOpen, FolderPlus, ListFilter, MoreHorizontal, Plus, RotateCcw } from "lucide-react";
+import { ArrowDown, Check, CheckCheck, ChevronDown, ChevronRight, ChevronsDownUp, ChevronsUpDown, Folder, FolderOpen, FolderPlus, ListFilter, MoreHorizontal, Plus, RotateCcw } from "lucide-react";
 
 export interface SettingsSidebarNav {
   activeTab: SettingsTabId;
@@ -188,6 +188,7 @@ interface SidebarUpdateActionView {
   ariaLabel: string;
   title: string;
   disabled: boolean;
+  progress: number | null;
 }
 
 const navItems: NavItem[] = [
@@ -1489,7 +1490,7 @@ export function AppFrame(props: AppFrameProps) {
                 void update?.requestInlineAction();
               }}
             >
-              {renderSidebarUpdateActionIcon(sidebarUpdateAction.kind)}
+              {renderSidebarUpdateActionIcon(sidebarUpdateAction)}
               <span className="app-frame-sidebar-update-button__label">{sidebarUpdateAction.label}</span>
             </button>
             <button
@@ -2973,7 +2974,8 @@ export function resolveSidebarUpdateAction(
       label: t("appFrame.update.available"),
       ariaLabel: t("appFrame.update.availableAria"),
       title: t("appFrame.update.availableAria"),
-      disabled: false
+      disabled: false,
+      progress: null
     };
   }
 
@@ -2984,7 +2986,8 @@ export function resolveSidebarUpdateAction(
       label: percent === null ? t("appFrame.update.downloading") : t("appFrame.update.progress", { percent }),
       ariaLabel: percent === null ? t("appFrame.update.downloadingAria") : t("appFrame.update.progressAria", { percent }),
       title: percent === null ? t("appFrame.update.downloadingAria") : t("appFrame.update.progressAria", { percent }),
-      disabled: true
+      disabled: true,
+      progress: percent
     };
   }
 
@@ -2994,7 +2997,8 @@ export function resolveSidebarUpdateAction(
       label: t("appFrame.update.installing"),
       ariaLabel: t("appFrame.update.installingAria"),
       title: t("appFrame.update.installingAria"),
-      disabled: true
+      disabled: true,
+      progress: null
     };
   }
 
@@ -3004,7 +3008,8 @@ export function resolveSidebarUpdateAction(
       label: t("appFrame.update.restart"),
       ariaLabel: t("appFrame.update.restartAria"),
       title: t("appFrame.update.restartAria"),
-      disabled: false
+      disabled: false,
+      progress: null
     };
   }
 
@@ -3018,12 +3023,29 @@ function normalizeUpdateDownloadPercent(percent: number | null | undefined): num
   return Math.min(100, Math.max(0, Math.round(percent)));
 }
 
-function renderSidebarUpdateActionIcon(kind: SidebarUpdateActionView["kind"]): ReactNode {
-  if (kind === "available") {
-    return <Download size={14} strokeWidth={2.2} aria-hidden="true" />;
+function renderSidebarUpdateActionIcon(action: SidebarUpdateActionView): ReactNode {
+  if (action.kind === "available") {
+    return <ArrowDown size={12} strokeWidth={2.2} aria-hidden="true" />;
   }
-  if (kind === "prepared") {
-    return <RefreshCw size={13} strokeWidth={2.1} aria-hidden="true" />;
+  if (action.kind === "downloading") {
+    if (action.progress === null) {
+      return <Loader2 size={14} strokeWidth={2.2} className="animate-spin" aria-hidden="true" />;
+    }
+    return (
+      <span
+        className="app-frame-sidebar-update-progress"
+        style={{ "--app-frame-sidebar-update-progress": `${action.progress}%` } as CSSProperties}
+        aria-hidden="true"
+      >
+        <span>{action.progress}</span>
+      </span>
+    );
+  }
+  if (action.kind === "installing") {
+    return <Loader2 size={14} strokeWidth={2.2} className="animate-spin" aria-hidden="true" />;
+  }
+  if (action.kind === "prepared") {
+    return <RefreshCw size={12} strokeWidth={2.1} aria-hidden="true" />;
   }
   return null;
 }

--- a/App/frontend/desktop/src/styles.css
+++ b/App/frontend/desktop/src/styles.css
@@ -10327,31 +10327,31 @@ input[type="checkbox"].check-sky:checked::after {
   flex: 0 0 auto;
   align-items: center;
   justify-content: center;
-  gap: 4px;
-  height: 32px;
-  min-width: 32px;
-  max-width: 86px;
-  padding: 0 10px;
+  gap: 3px;
+  height: 24px;
+  min-width: 24px;
+  max-width: 78px;
+  padding: 0 7px;
   border: 0;
   border-radius: 999px;
   appearance: none;
-  background: #2f8fff;
+  background: var(--color-action-sky);
   color: #fff;
   cursor: pointer;
   font-family: inherit;
-  font-size: 12px;
+  font-size: 11px;
   font-weight: 700;
   line-height: 1;
   letter-spacing: 0;
   white-space: nowrap;
-  box-shadow: 0 4px 10px rgba(47, 143, 255, 0.22);
-  transition: background-color 120ms ease, box-shadow 120ms ease, min-width 120ms ease, padding 120ms ease;
+  box-shadow: 0 2px 6px color-mix(in srgb, var(--color-action-sky) 22%, transparent);
+  transition: background-color 120ms ease, box-shadow 120ms ease, gap 120ms ease, min-width 120ms ease, padding 120ms ease;
 }
 
 .app-frame-sidebar-update-button:hover,
 .app-frame-sidebar-update-button:focus-visible {
-  background: #1d7df2;
-  box-shadow: 0 6px 14px rgba(47, 143, 255, 0.28);
+  background: var(--color-action-sky-hover);
+  box-shadow: 0 3px 8px color-mix(in srgb, var(--color-action-sky-hover) 26%, transparent);
 }
 
 .app-frame-sidebar-update-button:focus-visible {
@@ -10365,8 +10365,9 @@ input[type="checkbox"].check-sky:checked::after {
 }
 
 .app-frame-sidebar-update-button svg {
-  width: 14px;
-  height: 14px;
+  display: block;
+  width: 12px;
+  height: 12px;
   flex-shrink: 0;
 }
 
@@ -10378,8 +10379,10 @@ input[type="checkbox"].check-sky:checked::after {
 }
 
 .app-frame-sidebar-update-button--available {
-  width: 32px;
+  width: 24px;
+  min-width: 24px;
   padding: 0;
+  gap: 0;
 }
 
 .app-frame-sidebar-update-button--available .app-frame-sidebar-update-button__label {
@@ -10391,8 +10394,9 @@ input[type="checkbox"].check-sky:checked::after {
 .app-frame-sidebar-update-button--available:hover,
 .app-frame-sidebar-update-button--available:focus-visible {
   width: auto;
-  min-width: 54px;
-  padding: 0 10px;
+  min-width: 46px;
+  padding: 0 7px;
+  gap: 3px;
 }
 
 .app-frame-sidebar-update-button--available:hover .app-frame-sidebar-update-button__label,
@@ -10401,24 +10405,75 @@ input[type="checkbox"].check-sky:checked::after {
   opacity: 1;
 }
 
+.app-frame-sidebar-update-button--available:hover,
+.app-frame-sidebar-update-button--available:focus-visible {
+  min-width: 38px;
+  gap: 0;
+}
+
+.app-frame-sidebar-update-button--available:hover svg,
+.app-frame-sidebar-update-button--available:focus-visible svg {
+  display: none;
+}
+
+.app-frame-sidebar-update-button--available:not(:hover):not(:focus-visible) svg {
+  transform: translateY(-0.5px);
+}
+
 .app-frame-sidebar-update-button--downloading {
+  width: 24px;
+  min-width: 24px;
+  padding: 0;
+  gap: 0;
+  cursor: default;
+}
+
+.app-frame-sidebar-update-button--downloading .app-frame-sidebar-update-button__label {
+  display: none;
+}
+
+.app-frame-sidebar-update-progress {
+  --app-frame-sidebar-update-progress: 0%;
+  position: relative;
+  display: inline-grid;
+  width: 16px;
+  height: 16px;
+  flex: 0 0 16px;
+  place-items: center;
+  border-radius: 50%;
+  background: conic-gradient(
+    #fff var(--app-frame-sidebar-update-progress),
+    rgb(255 255 255 / 28%) 0
+  );
+  color: #fff;
+  font-size: 6px;
+  font-variant-numeric: tabular-nums;
+  font-weight: 800;
+  line-height: 1;
+}
+
+.app-frame-sidebar-update-progress::before {
+  position: absolute;
+  inset: 1.5px;
+  border-radius: inherit;
+  background: var(--color-action-sky);
+  content: "";
+}
+
+.app-frame-sidebar-update-progress > span {
+  position: relative;
+  z-index: 1;
+}
+
+.app-frame-sidebar-update-button--prepared {
+  width: auto;
   min-width: 50px;
+  padding: 0 7px;
+  gap: 3px;
 }
 
 .app-frame-sidebar-update-button--installing {
   min-width: 72px;
-}
-
-.app-frame-sidebar-update-button--prepared {
-  min-width: 58px;
-  background: #159a84;
-  box-shadow: 0 4px 10px rgba(21, 154, 132, 0.2);
-}
-
-.app-frame-sidebar-update-button--prepared:hover,
-.app-frame-sidebar-update-button--prepared:focus-visible {
-  background: #118572;
-  box-shadow: 0 6px 14px rgba(21, 154, 132, 0.24);
 }
 
 .rounded-menu {


### PR DESCRIPTION
## Summary

- align the sidebar update action with the desktop theme and compact account footer
- render downloading state as a compact circular progress indicator
- keep the restart action visible with an icon and label

## Testing

- `npm run typecheck -w @memmy/frontend-desktop`
- `npm run test -w @memmy/frontend-desktop -- --run src/app/tests/update-coordinator.test.tsx src/pages/tests/app-frame.test.tsx` (63 tests)