### PR TITLE
test(windows): track packaged runtime manifest helper

### DIFF
--- a/App/shell/desktop/tests/packaged-runtime-boundary.test.ts
+++ b/App/shell/desktop/tests/packaged-runtime-boundary.test.ts
@@ -31,6 +31,9 @@ const signedMacArm64PackagePath = fileURLToPath(
 );
 const packageWinPath = fileURLToPath(new URL("../../../../scripts/package-win.sh", import.meta.url));
 const packageWinX64Path = fileURLToPath(new URL("../../../../scripts/internal/win/build-nsis.sh", import.meta.url));
+const createMemoryRuntimeManifestPath = fileURLToPath(
+  new URL("../../../../scripts/internal/win/create-memory-runtime-manifest.mjs", import.meta.url),
+);
 const winUnsignedBuilderPath = fileURLToPath(new URL("../electron-builder.win.unsigned.yml", import.meta.url));
 const winUnsignedInstallerIncludePath = fileURLToPath(new URL("../build/installer-win-unsigned.nsh", import.meta.url));
 const winUpgradeRelayScriptPath = fileURLToPath(new URL("../build/MemmyWindowsUpgradeRelay.ps1", import.meta.url));
@@ -289,13 +292,15 @@ describe("desktop packaged runtime boundaries", () => {
 
   it("keeps the Windows Memory runtime independent from private workspaces", () => {
     const source = readFileSync(packageWinX64Path, "utf8");
+    const manifestSource = readFileSync(createMemoryRuntimeManifestPath, "utf8");
 
     expect(source).toContain("run build -w @memmy/local-api-contracts");
     expect(source).not.toContain('memory/node_modules/@memmy/local-api-contracts');
     expect(source).not.toContain('memory/node_modules/@memmy/migrations');
     expect(source).toContain('cp -R "$MEMORY_DIR/dist/viewer" "$RUNTIME_DIR/memory/dist/viewer"');
     expect(source).toContain('cp -R "$MEMORY_DIR/adapters" "$RUNTIME_DIR/memory/adapters"');
-    expect(source).toContain('protocolVersion: 1');
+    expect(source).toContain('node "$ROOT_DIR/scripts/internal/win/create-memory-runtime-manifest.mjs" \\');
+    expect(manifestSource).toContain("protocolVersion: 1");
     expect(source.indexOf("run build -w @memmy/local-api-contracts")).toBeLessThan(
       source.indexOf("run build -w @memmy/memory"),
     );


### PR DESCRIPTION
## Summary
- Update the Windows packaged-runtime boundary test to follow the manifest-helper refactor from #350.
- Assert that `build-nsis.sh` invokes `scripts/internal/win/create-memory-runtime-manifest.mjs`.
- Assert that the helper continues to emit `protocolVersion: 1`.

## Why
PR #350 moved manifest generation out of the NSIS script into the dedicated helper, but the existing boundary test still inspected the old inline location. This caused the release/v1.1.2 baseline test to fail even though the generated manifest still contains the required protocol version.

## Scope
Test-only change. No Windows packaging production script or runtime behavior is changed.

## Validation
- `App/shell/desktop/tests/packaged-runtime-boundary.test.ts`: 69/69 passed.
- Project Harness Full profile: all 12 evidence checks passed.
- Base: `release/v1.1.2` at `7e3eacc2c9f65f6e59c46282baff6b906d8fe065`.

Related: follows up on #350.