### PR TITLE
fix(windows): package standalone memory runtime offline

### DIFF
--- a/App/shell/desktop/electron-builder.win.unsigned.yml
+++ b/App/shell/desktop/electron-builder.win.unsigned.yml
@@ -33,6 +33,12 @@ extraResources:
     to: memory-runtime
     filter:
       - "**/*"
+  # electron-builder excludes a matcher-root node_modules directory. Copy it
+  # through its own matcher so the standalone Memory runtime stays complete.
+  - from: dist/runtime/memory/node_modules
+    to: memory-runtime/node_modules
+    filter:
+      - "**/*"
   - from: dist/runtime/bin
     to: cli
     filter:

--- a/App/shell/desktop/electron-builder.win.yml
+++ b/App/shell/desktop/electron-builder.win.yml
@@ -33,6 +33,12 @@ extraResources:
     to: memory-runtime
     filter:
       - "**/*"
+  # electron-builder excludes a matcher-root node_modules directory. Copy it
+  # through its own matcher so the standalone Memory runtime stays complete.
+  - from: dist/runtime/memory/node_modules
+    to: memory-runtime/node_modules
+    filter:
+      - "**/*"
   - from: dist/runtime/bin
     to: cli
     filter:

--- a/scripts/internal/shared/verify-packaged-asar.mjs
+++ b/scripts/internal/shared/verify-packaged-asar.mjs
@@ -2,10 +2,22 @@
 
 import { extractFile, listPackage } from "@electron/asar";
 
