### PR TITLE
fix(frontend): refine sidebar alignment and modal interaction

### DIFF
--- a/App/frontend/desktop/src/components/modal.tsx
+++ b/App/frontend/desktop/src/components/modal.tsx
@@ -36,6 +36,7 @@ export interface ModalProps {
 export function Modal(props: ModalProps) {
   const titleId = useId();
   const dialogRef = useRef<HTMLElement | null>(null);
+  const backdropPressRef = useRef(false);
   const wasOpenRef = useRef(false);
   const showHeader = props.showHeader ?? true;
   const showCloseButton = props.showCloseButton ?? Boolean(props.onClose);
@@ -82,7 +83,22 @@ export function Modal(props: ModalProps) {
     <div
       className={["modal-backdrop", props.backdropClassName].filter(Boolean).join(" ")}
       role="presentation"
-      onClick={(event) => shouldCloseModalByBackdrop(event) && props.onClose?.()}
+      onPointerDown={(event) => {
+        backdropPressRef.current = event.target === event.currentTarget;
+      }}
+      onPointerUp={(event) => {
+        backdropPressRef.current = backdropPressRef.current && event.target === event.currentTarget;
+      }}
+      onPointerCancel={() => {
+        backdropPressRef.current = false;
+      }}
+      onClick={(event) => {
+        const shouldClose = backdropPressRef.current && shouldCloseModalByBackdrop(event);
+        backdropPressRef.current = false;
+        if (shouldClose) {
+          props.onClose?.();
+        }
+      }}
     >
       <section
         ref={dialogRef}

--- a/App/frontend/desktop/src/components/tests/Modal.test.tsx
+++ b/App/frontend/desktop/src/components/tests/Modal.test.tsx
@@ -1,7 +1,13 @@
+// @vitest-environment happy-dom
+
 /** Modal tests. */
+import { act } from "react";
+import { createRoot } from "react-dom/client";
 import { renderToString } from "react-dom/server";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { Modal, shouldCloseModalByBackdrop, shouldCloseModalByKey, shouldInitializeModalFocus } from "../modal.js";
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
 describe("Modal", () => {
   it("renders a centered dialog without right-side drawer classes", () => {
@@ -81,5 +87,47 @@ describe("Modal", () => {
 
     expect(shouldCloseModalByBackdrop({ target: backdrop, currentTarget: backdrop } as never)).toBe(true);
     expect(shouldCloseModalByBackdrop({ target: {}, currentTarget: backdrop } as never)).toBe(false);
+  });
+
+  it("does not close when a text-selection drag starts inside the modal and ends on the backdrop", () => {
+    const container = document.createElement("div");
+    const root = createRoot(container);
+    const onClose = vi.fn();
+    document.body.append(container);
+
+    try {
+      act(() => root.render(
+        <Modal open title="Model configuration" onClose={onClose}>
+          <span>gpt-5.4</span>
+        </Modal>
+      ));
+
+      const backdrop = container.querySelector<HTMLElement>(".modal-backdrop")!;
+      const modelId = container.querySelector<HTMLElement>(".modal-body span")!;
+
+      act(() => {
+        modelId.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true }));
+        backdrop.dispatchEvent(new PointerEvent("pointerup", { bubbles: true }));
+        backdrop.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      });
+      expect(onClose).not.toHaveBeenCalled();
+
+      act(() => {
+        backdrop.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true }));
+        modelId.dispatchEvent(new PointerEvent("pointerup", { bubbles: true }));
+        backdrop.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      });
+      expect(onClose).not.toHaveBeenCalled();
+
+      act(() => {
+        backdrop.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true }));
+        backdrop.dispatchEvent(new PointerEvent("pointerup", { bubbles: true }));
+        backdrop.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      });
+      expect(onClose).toHaveBeenCalledOnce();
+    } finally {
+      act(() => root.unmount());
+      container.remove();
+    }
   });
 });

--- a/App/frontend/desktop/src/styles.css
+++ b/App/frontend/desktop/src/styles.css
@@ -10602,7 +10602,7 @@ input[type="checkbox"].check-sky:checked::after {
   display: flex;
   min-height: 44px;
   align-items: center;
-  padding: 6px 14px 12px 30px;
+  padding: 6px 14px 12px 20px;
 }
 
 .memory-page-back-button {
@@ -10631,7 +10631,7 @@ input[type="checkbox"].check-sky:checked::after {
 }
 
 .memory-page-section-header {
-  padding: 0 14px 0 30px;
+  padding: 0 14px 0 20px;
   margin-bottom: 6px;
 }
 

--- a/App/frontend/desktop/src/theme/tests/style-alignment.test.ts
+++ b/App/frontend/desktop/src/theme/tests/style-alignment.test.ts
@@ -170,11 +170,11 @@ describe("prototype style alignment", () => {
     expect(memorySidebarRule).toContain("padding-top: 0;");
     expect(memoryToolbarRule).toContain("flex: 0 0 var(--codex-toolbar-height);");
     expect(memoryToolbarRule).toContain("min-height: var(--codex-toolbar-height);");
-    expect(memoryReturnRowRule).toContain("padding: 6px 14px 12px 30px;");
+    expect(memoryReturnRowRule).toContain("padding: 6px 14px 12px 20px;");
     expect(memoryBackButtonRule).toContain("height: 32px;");
     expect(memoryBackButtonRule).toContain("gap: 10px;");
     expect(memoryBackButtonRule).toContain("font-size: var(--codex-text-base);");
-    expect(memorySectionHeaderRule).toContain("padding: 0 14px 0 30px;");
+    expect(memorySectionHeaderRule).toContain("padding: 0 14px 0 20px;");
     expect(dragRegionRule).toContain("position: fixed;");
     expect(dragRegionRule).toContain("right: 0;");
     expect(dragRegionRule).toContain("left: 0;");


### PR DESCRIPTION
## Summary
- align the settings and memory sidebar back controls and memory section headings with the verified sidebar spacing
- prevent modal backdrop closure when dragging to select text outside the dialog
- keep direct backdrop clicks, Escape, and the explicit close button behavior intact

## Validation
- `npm test -w @memmy/frontend-desktop -- src/components/tests/Modal.test.tsx src/theme/tests/style-alignment.test.ts` (23 passed)
- `npm run build -w @memmy/frontend-desktop`
- launched the complete desktop development stack and verified the renderer, Memory, gateway, WebUI, and Agent API listeners

No documentation changes are included.