### PR TITLE
fix(agent): let BYOK models outside the capability catalog receive images

### DIFF
--- a/App/memmy-agent/src/core/agent-runtime/runner.ts
+++ b/App/memmy-agent/src/core/agent-runtime/runner.ts
@@ -4,6 +4,7 @@ import { LLMProvider, LLMResponse, ToolCallRequest } from "../../providers/base.
 import {
   coversInputModalities,
   getModelInputModalities,
+  hasDeclaredInputModalities,
   requiredInputModalities,
 } from "../../providers/model-input-capabilities.js";
 import type { ActualModelContext } from "@memmy/local-api-contracts";
@@ -675,9 +676,14 @@ export class AgentRunner {
     const canUseAccountFallback = missing.length === 1
       && missing[0] === "image"
       && this.canRunAccountImageTextFallback(spec, null);
+    // A BYOK model ID we have never reviewed may well be multimodal, and BYOK has no
+    // image2text fallback to fall back on, so let the user's own endpoint answer rather
+    // than refusing the request here.
+    const deferToProvider = spec.actualModelContext?.source === "byok"
+      && !hasDeclaredInputModalities(model);
 
     let initialResponse: LLMResponse | null = null;
-    if (coversInputModalities(supported, required)) {
+    if (deferToProvider || coversInputModalities(supported, required)) {
       initialResponse = await this.requestModel(spec, messagesForModel, hook, context, options);
       const canRecoverExplicitRejection = initialResponse.errorCategory === "image_input_unsupported"
         && !context.streamedContent

--- a/App/memmy-agent/src/providers/model-input-capabilities.ts
+++ b/App/memmy-agent/src/providers/model-input-capabilities.ts
@@ -353,6 +353,14 @@ export function getModelInputModalities(
   return MODEL_INPUT_CAPABILITIES[model] ?? TEXT;
 }
 
+// The catalog only covers model IDs we have reviewed against a vendor's docs, so a miss
+// means "unknown", not "text-only". Callers that can afford to let the provider answer
+// should branch on this instead of on the TEXT fallback above.
+export function hasDeclaredInputModalities(model: string | null | undefined): boolean {
+  return typeof model === "string"
+    && Object.prototype.hasOwnProperty.call(MODEL_INPUT_CAPABILITIES, model);
+}
+
 export function requiredInputModalities(
   messages: readonly Record<string, any>[],
 ): readonly ModelInputModality[] {

--- a/App/memmy-agent/tests/core/agent-runtime/runner-byok-image-input.test.ts
+++ b/App/memmy-agent/tests/core/agent-runtime/runner-byok-image-input.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+import { AgentRunner, AgentRunSpec } from "../../../src/core/agent-runtime/runner.js";
+import { LLMProvider, LLMResponse } from "../../../src/providers/base.js";
+
+function imageMessage() {
+  return {
+    role: "user",
+    content: [
+      { type: "text", text: "What is shown?" },
+      {
+        type: "image_url",
+        image_url: { url: "data:image/png;base64,one" },
+        meta: { path: "/media/one.png" },
+      },
+    ],
+  };
+}
+
+function byokContext(model: string) {
+  return {
+    presetId: "custom",
+    provider: "custom",
+    endpointId: "chat",
+    protocol: "openai-chat-completions" as const,
+    model,
+    source: "byok" as const,
+    ownerAccountId: null,
+    capability: "agent" as const,
+    capabilities: ["agent" as const],
+  };
+}
+
+function accountContext(model: string) {
+  return { ...byokContext(model), presetId: "account-default", provider: "memmy_account", source: "account" as const, ownerAccountId: "account-1" };
+}
+
+class ByokProvider extends LLMProvider {
+  calls: any[] = [];
+
+  constructor(private readonly responses: LLMResponse[] = []) {
+    super();
+  }
+
+  getDefaultModel(): string {
+    return "Qwen3-27B";
+  }
+
+  supportsAccountImageTextFallback(): boolean {
+    return false;
+  }
+
+  async chat(args: any): Promise<LLMResponse> {
+    this.calls.push(args);
+    return this.responses.shift() ?? new LLMResponse({ content: "described the image" });
+  }
+}
+
+describe("BYOK custom model image input", () => {
+  it("sends images to a BYOK model that is absent from the built-in capability catalog", async () => {
+    const provider = new ByokProvider();
+
+    const result = await new AgentRunner(provider).run(new AgentRunSpec({
+      initialMessages: [imageMessage()],
+      provider,
+      model: "Qwen3-27B",
+      actualModelContext: byokContext("Qwen3-27B"),
+    }));
+
+    expect(result.finalContent).toBe("described the image");
+    expect(provider.calls).toHaveLength(1);
+    expect(JSON.stringify(provider.calls[0].messages)).toContain('"type":"image_url"');
+  });
+
+  it("surfaces the provider's own rejection when the BYOK model really cannot read images", async () => {
+    const provider = new ByokProvider([
+      new LLMResponse({
+        content: "Invalid type for 'messages[0].content[1]': image_url is not supported",
+        finishReason: "error",
+        errorStatusCode: 400,
+      }),
+    ]);
+
+    const result = await new AgentRunner(provider).run(new AgentRunSpec({
+      initialMessages: [imageMessage()],
+      provider,
+      model: "some-text-only-model",
+      actualModelContext: byokContext("some-text-only-model"),
+    }));
+
+    expect(provider.calls).toHaveLength(1);
+    expect(result.finalContent).toContain("image_url is not supported");
+  });
+
+  it("still blocks images client-side for a BYOK model the catalog knows is text-only", async () => {
+    const provider = new ByokProvider();
+
+    const result = await new AgentRunner(provider).run(new AgentRunSpec({
+      initialMessages: [imageMessage()],
+      provider,
+      model: "deepseek-v4-pro",
+      actualModelContext: byokContext("deepseek-v4-pro"),
+    }));
+
+    expect(provider.calls).toHaveLength(0);
+    expect(result.finalContent).toBe("Current model does not support image input.");
+  });
+
+  it("still blocks images for an unknown account-managed model", async () => {
+    const provider = new ByokProvider();
+
+    const result = await new AgentRunner(provider).run(new AgentRunSpec({
+      initialMessages: [imageMessage()],
+      provider,
+      model: "unlisted-account-model",
+      actualModelContext: accountContext("unlisted-account-model"),
+    }));
+
+    expect(provider.calls).toHaveLength(0);
+    expect(result.finalContent).toBe("Current model does not support image input.");
+  });
+});

--- a/App/memmy-agent/tests/core/agent-runtime/runner-image-text-fallback.test.ts
+++ b/App/memmy-agent/tests/core/agent-runtime/runner-image-text-fallback.test.ts
@@ -215,14 +215,16 @@ describe("AgentRunner account image-to-text fallback", () => {
     expect(provider.imageCalls).toHaveLength(0);
   });
 
-  it("treats an unknown exact model as text-only and never calls the provider", async () => {
+  // An unknown BYOK model is deferred to the provider instead; see
+  // tests/core/agent-runtime/runner-byok-image-input.test.ts.
+  it("treats a catalog text-only model as text-only and never calls the provider", async () => {
     const provider = new AccountFallbackProvider([], []);
 
     const result = await new AgentRunner(provider).run(new AgentRunSpec({
       initialMessages: [imageMessage()],
       provider,
-      model: "unknown-vision-model",
-      actualModelContext: modelContext("byok", "unknown-vision-model", "custom"),
+      model: "deepseek-v4-pro",
+      actualModelContext: modelContext("byok", "deepseek-v4-pro", "custom"),
     }));
 
     expect(result.response).toMatchObject({
@@ -231,7 +233,7 @@ describe("AgentRunner account image-to-text fallback", () => {
       errorCategory: "image_input_unsupported",
       errorShouldRetry: false,
       actualProvider: "custom",
-      actualModel: "unknown-vision-model",
+      actualModel: "deepseek-v4-pro",
     });
     expect(provider.mainCalls).toHaveLength(0);
     expect(provider.imageCalls).toHaveLength(0);

--- a/App/memmy-agent/tests/providers/model-input-capabilities.test.ts
+++ b/App/memmy-agent/tests/providers/model-input-capabilities.test.ts
@@ -3,6 +3,7 @@ import {
   coversInputModalities,
   defineModelInputCapabilities,
   getModelInputModalities,
+  hasDeclaredInputModalities,
   MODEL_INPUT_CAPABILITIES,
   MODEL_INPUT_CAPABILITIES_REVIEWED_AT,
   requiredInputModalities,
@@ -43,6 +44,17 @@ describe("model input capabilities", () => {
     expect(getModelInputModalities(" gpt-5.6 ")).toEqual(["text"]);
     expect(getModelInputModalities("gpt-5.6-unknown-snapshot")).toEqual(["text"]);
     expect(getModelInputModalities(null)).toEqual(["text"]);
+  });
+
+  it("separates an unknown model from one the catalog declares text-only", () => {
+    expect(hasDeclaredInputModalities("deepseek-v4-pro")).toBe(true);
+    expect(hasDeclaredInputModalities("gpt-5.6")).toBe(true);
+    expect(hasDeclaredInputModalities("Qwen3-27B")).toBe(false);
+    expect(hasDeclaredInputModalities("Gpt-5.6")).toBe(false);
+    expect(hasDeclaredInputModalities("gpt-5.6-unknown-snapshot")).toBe(false);
+    expect(hasDeclaredInputModalities("toString")).toBe(false);
+    expect(hasDeclaredInputModalities(null)).toBe(false);
+    expect(hasDeclaredInputModalities(undefined)).toBe(false);
   });
 
   it("rejects duplicate model keys instead of overwriting them", () => {


### PR DESCRIPTION
## 问题

客户配置自己的 API key（BYOK）后无法识图：发送图片报「当前模型不支持图片输入，请切换到支持多模态能力的模型后重试」，但发送纯文字正常。客户的模型本身是支持图片的。

## 根因

`MODEL_INPUT_CAPABILITIES` 是一张按厂商文档人工核对过的模型能力目录，**精确匹配、大小写敏感**。`getModelInputModalities()` 在查不到时回退为纯文本：

```ts
return MODEL_INPUT_CAPABILITIES[model] ?? TEXT;
```

问题在于这个回退把「**目录里没有这个模型**」当成了「**这个模型不支持图片**」。对自配模型来说，这是在替一个从未见过的模型下结论。

于是 `requestModelWithImagePolicy()` 依据这个结论在本地直接拦截：required 是 `[text, image]`，supported 是 `[text]`，不覆盖 → 构造错误返回。**请求根本没有发出去，provider 一次都没被调用。**

纯文字之所以正常，是因为它算出的 required 是 `[text]`，恰好被兜底值覆盖，闸门放行。

加重因素：图转文字的降级路径 `canRunAccountImageTextFallback()` 要求 `source === "account" && provider === "memmy_account"`，BYOK 用户被排除在外，没有任何退路。

## 改动

区分「目录里没有」和「目录说是纯文本」这两件不同的事。

1. 新增 `hasDeclaredInputModalities()`，用 `hasOwnProperty` 判断目录里是否真的有这一条。`getModelInputModalities()` 未做任何改动，所有既有调用方行为不变。

2. `requestModelWithImagePolicy()` 中：BYOK 来源且目录中无此模型时，不再本地拦截，交给用户自己的 endpoint 回答。

如果该模型确实不支持图片，provider 返回的错误会被既有的 `classifyImageInputUnsupportedResponse()` 归类为 `image_input_unsupported`，用户依然看到正确提示——区别在于这次是模型给出的真实结果，而非本地猜测。

**行为未变的部分**：账号托管模型（目录由我们自己维护，可信）、以及目录中明确标记为纯文本的模型（如 `deepseek-v4-pro`），仍然在本地拦截，不浪费请求。