-const { asarPath, expected, platform, arch } = parseArgs(process.argv.slice(2));
-if (!/^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/.test(expected)) {
-  throw new Error("Expected packaged version must use semantic version syntax");
-}
+const semanticVersionPattern = /^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/;
+const assertSemanticVersion = (version, label) => {
+  if (!semanticVersionPattern.test(version ?? "")) {
+    throw new Error(`${label} must use semantic version syntax`);
+  }
+};
+
+const {
+  asarPath,
+  expected: expectedDesktop,
+  expectedMemory,
+  platform,
+  arch,
+} = parseArgs(process.argv.slice(2));
+assertSemanticVersion(expectedDesktop, "Expected packaged version");
+if (platform === "win32") assertSemanticVersion(expectedMemory, "Expected packaged Memory version");
 
 const entries = listPackage(asarPath).map((entry) => entry.replaceAll("\\", "/").replace(/^\/+/, ""));
 if (entries.some((entry) => /(^|\/)\.env(?:$|\.)/u.test(entry))) {
@@ -22,6 +34,8 @@ const requiredFiles = [
 if (platform === "win32") {
   requiredFiles.push(
     "dist/runtime/memory/package.json",
+    "dist/runtime/memory/node_modules/@memmy/agent-source-core/package.json",
+    "dist/runtime/memory/node_modules/@memmy/agent-source-core/dist/src/index.js",
     `dist/runtime/memory/node_modules/onnxruntime-node/bin/napi-v3/${platform}/${arch}/onnxruntime_binding.node`,
     `dist/runtime/memory/node_modules/onnxruntime-node/bin/napi-v3/${platform}/${arch}/onnxruntime.dll`,
     "dist/runtime/memmy-agent/dist/main.js.map",
@@ -56,30 +70,31 @@ if (platform === "win32") {
 }
 
 const versionedFiles = [
-  ["package.json", false],
-  ["dist/runtime/memmy-agent/package.json", false],
-  ["dist/runtime/memmy-agent/package-lock.json", true],
+  ["package.json", false, expectedDesktop],
+  ["dist/runtime/memmy-agent/package.json", false, expectedDesktop],
+  ["dist/runtime/memmy-agent/package-lock.json", true, expectedDesktop],
 ];
 if (platform === "win32") {
   versionedFiles.splice(1, 0,
-    ["dist/runtime/memory/package.json", false],
-    ["dist/runtime/memory/package-lock.json", true],
+    ["dist/runtime/memory/package.json", false, expectedMemory],
+    ["dist/runtime/memory/package-lock.json", true, expectedMemory],
   );
 }
-for (const [file, lock] of versionedFiles) {
+for (const [file, lock, expectedVersion] of versionedFiles) {
   // electron-builder excludes npm lockfiles by default. The staged-runtime
   // version guard validates them before packaging; re-check any that are kept.
   if (lock && !entrySet.has(file)) continue;
   const json = readAsarJson(asarPath, file);
-  if (json.version !== expected) {
+  if (json.version !== expectedVersion) {
     throw new Error(`Packaged version does not match the requested version: ${file}`);
   }
-  if (lock && json.packages?.[""]?.version !== expected) {
+  if (lock && json.packages?.[""]?.version !== expectedVersion) {
     throw new Error(`Packaged lock root does not match the requested version: ${file}`);
   }
 }
 
-console.log(`Verified packaged ASAR boundary and version ${expected}`);
+const memoryVersionSummary = expectedMemory ? ` and Memory version ${expectedMemory}` : "";
+console.log(`Verified packaged ASAR boundary and version ${expectedDesktop}${memoryVersionSummary}`);
 
 function readAsarJson(path, file) {
   try {
@@ -102,10 +117,11 @@ function parseArgs(args) {
     const flag = args[index];
     const value = args[index + 1];
     if (!flag?.startsWith("--") || value === undefined) {
-      throw new Error("Usage: verify-packaged-asar.mjs --asar <path> --expected <version> --platform <platform> --arch <arch>");
+      throw new Error("Usage: verify-packaged-asar.mjs --asar <path> --expected <version> [--expected-memory <version>] --platform <platform> --arch <arch>");
     }
     const key = flag.slice(2);
-    if (!new Set(["asar", "expected", "platform", "arch"]).has(key) || parsed[key]) {
+    if (!new Set(["asar", "expected", "expected-memory", "platform", "arch"]).has(key)
+      || Object.hasOwn(parsed, key)) {
       throw new Error(`Unknown or duplicate option: ${flag}`);
     }
     parsed[key] = value;
@@ -119,5 +135,18 @@ function parseArgs(args) {
   if (!new Set(["arm64", "x64"]).has(parsed.arch)) {
     throw new Error(`Unsupported packaged architecture: ${parsed.arch}`);
   }
-  return { asarPath: parsed.asar, expected: parsed.expected, platform: parsed.platform, arch: parsed.arch };
+  const hasExpectedMemory = Object.hasOwn(parsed, "expected-memory");
+  if (parsed.platform === "win32" && !hasExpectedMemory) {
+    throw new Error("--expected-memory is required for win32 packages");
+  }
+  if (parsed.platform !== "win32" && hasExpectedMemory) {
+    throw new Error("--expected-memory is only supported for win32 packages");
+  }
+  return {
+    asarPath: parsed.asar,
+    expected: parsed.expected,
+    expectedMemory: parsed["expected-memory"],
+    platform: parsed.platform,
+    arch: parsed.arch,
+  };
 }

--- a/scripts/internal/win/build-nsis.sh
+++ b/scripts/internal/win/build-nsis.sh
@@ -6,6 +6,7 @@ source "$ROOT_DIR/scripts/internal/shared/package-logging.sh"
 DESKTOP_DIR="$ROOT_DIR/App/shell/desktop"
 AGENT_DIR="$ROOT_DIR/App/memmy-agent"
 MEMORY_DIR="$ROOT_DIR/Memory"
+AGENT_SOURCE_CORE_DIR="$ROOT_DIR/AgentSourceCore"
 MIGRATIONS_DIR="$ROOT_DIR/Migrations"
 LOCAL_API_CONTRACTS_DIR="$ROOT_DIR/App/backend/local-api-contracts"
 RUNTIME_DIR="$DESKTOP_DIR/dist/runtime"
@@ -82,6 +83,7 @@ if [ -n "${MEMMY_DESKTOP_VERSION:-}" ]; then
 else
   DESKTOP_VERSION="$(read_package_version "$DESKTOP_DIR/package.json")"
 fi
+MEMORY_VERSION="$(read_package_version "$MEMORY_DIR/package.json")"
 node "$ROOT_DIR/scripts/internal/shared/verify-package-version.mjs" --expected "$DESKTOP_VERSION"
 export MEMMY_VERSION_SYNC_CHECK_ONLY=1
 for builder_arg in "$@"; do
@@ -301,29 +303,10 @@ install_better_sqlite3_prebuild_with_download_fallback() {
 }
 
 create_memory_runtime_manifest() {
-  node - "$MEMORY_DIR/package.json" "$RUNTIME_DIR/memory/package.json" "$RUNTIME_DIR/memory/memory-runtime.json" <<'NODE'
-const { readFileSync, writeFileSync } = require("node:fs");
-
-const [sourcePackagePath, runtimePackagePath, runtimeMetadataPath] = process.argv.slice(2);
-const sourcePackage = JSON.parse(readFileSync(sourcePackagePath, "utf8"));
-const dependencies = { ...(sourcePackage.dependencies ?? {}) };
-const runtimePackage = {
-  name: "@memmy/packaged-memory-runtime",
-  version: sourcePackage.version,
-  private: true,
-  type: "module",
-  dependencies
-};
-
-writeFileSync(runtimePackagePath, `${JSON.stringify(runtimePackage, null, 2)}\n`);
-writeFileSync(runtimeMetadataPath, `${JSON.stringify({
-  version: sourcePackage.version,
-  protocolVersion: 1,
-  target: "windows-x64",
-  entrypoint: "dist/src/server/index.js",
-  viewer: "dist/viewer/index.html"
-}, null, 2)}\n`);
-NODE
+  node "$ROOT_DIR/scripts/internal/win/create-memory-runtime-manifest.mjs" \
+    "$MEMORY_DIR/package.json" \
+    "$RUNTIME_DIR/memory/package.json" \
+    "$RUNTIME_DIR/memory/memory-runtime.json"
 
   create_memory_runtime_lock
 }
@@ -504,6 +487,15 @@ verify_windows_native_module() {
     "Memory better-sqlite3"
 }
 
+verify_windows_memory_workspace_artifacts() {
+  require_packaged_runtime_file "$RUNTIME_AGENT_SOURCE_CORE_DIR/package.json"
+  require_packaged_runtime_file "$RUNTIME_AGENT_SOURCE_CORE_DIR/dist/src/index.js"
+  if [ -L "$RUNTIME_AGENT_SOURCE_CORE_DIR" ]; then
+    echo "Packaged agent source core must not be a symbolic link." >&2
+    exit 1
+  fi
+}
+
 verify_windows_onnxruntime_module() {
   local onnxruntime_node="$RUNTIME_DIR/memory/node_modules/onnxruntime-node/bin/napi-v3/win32/x64/onnxruntime_binding.node"
   local onnxruntime_dir
@@ -597,12 +589,20 @@ verify_pruned_windows_runtime() {
 
 verify_packaged_windows_unpacked_artifacts() {
   local unpacked_runtime="$DESKTOP_DIR/release/win-unpacked/resources/app.asar.unpacked/dist/runtime"
+  local packaged_memory_runtime="$DESKTOP_DIR/release/win-unpacked/resources/memory-runtime"
+  local packaged_agent_source_core="$packaged_memory_runtime/node_modules/@memmy/agent-source-core"
   local packaged_embedding_model="$DESKTOP_DIR/release/win-unpacked/resources/embedding-models/$EMBEDDING_MODEL_ID"
 
   require_packaged_runtime_file "$DESKTOP_DIR/release/win-unpacked/resources/app.asar"
   require_packaged_runtime_file "$DESKTOP_DIR/release/win-unpacked/resources/cli/memmy-memory.cmd"
   require_packaged_runtime_file "$DESKTOP_DIR/release/win-unpacked/resources/cli/memmy.cmd"
   verify_packaged_runtime_config_boundary "$DESKTOP_DIR/release/win-unpacked/resources"
+  require_packaged_runtime_file "$packaged_agent_source_core/package.json"
+  require_packaged_runtime_file "$packaged_agent_source_core/dist/src/index.js"
+  if [ -L "$packaged_agent_source_core" ]; then
+    echo "Packaged offline Memory agent source core must not be a symbolic link." >&2
+    exit 1
+  fi
   verify_windows_x64_native_module \
     "$unpacked_runtime/memory/node_modules/better-sqlite3/build/Release/better_sqlite3.node" \
     "packaged Memory better-sqlite3"
@@ -648,6 +648,7 @@ verify_packaged_runtime_config_boundary() {
   node "$ROOT_DIR/scripts/internal/shared/verify-packaged-asar.mjs" \
     --asar "$(to_node_readable_path "$asar_file")" \
     --expected "$DESKTOP_VERSION" \
+    --expected-memory "$MEMORY_VERSION" \
     --platform win32 \
     --arch "$PACKAGE_ARCH"
 }
@@ -726,7 +727,14 @@ create_memory_runtime_manifest
 package_step_start "Install Windows x64 Memory runtime dependencies"
 npm_ci_win_x64 "$RUNTIME_DIR/memory"
 install_better_sqlite3_win_x64 "$RUNTIME_DIR/memory"
+package_step_start "Stage Windows Memory workspace runtime packages"
+RUNTIME_AGENT_SOURCE_CORE_DIR="$RUNTIME_DIR/memory/node_modules/@memmy/agent-source-core"
+rm -rf "$RUNTIME_AGENT_SOURCE_CORE_DIR"
+mkdir -p "$RUNTIME_AGENT_SOURCE_CORE_DIR"
+cp "$AGENT_SOURCE_CORE_DIR/package.json" "$RUNTIME_AGENT_SOURCE_CORE_DIR/package.json"
+cp -R "$AGENT_SOURCE_CORE_DIR/dist" "$RUNTIME_AGENT_SOURCE_CORE_DIR/dist"
 package_step_start "Verify Windows x64 Memory runtime artifacts"
+verify_windows_memory_workspace_artifacts
 verify_windows_native_module
 verify_windows_better_sqlite3_runtime "$RUNTIME_DIR/memory"
 verify_windows_onnxruntime_module

--- a/scripts/internal/win/create-memory-runtime-manifest.mjs
+++ b/scripts/internal/win/create-memory-runtime-manifest.mjs
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+
+const [sourcePackagePath, runtimePackagePath, runtimeMetadataPath] = process.argv.slice(2);
+if (!sourcePackagePath || !runtimePackagePath || !runtimeMetadataPath) {
+  throw new Error(
+    "Usage: create-memory-runtime-manifest.mjs <source-package> <runtime-package> <runtime-metadata>",
+  );
+}
+
+const sourcePackage = JSON.parse(await readFile(sourcePackagePath, "utf8"));
+const dependencies = { ...(sourcePackage.dependencies ?? {}) };
+delete dependencies["@memmy/agent-source-core"];
+
+const runtimePackage = {
+  name: "@memmy/packaged-memory-runtime",
+  version: sourcePackage.version,
+  private: true,
+  type: "module",
+  dependencies,
+};
+const runtimeMetadata = {
+  version: sourcePackage.version,
+  protocolVersion: 1,
+  target: "windows-x64",
+  entrypoint: "dist/src/server/index.js",
+  viewer: "dist/viewer/index.html",
+};
+
+await Promise.all([
+  mkdir(dirname(runtimePackagePath), { recursive: true }),
+  mkdir(dirname(runtimeMetadataPath), { recursive: true }),
+]);
+await Promise.all([
+  writeFile(runtimePackagePath, `${JSON.stringify(runtimePackage, null, 2)}\n`),
+  writeFile(runtimeMetadataPath, `${JSON.stringify(runtimeMetadata, null, 2)}\n`),
+]);

--- a/tests/packaged-runtime-config.test.mjs
+++ b/tests/packaged-runtime-config.test.mjs
@@ -143,6 +143,146 @@ describe("packaged desktop runtime configuration", () => {
     expect(existsSync(join(runtime, ".env"))).toBe(false);
   });
 
+  it("creates a standalone Windows Memory manifest without private workspace dependencies", () => {
+    const root = fixtureRoot();
+    const sourcePackage = join(root, "Memory", "package.json");
+    const runtimePackage = join(root, "runtime", "package.json");
+    const runtimeMetadata = join(root, "runtime", "memory-runtime.json");
+    writeFixtureJson(sourcePackage, {
+      name: "@memmy/memory",
+      version: "2.1.0",
+      dependencies: {
+        "@memmy/agent-source-core": "0.0.0",
+        zod: "^4.4.3",
+      },
+    });
+    const generator = join(
+      dirname(fileURLToPath(import.meta.url)),
+      "..", "scripts", "internal", "win", "create-memory-runtime-manifest.mjs",
+    );
+
+    const result = spawnSync(process.execPath, [
+      generator,
+      sourcePackage,
+      runtimePackage,
+      runtimeMetadata,
+    ], { encoding: "utf8" });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(JSON.parse(readFileSync(runtimePackage, "utf8"))).toEqual({
+      name: "@memmy/packaged-memory-runtime",
+      version: "2.1.0",
+      private: true,
+      type: "module",
+      dependencies: { zod: "^4.4.3" },
+    });
+    expect(JSON.parse(readFileSync(runtimeMetadata, "utf8"))).toEqual({
+      version: "2.1.0",
+      protocolVersion: 1,
+      target: "windows-x64",
+      entrypoint: "dist/src/server/index.js",
+      viewer: "dist/viewer/index.html",
+    });
+  });
+
+  it("validates desktop and Memory ASAR versions against independent authorities", async () => {
+    const root = fixtureRoot();
+    const verifier = join(
+      dirname(fileURLToPath(import.meta.url)),
+      "..",
+      "scripts",
+      "internal",
+      "shared",
+      "verify-packaged-asar.mjs",
+    );
+    const asar = await createAsarFixture(
+      root,
+      "independent-component-versions",
+      "1.1.2",
+      false,
+      true,
+      [],
+      "win32",
+      "complete",
+      "2.1.0",
+    );
+
+    const verified = spawnSync(
+      process.execPath,
+      [verifier, ...verifierArgs(asar, "1.1.2", "win32", "x64", "2.1.0")],
+      { encoding: "utf8" },
+    );
+    expect(verified.status, verified.stderr).toBe(0);
+
+    const staleMemory = spawnSync(
+      process.execPath,
+      [verifier, ...verifierArgs(asar, "1.1.2", "win32", "x64", "2.0.9")],
+      { encoding: "utf8" },
+    );
+    expect(staleMemory.status).not.toBe(0);
+    expect(staleMemory.stderr).toContain("dist/runtime/memory/package.json");
+
+    const missingMemoryAuthority = spawnSync(process.execPath, [
+      verifier,
+      "--asar", asar,
+      "--expected", "1.1.2",
+      "--platform", "win32",
+      "--arch", "x64",
+    ], { encoding: "utf8" });
+    expect(missingMemoryAuthority.status).not.toBe(0);
+    expect(missingMemoryAuthority.stderr).toContain("--expected-memory is required");
+
+    const invalidMemoryAuthority = spawnSync(
+      process.execPath,
+      [verifier, ...verifierArgs(asar, "1.1.2", "win32", "x64", "invalid")],
+      { encoding: "utf8" },
+    );
+    expect(invalidMemoryAuthority.status).not.toBe(0);
+    expect(invalidMemoryAuthority.stderr).toContain(
+      "Expected packaged Memory version must use semantic version syntax",
+    );
+
+    const unexpectedDarwinMemoryAuthority = spawnSync(
+      process.execPath,
+      [verifier, ...verifierArgs(asar, "1.1.2", "darwin", "arm64"), "--expected-memory", "2.1.0"],
+      { encoding: "utf8" },
+    );
+    expect(unexpectedDarwinMemoryAuthority.status).not.toBe(0);
+    expect(unexpectedDarwinMemoryAuthority.stderr).toContain(
+      "--expected-memory is only supported for win32 packages",
+    );
+
+    const emptyDarwinMemoryAuthority = spawnSync(process.execPath, [
+      verifier,
+      ...verifierArgs(asar, "1.1.2", "darwin", "arm64"),
+      "--expected-memory", "",
+    ], { encoding: "utf8" });
+    expect(emptyDarwinMemoryAuthority.status).not.toBe(0);
+    expect(emptyDarwinMemoryAuthority.stderr).toContain(
+      "--expected-memory is only supported for win32 packages",
+    );
+
+    const staleAgentAsar = await createAsarFixture(
+      root,
+      "stale-agent-version",
+      "1.1.2",
+      false,
+      true,
+      [],
+      "win32",
+      "complete",
+      "2.1.0",
+      "1.1.1",
+    );
+    const staleAgent = spawnSync(
+      process.execPath,
+      [verifier, ...verifierArgs(staleAgentAsar, "1.1.2", "win32", "x64", "2.1.0")],
+      { encoding: "utf8" },
+    );
+    expect(staleAgent.status).not.toBe(0);
+    expect(staleAgent.stderr).toContain("dist/runtime/memmy-agent/package.json");
+  });
+
   it("fails closed on ASAR env files and stale embedded versions", async () => {
     const root = fixtureRoot();
     const verifier = join(
@@ -158,6 +298,26 @@ describe("packaged desktop runtime configuration", () => {
       encoding: "utf8",
     });
     expect(good.status, good.stderr).toBe(0);
+
+    const missingAgentSourceCoreAsar = await createAsarFixture(
+      root,
+      "without-agent-source-core",
+      "1.0.8",
+      false,
+      true,
+      [],
+      "win32",
+      "manifest-only",
+    );
+    const missingAgentSourceCore = spawnSync(
+      process.execPath,
+      [verifier, ...verifierArgs(missingAgentSourceCoreAsar, "1.0.8")],
+      { encoding: "utf8" },
+    );
+    expect(missingAgentSourceCore.status).not.toBe(0);
+    expect(missingAgentSourceCore.stderr).toContain(
+      "dist/runtime/memory/node_modules/@memmy/agent-source-core/dist/src/index.js",
+    );
 
     const darwinAsar = await createAsarFixture(root, "darwin", "1.0.8", false, true, [], "darwin");
     const darwin = spawnSync(process.execPath, [verifier, ...verifierArgs(darwinAsar, "1.0.8", "darwin", "arm64")], {
@@ -226,22 +386,87 @@ describe("packaged desktop runtime configuration", () => {
     );
 
     expect(verifierCall).toContain('--arch "$PACKAGE_ARCH"');
+    expect(verifierCall).toContain('--expected-memory "$MEMORY_VERSION"');
     expect(verifierCall).not.toContain("TARGET_ARCH");
+  });
+
+  it("stages the private agent source workspace package without resolving it from npm", () => {
+    const buildScript = readFileSync(join(
+      dirname(fileURLToPath(import.meta.url)),
+      "..", "scripts", "internal", "win", "build-nsis.sh",
+    ), "utf8");
+
+    expect(buildScript).toContain('AGENT_SOURCE_CORE_DIR="$ROOT_DIR/AgentSourceCore"');
+    expect(buildScript).toContain(
+      'node "$ROOT_DIR/scripts/internal/win/create-memory-runtime-manifest.mjs"',
+    );
+    expect(buildScript).toContain(
+      'RUNTIME_AGENT_SOURCE_CORE_DIR="$RUNTIME_DIR/memory/node_modules/@memmy/agent-source-core"',
+    );
+    expect(buildScript).toContain(
+      'cp -R "$AGENT_SOURCE_CORE_DIR/dist" "$RUNTIME_AGENT_SOURCE_CORE_DIR/dist"',
+    );
+    expect(buildScript).toContain(
+      'require_packaged_runtime_file "$RUNTIME_AGENT_SOURCE_CORE_DIR/dist/src/index.js"',
+    );
+    expect(buildScript.indexOf('npm_ci_win_x64 "$RUNTIME_DIR/memory"')).toBeLessThan(
+      buildScript.indexOf('RUNTIME_AGENT_SOURCE_CORE_DIR="$RUNTIME_DIR/memory/node_modules/@memmy/agent-source-core"'),
+    );
+    expect(buildScript).toContain(
+      'local packaged_memory_runtime="$DESKTOP_DIR/release/win-unpacked/resources/memory-runtime"',
+    );
+    expect(buildScript).toContain(
+      'require_packaged_runtime_file "$packaged_agent_source_core/package.json"',
+    );
+    expect(buildScript).toContain(
+      'require_packaged_runtime_file "$packaged_agent_source_core/dist/src/index.js"',
+    );
+  });
+
+  it("copies Memory node_modules into both Windows offline runtime variants", () => {
+    for (const configName of [
+      "electron-builder.win.yml",
+      "electron-builder.win.unsigned.yml",
+    ]) {
+      const config = readFileSync(join(
+        dirname(fileURLToPath(import.meta.url)),
+        "..", "App", "shell", "desktop", configName,
+      ), "utf8");
+      expect(config).toContain([
+        "  - from: dist/runtime/memory/node_modules",
+        "    to: memory-runtime/node_modules",
+        "    filter:",
+        '      - "**/*"',
+      ].join("\n"));
+    }
   });
 });
 
-async function createAsarFixture(root, name, version, includeEnv = false, includeLocks = true, extraFiles = [], platform = "win32") {
+async function createAsarFixture(
+  root,
+  name,
+  version,
+  includeEnv = false,
+  includeLocks = true,
+  extraFiles = [],
+  platform = "win32",
+  agentSourceCoreFixture = "complete",
+  memoryVersion = version,
+  agentVersion = version,
+) {
   const source = join(root, `${name}-source`);
   const asar = join(root, `${name}.asar`);
   const manifest = { version };
-  const lock = { version, packages: { "": { version } } };
   writeFixtureJson(join(source, "package.json"), manifest);
   writeFixtureJson(join(source, "dist/main/desktop-edition.json"), {
     cloudService: "https://manifest.example.test",
   });
   for (const component of ["memory", "memmy-agent"]) {
-    writeFixtureJson(join(source, `dist/runtime/${component}/package.json`), manifest);
-    if (includeLocks) writeFixtureJson(join(source, `dist/runtime/${component}/package-lock.json`), lock);
+    const componentVersion = component === "memory" ? memoryVersion : agentVersion;
+    const componentManifest = { version: componentVersion };
+    const componentLock = { version: componentVersion, packages: { "": { version: componentVersion } } };
+    writeFixtureJson(join(source, `dist/runtime/${component}/package.json`), componentManifest);
+    if (includeLocks) writeFixtureJson(join(source, `dist/runtime/${component}/package-lock.json`), componentLock);
   }
   const contracts = join(
     source,
@@ -253,6 +478,25 @@ async function createAsarFixture(root, name, version, includeEnv = false, includ
     const ownSourceMap = join(source, "dist/runtime/memmy-agent/dist/main.js.map");
     mkdirSync(dirname(ownSourceMap), { recursive: true });
     writeFileSync(ownSourceMap, "own-production-map\n");
+    if (agentSourceCoreFixture === "complete") {
+      const agentSourceCore = join(
+        source,
+        "dist/runtime/memory/node_modules/@memmy/agent-source-core/dist/src/index.js",
+      );
+      mkdirSync(dirname(agentSourceCore), { recursive: true });
+      writeFileSync(agentSourceCore, "export {};\n");
+    }
+    if (agentSourceCoreFixture !== "missing") {
+      writeFixtureJson(
+        join(source, "dist/runtime/memory/node_modules/@memmy/agent-source-core/package.json"),
+        {
+          name: "@memmy/agent-source-core",
+          version: "0.0.0",
+          type: "module",
+          main: "./dist/src/index.js",
+        },
+      );
+    }
   }
   const targetArch = platform === "darwin" ? "arm64" : "x64";
   const onnxRuntimeRoot = join(source, `dist/runtime/memory/node_modules/onnxruntime-node/bin/napi-v3/${platform}/${targetArch}`);
@@ -275,8 +519,10 @@ async function createAsarFixture(root, name, version, includeEnv = false, includ
   return asar;
 }
 
-function verifierArgs(asar, expected, platform = "win32", arch = "x64") {
-  return ["--asar", asar, "--expected", expected, "--platform", platform, "--arch", arch];
+function verifierArgs(asar, expected, platform = "win32", arch = "x64", expectedMemory = expected) {
+  const args = ["--asar", asar, "--expected", expected, "--platform", platform, "--arch", arch];
+  if (platform === "win32") args.push("--expected-memory", expectedMemory);
+  return args;
 }
 
 function writeFixtureJson(path, value) {


### PR DESCRIPTION
## Summary

- generate the Windows standalone Memory manifest without the private @memmy/agent-source-core workspace dependency, then stage that package locally after npm installs complete
- copy the complete Memory node_modules tree into the external offline runtime and verify the staged package in both packaged runtime locations
- validate Desktop/Agent and Memory manifests with the same comparison loop while preserving their independent version authorities

## Root cause

The generated standalone Memory package retained @memmy/agent-source-core as a registry dependency, so npm attempted to resolve a private workspace package from registry.npmjs.org and failed with 404.

After removing that registry lookup, the final ASAR verifier still compared Memory 2.1.0 against the Desktop 1.1.2 expected version. Windows now passes the Memory version explicitly and applies the same validation logic with the correct per-component expected value.

## Verification

- npm run test:packaging-guards (30 tests passed)
- npx vitest run tests/release-workflow.test.ts tests/package-version-guard.test.mjs (27 tests passed)
- npm run version:check
- bash and Node syntax checks
- git diff --check
- replayed the final verifier against the previously failing app.asar: Desktop 1.1.2 and Memory 2.1.0 passed

A complete dual-repository packaging run was not repeated after the final commit.