### PR TITLE
fix(desktop): prevent bundled Memory restart service registration failure

### DIFF
--- a/App/shell/desktop/src/main/runtime-services.ts
+++ b/App/shell/desktop/src/main/runtime-services.ts
@@ -20,6 +20,8 @@ const MEMORY_STARTUP_TIMEOUT_MS = 120_000;
 const POLL_INTERVAL_MS = 250;
 const HTTP_TIMEOUT_MS = 1_000;
 const STOP_MANAGED_CHILD_GRACE_MS = 1_000;
+const MEMORY_STOP_COMMAND_TIMEOUT_MS = 10_000;
+const MEMORY_RESTART_STOP_TIMEOUT_MS = 10_000;
 
 type RuntimeEnv = Record<string, string | undefined>;
 type ConfigRecord = Record<string, unknown>;
@@ -194,6 +196,7 @@ export async function startManagedRuntimeServices(
   let memoryStartup: Promise<void> | null = null;
   let browserPreparation: PackagedBrowserPreparation | null = null;
   let closing = false;
+  let stopMemoryOnClose = false;
 
   async function restartMemoryRuntime(): Promise<void> {
     if (closing) throw new Error("Memmy is shutting down");
@@ -236,11 +239,23 @@ export async function startManagedRuntimeServices(
       children,
       options,
       memmyConfigPreexisting,
-      requestMemoryRestart
+      requestMemoryRestart,
+      () => closing && stopMemoryOnClose
     );
-    memoryStartup = memoryReady.catch((error) => {
-      console.warn(`Memory service unavailable during desktop startup: ${errorMessage(error)}`);
-    });
+    memoryStartup = memoryReady
+      .catch((error) => {
+        console.warn(`Memory service unavailable during desktop startup: ${errorMessage(error)}`);
+      })
+      .finally(() => {
+        // Closing can race the asynchronous installer/health wait. If a
+        // detached child is materialized after the first cleanup pass, run
+        // the same policy once more when startup settles.
+        if (closing) {
+          void stopManagedChildrenForDesktopExit(children, stopMemoryOnClose).catch((error) => {
+            console.warn(`Memory child cleanup after startup close failed: ${errorMessage(error)}`);
+          });
+        }
+      });
     const agentGatewayStartupIssue = await startAgentGatewayWithRecovery(gatewaySupervisor);
 
     return {
@@ -263,20 +278,31 @@ export async function startManagedRuntimeServices(
       },
       async close(closeOptions = {}) {
         closing = true;
+        stopMemoryOnClose = closeOptions.stopMemory === true;
         browserPreparation?.stop();
         await memoryRestart?.catch(() => undefined);
         await gatewaySupervisor.close();
         if (closeOptions.stopMemory && options.offlineMemoryRuntimeDirectory) {
-          await runBundledMemoryCli(
-            options.offlineMemoryRuntimeDirectory,
-            runtimeConfig,
-            options,
-            ["stop", "--home", dirname(runtimeConfig.configPath)]
-          );
+          try {
+            await runBundledMemoryCli(
+              options.offlineMemoryRuntimeDirectory,
+              runtimeConfig,
+              options,
+              ["stop", "--home", dirname(runtimeConfig.configPath)],
+              MEMORY_STOP_COMMAND_TIMEOUT_MS
+            );
+          } catch (error) {
+            // A failed service-manager command must not prevent cleanup of a
+            // Desktop-owned child or turn an intentional quit into a
+            // rejected close promise.
+            console.warn(`Failed to stop bundled Memory during Desktop close: ${errorMessage(error)}`);
+          }
         }
         await stopManagedChildrenForDesktopExit(children, closeOptions.stopMemory === true);
       },
       terminateSync(terminateOptions = {}) {
+        closing = true;
+        stopMemoryOnClose = terminateOptions.stopMemory === true;
         browserPreparation?.stop();
         if (terminateOptions.stopMemory && options.offlineMemoryRuntimeDirectory) {
           runBundledMemoryCliSync(
@@ -291,6 +317,8 @@ export async function startManagedRuntimeServices(
       }
     };
   } catch (error) {
+    closing = true;
+    stopMemoryOnClose = true;
     browserPreparation?.stop();
     await gatewaySupervisor.close();
     await stopManagedChildren(children);
@@ -745,8 +773,10 @@ export async function ensureMemoryService(
   children: ManagedChild[],
   options: StartManagedRuntimeServicesOptions,
   memmyConfigPreexisting = true,
-  onRestartRequested?: () => void
+  onRestartRequested?: () => void,
+  shouldStop?: () => boolean
 ): Promise<void> {
+  if (shouldStop?.()) return;
   const healthUrl = `${runtimeConfig.memoryBaseUrl}/api/v1/health`;
   const healthHeaders = memoryAuthHeaders(runtimeConfig.memoryToken);
   const probe = await probeMemoryService(healthUrl, healthHeaders);
@@ -761,70 +791,84 @@ export async function ensureMemoryService(
   }
 
   if (options.offlineMemoryRuntimeDirectory) {
+    const existingLock = readLiveMemoryServerLock(runtimeConfig.memoryDatabasePath);
+    if (existingLock) {
+      // Never switch the stable pointer while an older service still owns
+      // the database. It may be in migrations before its HTTP endpoint is
+      // available; let that owner finish before activating a new runtime.
+      try {
+        await waitForExistingMemoryService(healthUrl, healthHeaders, existingLock);
+        return;
+      } catch (error) {
+        if (readLiveMemoryServerLock(runtimeConfig.memoryDatabasePath)) throw error;
+      }
+    }
+    if (shouldStop?.()) return;
     await installBundledMemoryRuntime(
       options.offlineMemoryRuntimeDirectory,
       runtimeConfig,
       options,
       memmyConfigPreexisting
     );
-    await waitForCompatibleMemoryService(healthUrl, healthHeaders, MEMORY_STARTUP_TIMEOUT_MS);
-    return;
-  }
-
-  const existingLock = readLiveMemoryServerLock(runtimeConfig.memoryDatabasePath);
-  if (existingLock) {
-    await waitForExistingMemoryService(healthUrl, healthHeaders, existingLock);
-    return;
-  }
-
-  const memoryChild = spawnNodeService("memory", entries.memoryEntry, [
-    "--config",
-    runtimeConfig.configPath,
-    "--host",
-    runtimeConfig.memoryListenHost,
-    "--port",
-    String(runtimeConfig.memoryListenPort),
-    "--db",
-    runtimeConfig.memoryDatabasePath
-  ], {
-    MEMMY_CONFIG: runtimeConfig.configPath,
-    MEMMY_MEMORY_URL: runtimeConfig.memoryBaseUrl,
-    MEMMY_MEMORY_TOKEN: runtimeConfig.memoryToken,
-    MEMMY_MEMORY_DB: runtimeConfig.memoryDatabasePath,
-    MEMMY_EMBEDDING_MODEL_ROOT: join(options.resourcesPath, "embedding-models"),
-    MEMORY_SERVICE_URL: runtimeConfig.memoryBaseUrl,
-    MEMORY_SERVICE_TOKEN: runtimeConfig.memoryToken,
-    MEMORY_SERVICE_DB: runtimeConfig.memoryDatabasePath,
-    ...(onRestartRequested ? { [DESKTOP_MANAGED_MEMORY_ENV]: "1" } : {})
-  }, {
-    logFilePath: join(options.logDirectory, "memory.log"),
-    logLevel: options.logLevel,
-    ipc: Boolean(onRestartRequested),
-    executablePath: options.runtimeExecutable,
-    persistOnDesktopExit: true
-  });
-  if (onRestartRequested) {
-    memoryChild.process.on("message", (message) => {
-      if (isRecord(message) && message.type === MEMORY_RESTART_IPC_TYPE) {
-        onRestartRequested();
-      }
-    });
-  }
-  children.push(memoryChild);
-  try {
-    await waitForHttpService(
-      "memory",
-      healthUrl,
-      memoryChild,
-      healthHeaders,
-      MEMORY_STARTUP_TIMEOUT_MS
+    if (shouldStop?.()) return;
+    const installed = await readInstalledMemoryRuntime(runtimeConfig.configPath);
+    await startManagedMemoryService(
+      installed?.entrypoint ?? entries.memoryEntry,
+      installed?.runtimeDir ?? options.offlineMemoryRuntimeDirectory,
+      installed?.runtimeExecutable,
+      runtimeConfig,
+      children,
+      options,
+      onRestartRequested,
+      true,
+      shouldStop
     );
+    return;
+  }
+
+  await startManagedMemoryService(
+    entries.memoryEntry,
+    undefined,
+    undefined,
+    runtimeConfig,
+    children,
+    options,
+    onRestartRequested,
+    false,
+    shouldStop
+  );
+}
+
+function hasPreviousMemoryRuntimeMarker(configPath: string): boolean {
+  const serviceHome = join(dirname(configPath), "memory-service");
+  return existsSync(join(serviceHome, "current.json"))
+    || existsSync(join(serviceHome, "runtime.json"));
+}
+
+/**
+ * Stop the service-manager instance left by an older packaged Desktop before
+ * taking ownership of the bundled runtime in this process. The registration
+ * itself is retained for the next login, preserving standalone persistence;
+ * the installer command is deliberately best effort so a stale registration
+ * can never make Desktop startup fail.
+ */
+async function stopPreviouslyRegisteredMemoryService(
+  runtimeDirectory: string,
+  runtimeConfig: PackagedRuntimeConfig,
+  options: StartManagedRuntimeServicesOptions
+): Promise<boolean> {
+  try {
+    await runBundledMemoryCli(
+      runtimeDirectory,
+      runtimeConfig,
+      options,
+      ["stop", "--home", dirname(runtimeConfig.configPath)],
+      MEMORY_STOP_COMMAND_TIMEOUT_MS
+    );
+    return true;
   } catch (error) {
-    const lockOwner = readLiveMemoryServerLock(runtimeConfig.memoryDatabasePath);
-    if (!lockOwner || lockOwner.pid === memoryChild.process.pid) {
-      throw error;
-    }
-    await waitForExistingMemoryService(healthUrl, healthHeaders, lockOwner);
+    console.warn("Failed to stop a previously registered Memory service: " + errorMessage(error));
+    return false;
   }
 }
 
@@ -851,8 +895,11 @@ export function bundledMemoryInstallArguments(
   runtimeDirectory: string,
   runtimeConfig: PackagedRuntimeConfig,
   memmyConfigPreexisting: boolean,
-  executable: string
+  nodeExecutable: string
 ): string[] {
+  // Packaged Desktop owns this child process. Registering a per-user OS
+  // service here makes signed, non-elevated installs fail on Windows
+  // (schtasks) and races the direct process on macOS (launchd KeepAlive).
   return [
     "install",
     "--service-only",
@@ -862,18 +909,135 @@ export function bundledMemoryInstallArguments(
     "--db", runtimeConfig.memoryDatabasePath,
     "--endpoint", runtimeConfig.memoryBaseUrl,
     "--memmy-config-preexisting", String(memmyConfigPreexisting),
-    "--node-executable", executable,
+    "--node-executable", nodeExecutable,
     "--non-interactive",
     "--use-compatible-installed",
+    "--skip-service-registration",
+    "--skip-health-check",
     "--health-check-timeout-ms", String(MEMORY_STARTUP_TIMEOUT_MS)
   ];
 }
 
+interface InstalledMemoryRuntime {
+  entrypoint: string;
+  runtimeDir?: string;
+  runtimeExecutable?: string;
+}
+
+async function readInstalledMemoryRuntime(configPath: string): Promise<InstalledMemoryRuntime | undefined> {
+  try {
+    const serviceHome = join(dirname(configPath), "memory-service");
+    const value = JSON.parse(
+      await readFile(join(serviceHome, "current.json"), "utf8")
+    ) as Record<string, unknown>;
+    if (typeof value.entrypoint !== "string" || !existsSync(value.entrypoint)) return undefined;
+    const runtimeDir = typeof value.runtimeDir === "string" && value.runtimeDir.trim().length > 0
+      ? value.runtimeDir
+      : undefined;
+    const runtimeExecutable = typeof value.runtimeExecutable === "string"
+      && value.runtimeExecutable.trim().length > 0
+      && existsSync(value.runtimeExecutable)
+      ? resolve(value.runtimeExecutable)
+      : undefined;
+    return {
+      entrypoint: value.entrypoint,
+      runtimeDir,
+      ...(runtimeExecutable ? { runtimeExecutable } : {})
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+async function startManagedMemoryService(
+  entry: string,
+  runtimeDir: string | undefined,
+  runtimeExecutable: string | undefined,
+  runtimeConfig: PackagedRuntimeConfig,
+  children: ManagedChild[],
+  options: StartManagedRuntimeServicesOptions,
+  onRestartRequested?: () => void,
+  requireCompatible = false,
+  shouldStop?: () => boolean
+): Promise<void> {
+  if (shouldStop?.()) return;
+  const healthUrl = runtimeConfig.memoryBaseUrl + "/api/v1/health";
+  const healthHeaders = memoryAuthHeaders(runtimeConfig.memoryToken);
+  const existingLock = readLiveMemoryServerLock(runtimeConfig.memoryDatabasePath);
+  if (existingLock) {
+    try {
+      await waitForExistingMemoryService(healthUrl, healthHeaders, existingLock);
+      return;
+    } catch (error) {
+      // A service can release its lock while the health waiter is still
+      // running. In that case this Desktop instance may safely take over;
+      // preserve the original error while the lock owner is still alive.
+      if (readLiveMemoryServerLock(runtimeConfig.memoryDatabasePath)) throw error;
+    }
+  }
+  if (shouldStop?.()) return;
+
+  const memoryChild = spawnNodeService("memory", entry, [
+    "--config",
+    runtimeConfig.configPath,
+    "--host",
+    runtimeConfig.memoryListenHost,
+    "--port",
+    String(runtimeConfig.memoryListenPort),
+    "--db",
+    runtimeConfig.memoryDatabasePath
+  ], {
+    MEMMY_CONFIG: runtimeConfig.configPath,
+    MEMMY_MEMORY_URL: runtimeConfig.memoryBaseUrl,
+    MEMMY_MEMORY_TOKEN: runtimeConfig.memoryToken,
+    MEMMY_MEMORY_DB: runtimeConfig.memoryDatabasePath,
+    MEMMY_EMBEDDING_MODEL_ROOT: join(runtimeDir ?? options.resourcesPath, "embedding-models"),
+    MEMORY_SERVICE_URL: runtimeConfig.memoryBaseUrl,
+    MEMORY_SERVICE_TOKEN: runtimeConfig.memoryToken,
+    MEMORY_SERVICE_DB: runtimeConfig.memoryDatabasePath,
+    ...(onRestartRequested ? { [DESKTOP_MANAGED_MEMORY_ENV]: "1" } : {})
+  }, {
+    logFilePath: join(options.logDirectory, "memory.log"),
+    logLevel: options.logLevel,
+    ipc: Boolean(onRestartRequested),
+    executablePath: runtimeExecutable ?? options.runtimeExecutable,
+    persistOnDesktopExit: true
+  });
+  if (onRestartRequested) {
+    memoryChild.process.on("message", (message) => {
+      if (isRecord(message) && message.type === MEMORY_RESTART_IPC_TYPE) onRestartRequested();
+    });
+  }
+  children.push(memoryChild);
+  try {
+    if (requireCompatible) {
+      await waitForCompatibleMemoryService(
+        healthUrl,
+        healthHeaders,
+        MEMORY_STARTUP_TIMEOUT_MS,
+        memoryChild
+      );
+    } else {
+      await waitForHttpService("memory", healthUrl, memoryChild, healthHeaders, MEMORY_STARTUP_TIMEOUT_MS);
+    }
+  } catch (error) {
+    const lockOwner = readLiveMemoryServerLock(runtimeConfig.memoryDatabasePath);
+    if (!lockOwner || lockOwner.pid === memoryChild.process.pid) {
+      await stopManagedChild(memoryChild).catch(() => undefined);
+      removeManagedChild(children, memoryChild);
+      throw error;
+    }
+    await stopManagedChild(memoryChild).catch(() => undefined);
+    removeManagedChild(children, memoryChild);
+    await waitForExistingMemoryService(healthUrl, healthHeaders, lockOwner);
+  }
+}
 async function runBundledMemoryCli(
   runtimeDirectory: string,
   runtimeConfig: PackagedRuntimeConfig,
   options: StartManagedRuntimeServicesOptions,
-  commandArgs: string[]
+  commandArgs: string[],
+  timeoutMs?: number
 ): Promise<void> {
   const cliEntry = join(runtimeDirectory, "dist", "src", "cli", "index.js");
   if (!existsSync(cliEntry)) throw new Error(`Bundled Memory CLI is missing: ${cliEntry}`);
@@ -895,11 +1059,28 @@ async function runBundledMemoryCli(
     const append = (chunk: unknown) => { output = `${output}${String(chunk)}`.slice(-4_000); };
     child.stdout?.on("data", append);
     child.stderr?.on("data", append);
-    child.once("error", rejectInstall);
+    let settled = false;
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    const finish = (error?: Error) => {
+      if (settled) return;
+      settled = true;
+      if (timeout) clearTimeout(timeout);
+      if (error) rejectInstall(error);
+      else resolveInstall();
+    };
+    child.once("error", (error) => finish(error instanceof Error ? error : new Error(String(error))));
     child.once("exit", (code, signal) => {
-      if (code === 0) resolveInstall();
-      else rejectInstall(new Error(`Bundled Memory command failed (${signal ? `signal ${signal}` : `code ${String(code)}`}): ${output.trim()}`));
+      if (code === 0) finish();
+      else finish(new Error(`Bundled Memory command failed (${signal ? `signal ${signal}` : `code ${String(code)}`}): ${output.trim()}`));
     });
+    if (timeoutMs !== undefined) {
+      const timer = setTimeout(() => {
+        finish(new Error("Bundled Memory command timed out after " + timeoutMs + "ms"));
+        try { child.kill(); } catch { /* the process may already have exited */ }
+      }, timeoutMs);
+      timeout = timer;
+      if (settled) clearTimeout(timer);
+    }
   });
 }
 
@@ -929,6 +1110,30 @@ function runBundledMemoryCliSync(
   }
 }
 
+async function stopManagedMemoryChild(
+  child: ManagedChild,
+  healthUrl: string,
+  healthHeaders: Record<string, string>,
+  runtimeConfig: PackagedRuntimeConfig
+): Promise<void> {
+  try {
+    if (await probeMemoryService(healthUrl, healthHeaders) === "ready") {
+      await requestMemoryServiceShutdown({
+        baseUrl: runtimeConfig.memoryBaseUrl,
+        token: runtimeConfig.memoryToken
+      });
+      await waitForHttpServiceStop(healthUrl, healthHeaders, MEMORY_RESTART_STOP_TIMEOUT_MS);
+      if (isManagedChildRunning(child)) {
+        await stopManagedChild(child);
+      }
+      return;
+    }
+  } catch (error) {
+    console.warn("Graceful Memory shutdown failed; falling back to process stop: " + errorMessage(error));
+  }
+  await stopManagedChild(child);
+}
+
 async function restartManagedMemoryService(
   entries: RuntimeEntryPaths,
   runtimeConfig: PackagedRuntimeConfig,
@@ -939,25 +1144,111 @@ async function restartManagedMemoryService(
   const healthUrl = `${runtimeConfig.memoryBaseUrl}/api/v1/health`;
   const healthHeaders = memoryAuthHeaders(runtimeConfig.memoryToken);
   const managedMemory = children.filter((child) => child.name === "memory" && isManagedChildRunning(child));
+  const installed = options.offlineMemoryRuntimeDirectory
+    ? await readInstalledMemoryRuntime(runtimeConfig.configPath)
+    : undefined;
+  let managerStopAttempted = false;
 
   if (managedMemory.length > 0) {
-    await Promise.all(managedMemory.map((child) => stopManagedChild(child)));
+    await Promise.all(managedMemory.map((child) => stopManagedMemoryChild(
+      child,
+      healthUrl,
+      healthHeaders,
+      runtimeConfig
+    )));
   } else {
-    const probe = await probeHttpService(healthUrl, healthHeaders);
-    if (probe === "ready") {
-      await requestMemoryServiceShutdown({
-        baseUrl: runtimeConfig.memoryBaseUrl,
-        token: runtimeConfig.memoryToken
-      });
-    } else if (probe === "unexpected") {
+    // Inspect the endpoint and sqlite lock before touching launchd/schtasks.
+    // A live lock can represent a legitimate migration that has not exposed
+    // HTTP yet; stopping it first would make the next process race the same DB.
+    let probe = await probeHttpService(healthUrl, healthHeaders);
+    if (probe === "unexpected") {
       throw new Error(`Memory endpoint is occupied by an unexpected service: ${healthUrl}`);
-    } else {
-      await stopLockedMemoryService(runtimeConfig.memoryDatabasePath, entries.memoryEntry);
+    }
+    const lock = probe === "unreachable"
+      ? readLiveMemoryServerLock(runtimeConfig.memoryDatabasePath)
+      : null;
+    if (lock) {
+      try {
+        await waitForExistingMemoryService(healthUrl, healthHeaders, lock);
+        probe = "ready";
+      } catch {
+        // If the owner is still alive, stop only after it has failed its
+        // bounded compatibility wait. If it exited, continue with install.
+        if (readLiveMemoryServerLock(runtimeConfig.memoryDatabasePath)) {
+          await stopLockedMemoryService(
+            runtimeConfig.memoryDatabasePath,
+            installed?.entrypoint ?? entries.memoryEntry
+          );
+        }
+        probe = await probeHttpService(healthUrl, healthHeaders);
+        if (probe === "unexpected") {
+          throw new Error(`Memory endpoint is occupied by an unexpected service: ${healthUrl}`);
+        }
+      }
+    }
+    if (options.offlineMemoryRuntimeDirectory && hasPreviousMemoryRuntimeMarker(runtimeConfig.configPath)) {
+      managerStopAttempted = await stopPreviouslyRegisteredMemoryService(
+        options.offlineMemoryRuntimeDirectory,
+        runtimeConfig,
+        options
+      );
+      // The CLI stop command normally shuts the endpoint down itself. Reprobe
+      // because an already-running KeepAlive manager may have restarted it.
+      probe = await probeHttpService(healthUrl, healthHeaders);
+      if (probe === "unexpected") {
+        throw new Error(`Memory endpoint is occupied by an unexpected service: ${healthUrl}`);
+      }
+    }
+    if (probe === "ready") {
+      try {
+        await requestMemoryServiceShutdown({
+          baseUrl: runtimeConfig.memoryBaseUrl,
+          token: runtimeConfig.memoryToken
+        });
+      } catch (error) {
+        console.warn("Memory service shutdown request failed during restart: " + errorMessage(error));
+        const lockAfterFailure = readLiveMemoryServerLock(runtimeConfig.memoryDatabasePath);
+        if (lockAfterFailure) {
+          await stopLockedMemoryService(
+            runtimeConfig.memoryDatabasePath,
+            installed?.entrypoint ?? entries.memoryEntry
+          );
+        }
+      }
+    } else if (probe === "unreachable") {
+      const lockAfterProbe = readLiveMemoryServerLock(runtimeConfig.memoryDatabasePath);
+      if (lockAfterProbe) {
+        try {
+          await waitForExistingMemoryService(healthUrl, healthHeaders, lockAfterProbe);
+          await requestMemoryServiceShutdown({
+            baseUrl: runtimeConfig.memoryBaseUrl,
+            token: runtimeConfig.memoryToken
+          });
+        } catch {
+          await stopLockedMemoryService(
+            runtimeConfig.memoryDatabasePath,
+            installed?.entrypoint ?? entries.memoryEntry
+          );
+        }
+      }
     }
   }
 
   removeManagedChildrenByName(children, "memory");
-  await waitForHttpServiceStop(healthUrl, healthHeaders);
+  try {
+    await waitForHttpServiceStop(
+      healthUrl,
+      healthHeaders,
+      options.offlineMemoryRuntimeDirectory ? MEMORY_RESTART_STOP_TIMEOUT_MS : undefined
+    );
+  } catch (error) {
+    // launchd KeepAlive can legitimately bring the standalone service back
+    // before the stop poll observes a gap. A compatible endpoint is already
+    // a valid restart result; ensureMemoryService will reuse it.
+    if (!options.offlineMemoryRuntimeDirectory || !managerStopAttempted || (await probeMemoryService(healthUrl, healthHeaders)) !== "ready") {
+      throw error;
+    }
+  }
   await ensureMemoryService(entries, runtimeConfig, children, options, true, onRestartRequested);
 }
 
@@ -1408,8 +1699,13 @@ export function spawnNodeService(
     appendTail(managed.stderrTail, text);
     logWriter?.write(text);
   });
+  child.once("error", (error) => {
+    managed.exitDescription ??= "error " + errorMessage(error);
+    logWriter?.write(managed.exitDescription + "\n");
+    managed.logWriter?.close();
+  });
   child.once("exit", (code, signal) => {
-    managed.exitDescription = signal ? `signal ${signal}` : `code ${code ?? "unknown"}`;
+    managed.exitDescription ??= signal ? `signal ${signal}` : `code ${code ?? "unknown"}`;
     managed.logWriter?.close();
   });
   if (persistOnDesktopExit) {
@@ -1452,11 +1748,21 @@ async function probeMemoryService(url: string, headers: Record<string, string> =
 async function waitForCompatibleMemoryService(
   url: string,
   headers: Record<string, string>,
-  timeoutMs: number
+  timeoutMs: number,
+  child?: ManagedChild,
+  lock?: MemoryServerLock
 ): Promise<void> {
   const deadline = Date.now() + timeoutMs;
   let lastProbe: HttpProbeResult | "incompatible" = "unreachable";
   while (Date.now() < deadline) {
+    if (child?.exitDescription) {
+      throw new Error(
+        "memory exited before it became compatible (" + child.exitDescription + "). " + formatChildTail(child)
+      );
+    }
+    if (lock && !isProcessAlive(lock.pid)) {
+      throw new Error("memory lock owner pid " + lock.pid + " exited before it became compatible");
+    }
     lastProbe = await probeMemoryService(url, headers);
     if (lastProbe === "ready") return;
     if (lastProbe === "incompatible") {
@@ -1464,11 +1770,15 @@ async function waitForCompatibleMemoryService(
     }
     await sleep(POLL_INTERVAL_MS);
   }
-  throw new Error(`Memory did not become compatible at ${url} (${lastProbe})`);
+  throw new Error("Memory did not become compatible at " + url + " (" + lastProbe + ")" + (child ? ". " + formatChildTail(child) : ""));
 }
 
-async function waitForHttpServiceStop(url: string, headers: Record<string, string> = {}): Promise<void> {
-  const deadline = Date.now() + STARTUP_TIMEOUT_MS;
+async function waitForHttpServiceStop(
+  url: string,
+  headers: Record<string, string> = {},
+  timeoutMs = STARTUP_TIMEOUT_MS
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     if (await probeHttpService(url, headers) === "unreachable") {
       return;
@@ -1526,7 +1836,13 @@ async function waitForExistingMemoryService(
   lock: MemoryServerLock
 ): Promise<void> {
   try {
-    await waitForCompatibleMemoryService(healthUrl, healthHeaders, MEMORY_STARTUP_TIMEOUT_MS);
+    await waitForCompatibleMemoryService(
+      healthUrl,
+      healthHeaders,
+      MEMORY_STARTUP_TIMEOUT_MS,
+      undefined,
+      lock
+    );
   } catch (error) {
     throw new Error(
       `Existing Memory service pid ${lock.pid} did not become ready at ${healthUrl}: ${errorMessage(error)}`
@@ -1661,6 +1977,11 @@ function removeManagedChildrenByName(children: ManagedChild[], name: string): vo
       children.splice(index, 1);
     }
   }
+}
+
+function removeManagedChild(children: ManagedChild[], child: ManagedChild): void {
+  const index = children.indexOf(child);
+  if (index >= 0) children.splice(index, 1);
 }
 
 function memoryAuthHeaders(token: string): Record<string, string> {

--- a/App/shell/desktop/tests/packaged-runtime-boundary.test.ts
+++ b/App/shell/desktop/tests/packaged-runtime-boundary.test.ts
@@ -1902,7 +1902,7 @@ describe("desktop packaged runtime boundaries", () => {
   it("points packaged Memory at the bundled local embedding model resources", () => {
     const source = readFileSync(runtimeServicesPath, "utf8");
 
-    expect(source).toContain('MEMMY_EMBEDDING_MODEL_ROOT: join(options.resourcesPath, "embedding-models")');
+    expect(source).toContain('MEMMY_EMBEDDING_MODEL_ROOT: join(runtimeDir ?? options.resourcesPath, "embedding-models")');
   });
 
   it("prunes and verifies only proven Windows x64 packaged runtime waste", () => {

--- a/App/shell/desktop/tests/runtime-services.test.ts
+++ b/App/shell/desktop/tests/runtime-services.test.ts
@@ -3,7 +3,7 @@ import { EventEmitter } from "node:events";
 import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { createServer, type Server } from "node:http";
 import { tmpdir } from "node:os";
-import { join, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { PassThrough } from "node:stream";
 import YAML from "yaml";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -124,6 +124,129 @@ describe("packaged desktop runtime config", () => {
     expect(spawnedEnv).not.toHaveProperty("MEMMY_MIGRATIONS_READY_APP_DATABASE");
   });
 
+  it("materializes bundled Memory without asking the OS to register a service", () => {
+    const args = bundledMemoryInstallArguments(
+      "/runtime/memory",
+      {
+        configPath: "/memmy/config.yaml",
+        agentWorkspace: "/memmy/workspace",
+        memoryDatabasePath: "/memmy/memory.sqlite",
+        memoryBaseUrl: "http://127.0.0.1:18960",
+        memoryToken: "",
+        memoryListenHost: "127.0.0.1",
+        memoryListenPort: 18960,
+        agentGatewayBaseUrl: "http://127.0.0.1:18980",
+        agentGatewayHealthHost: "127.0.0.1",
+        agentGatewayHealthPort: 18970,
+        agentGatewayBootstrapSecret: "secret"
+      },
+      true,
+      process.execPath
+    );
+
+    expect(args).toContain("--skip-service-registration");
+    expect(args).toContain("--skip-health-check");
+  });
+
+  it("starts the materialized bundled Memory runtime as a Desktop child", async () => {
+    const root = await makeTempRoot();
+    const home = join(root, "home");
+    const bundled = join(root, "bundled-memory");
+    const cliEntry = join(bundled, "dist", "src", "cli", "index.js");
+    const runtimeDir = join(home, "memory-service", "runtime", "fixture");
+    const bundledServerEntry = join(bundled, "dist", "src", "server", "index.js");
+    const installedServerEntry = join(runtimeDir, "dist", "src", "server", "index.js");
+    await mkdir(dirname(cliEntry), { recursive: true });
+    await mkdir(dirname(bundledServerEntry), { recursive: true });
+    await writeFile(bundledServerEntry, [
+      "const http = require('node:http');",
+      "const args = process.argv.slice(2);",
+      "const port = Number(args[args.indexOf('--port') + 1]);",
+      "const server = http.createServer((request, response) => {",
+      "  if (request.url === '/api/v1/health') {",
+      "    response.writeHead(200, { 'content-type': 'application/json' });",
+      "    response.end(JSON.stringify({ ok: true, protocolVersion: 1 }));",
+      "    return;",
+      "  }",
+      "  response.writeHead(404);",
+      "  response.end();",
+      "});",
+      "server.listen(port, '127.0.0.1');",
+      "const shutdown = () => server.close(() => process.exit(0));",
+      "process.once('SIGTERM', shutdown);",
+      "process.once('SIGINT', shutdown);"
+    ].join("\n"), "utf8");
+    await writeFile(cliEntry, [
+      "const fs = require('node:fs');",
+      "const path = require('node:path');",
+      "const args = process.argv.slice(2);",
+      "if (args[0] !== 'install' || !args.includes('--skip-service-registration') || !args.includes('--skip-health-check')) {",
+      "  console.error('Desktop must not register a bundled Memory service');",
+      "  process.exit(17);",
+      "}",
+      "const homeArg = args.indexOf('--home');",
+      "const home = args[homeArg + 1];",
+      "const bundledArg = args.indexOf('--runtime-directory');",
+      "const bundled = args[bundledArg + 1];",
+      "const installedRuntimeDir = path.join(home, 'memory-service', 'runtime', 'fixture');",
+      "const entrypoint = path.join(installedRuntimeDir, 'dist', 'src', 'server', 'index.js');",
+      "fs.mkdirSync(path.dirname(entrypoint), { recursive: true });",
+      "fs.copyFileSync(path.join(bundled, 'dist', 'src', 'server', 'index.js'), entrypoint);",
+      "fs.writeFileSync(path.join(home, 'memory-service', 'current.json'), JSON.stringify({ runtimeDir: installedRuntimeDir, entrypoint, runtimeExecutable: process.execPath }));",
+      "process.exit(0);"
+    ].join("\n"), "utf8");
+
+    const reservation = createServer();
+    await new Promise<void>((resolveListen, rejectListen) => {
+      reservation.once("error", rejectListen);
+      reservation.listen(0, "127.0.0.1", resolveListen);
+    });
+    const address = reservation.address();
+    if (!address || typeof address === "string") throw new Error("expected TCP address");
+    const port = address.port;
+    await new Promise<void>((resolveClose) => reservation.close(() => resolveClose()));
+
+    const runtimeConfig: PackagedRuntimeConfig = {
+      configPath: join(home, "config.yaml"),
+      agentWorkspace: join(home, "workspace"),
+      memoryDatabasePath: join(home, "memory.sqlite"),
+      memoryBaseUrl: "http://127.0.0.1:" + port,
+      memoryToken: "",
+      memoryListenHost: "127.0.0.1",
+      memoryListenPort: port,
+      agentGatewayBaseUrl: "http://127.0.0.1:18980",
+      agentGatewayHealthHost: "127.0.0.1",
+      agentGatewayHealthPort: 18970,
+      agentGatewayBootstrapSecret: "secret"
+    };
+    const children: ManagedChild[] = [];
+    try {
+      await ensureMemoryService(
+        { memoryEntry: join(root, "missing-memory.js"), agentEntry: join(root, "missing-agent.js") },
+        runtimeConfig,
+        children,
+        {
+          appPath: root,
+          appDatabaseFile: join(home, "app.sqlite"),
+          resourcesPath: root,
+          logDirectory: root,
+          logLevel: "info",
+          runtimeExecutable: process.execPath,
+          offlineMemoryRuntimeDirectory: bundled
+        },
+        true,
+        vi.fn()
+      );
+
+      expect(children).toHaveLength(1);
+      expect(children[0]?.name).toBe("memory");
+      expect(children[0]?.persistOnDesktopExit).toBe(true);
+      expect(children[0]?.process.pid).toBeTypeOf("number");
+    } finally {
+      await stopManagedChildrenForDesktopExit(children, true);
+    }
+  });
+
   it("omits an implicit workspace override while still passing the Desktop database target", async () => {
     const root = await makeTempRoot();
     const child = Object.assign(new EventEmitter(), {
@@ -178,7 +301,8 @@ describe("packaged desktop runtime config", () => {
     );
 
     expect(args.slice(-2)).toEqual(["--health-check-timeout-ms", "120000"]);
-    expect(args).not.toContain("--skip-health-check");
+    expect(args).toContain("--skip-service-registration");
+    expect(args).toContain("--skip-health-check");
   });
 
   it("rejects when the packaged migration command exits unsuccessfully", async () => {


### PR DESCRIPTION
## 问题

1.1.2 签名包安装后，Desktop 离线启动仍调用 Memory installer 注册系统服务。Windows 以普通用户执行 schtasks /Create /F 时，旧任务的权限或所有权会导致拒绝访问；macOS 的 launchd KeepAlive 与重启和健康检查并发，造成旧进程重新拉起、端口竞争和 memory layer network error。

## 修复

- 打包版 Desktop 安装 Memory 时跳过 OS service registration 和 installer health check。
- Desktop 读取已安装 runtime 指针，并直接托管 bundled Memory 子进程。
- 增加 SQLite 锁感知等待、协议兼容等待、优雅停止和旧版服务接管。
- 保留普通 Memory CLI 的独立服务注册行为。
- 增加实际启动 bundled runtime 的回归测试。

## 验证

- Harness Full 全部必需证据通过。
- lint、typecheck、Desktop/Memory/App Agent 测试通过。
- memory-layer smoke 3/3 通过。

修复提交：080c4ce