### PR TITLE
fix(memory): keep Windows background service console-free

### DIFF
--- a/App/shell/desktop/src/main/runtime-services.ts
+++ b/App/shell/desktop/src/main/runtime-services.ts
@@ -57,6 +57,7 @@ export interface StartPackagedRuntimeServicesOptions {
 export interface StartManagedRuntimeServicesOptions extends StartPackagedRuntimeServicesOptions {
   runtimeEntries?: RuntimeEntryPaths;
   runtimeExecutable?: string;
+  platform?: NodeJS.Platform;
   /** Runs after migrations/config preparation and before any managed child starts. */
   beforeStartServices?: (input: { databasePath: string; configPath: string }) => Promise<void>;
   /** Unpacked Memory runtime shipped as an offline Desktop resource. */
@@ -779,7 +780,38 @@ export async function ensureMemoryService(
   if (shouldStop?.()) return;
   const healthUrl = `${runtimeConfig.memoryBaseUrl}/api/v1/health`;
   const healthHeaders = memoryAuthHeaders(runtimeConfig.memoryToken);
-  const probe = await probeMemoryService(healthUrl, healthHeaders);
+  let probe = await probeMemoryService(healthUrl, healthHeaders);
+  if ((options.platform ?? process.platform) === "win32"
+    && options.offlineMemoryRuntimeDirectory
+    && hasPreviousMemoryRuntimeMarker(runtimeConfig.configPath)
+    && (probe === "ready" || probe === "unreachable")) {
+    const lock = readLiveMemoryServerLock(runtimeConfig.memoryDatabasePath);
+    if (lock) {
+      // A legacy scheduled service may still be migrating its database. Wait
+      // before repairing the launcher, because repair ends that scheduled task.
+      try {
+        await waitForExistingMemoryService(healthUrl, healthHeaders, lock);
+      } catch (error) {
+        if (readLiveMemoryServerLock(runtimeConfig.memoryDatabasePath)) throw error;
+      }
+      const remainingLock = readLiveMemoryServerLock(runtimeConfig.memoryDatabasePath);
+      if (remainingLock && remainingLock.pid !== lock.pid) {
+        throw new Error("Memory database ownership changed before launcher repair");
+      }
+    }
+    if (shouldStop?.()) return;
+    // Repair before the healthy-service early return; newer Desktop installs
+    // deliberately skip OS registration and otherwise leave old .cmd tasks intact.
+    await runBundledMemoryCli(
+      options.offlineMemoryRuntimeDirectory,
+      runtimeConfig,
+      options,
+      ["service", "repair-launcher", "--home", dirname(runtimeConfig.configPath)],
+      MEMORY_STARTUP_TIMEOUT_MS
+    );
+    if (shouldStop?.()) return;
+    probe = await probeMemoryService(healthUrl, healthHeaders);
+  }
   if (probe === "ready") {
     if (!(await stopOlderBundledMemoryRuntime(runtimeConfig, options, shouldStop))) return;
   }

--- a/App/shell/desktop/tests/runtime-memory-upgrade.test.ts
+++ b/App/shell/desktop/tests/runtime-memory-upgrade.test.ts
@@ -27,6 +27,11 @@ async function fixture(options: {
   shutdownDelay?: number;
   wrongConfig?: boolean;
   stopFails?: boolean;
+  platform?: NodeJS.Platform;
+  repairFails?: boolean;
+  repairStopsService?: boolean;
+  noRuntimeMarkers?: boolean;
+  noOfflineRuntime?: boolean;
 } = {}) {
   const root = await mkdtemp(join(tmpdir(), "memmy-runtime-upgrade-"));
   roots.push(root);
@@ -36,6 +41,7 @@ async function fixture(options: {
   const runtimeDir = join(serviceHome, "runtime", "2.1.0", "fixture");
   const entry = join(runtimeDir, "dist", "src", "server", "index.js");
   const cli = join(bundled, "dist", "src", "cli", "index.js");
+  const repairCallsPath = join(root, "repair-calls.jsonl");
   await mkdir(dirname(entry), { recursive: true });
   await mkdir(dirname(cli), { recursive: true });
   const reservation = createServer();
@@ -79,6 +85,20 @@ async function fixture(options: {
   await writeFile(cli, [
     "const fs = require('node:fs'); const path = require('node:path');",
     "const args = process.argv.slice(2); const arg = key => args[args.indexOf(key) + 1];",
+    "if (args[0] === 'service' && args[1] === 'repair-launcher') {",
+    `  fs.appendFileSync(${JSON.stringify(repairCallsPath)}, JSON.stringify(args) + '\\n');`,
+    "  if (!fs.existsSync(path.join(arg('--home'), 'memory-service', 'runtime.json'))) { console.error('launcher repair raced a migrating database owner'); process.exit(19); }",
+    `  if (${Boolean(options.repairFails)}) { console.error('launcher repair failed'); process.exit(23); }`,
+    `  if (${Boolean(options.repairStopsService)}) {`,
+    "    const running = JSON.parse(fs.readFileSync(path.join(arg('--home'), 'memory-service', 'runtime.json'), 'utf8'));",
+    "    fetch(running.endpoint + '/api/v1/admin/shutdown', { method: 'POST' }).then(response => {",
+    "      if (!response.ok) throw new Error('fixture shutdown failed');",
+    "      setInterval(() => { if (!fs.existsSync(running.sqlitePath + '.server.lock')) process.exit(0); }, 10);",
+    "    }).catch(error => { console.error(error); process.exit(20); });",
+    "    return;",
+    "  }",
+    "  process.exit(0);",
+    "}",
     `if (args[0] === 'stop') process.exit(${options.stopFails ? 17 : 0});`,
     "if (args[0] !== 'install' || !args.includes('--skip-service-registration')) process.exit(17);",
     "const home = arg('--home'); const bundled = arg('--runtime-directory');",
@@ -103,6 +123,10 @@ async function fixture(options: {
   };
   await waitUntil(async () => readFile(config.memoryDatabasePath + ".server.lock").then(() => true, () => false));
   if (!options.delay) await waitUntil(async () => fetch(config.memoryBaseUrl + "/api/v1/health").then(() => true, () => false));
+  if (options.noRuntimeMarkers) {
+    await rm(join(serviceHome, "current.json"));
+    await rm(join(serviceHome, "runtime.json"));
+  }
   const children: ManagedChild[] = [];
   return {
     old, config, children,
@@ -110,7 +134,9 @@ async function fixture(options: {
       try {
         await ensureMemoryService({ memoryEntry: entry, agentEntry: join(root, "unused.js") }, config, children, {
           appPath: root, appDatabaseFile: join(home, "app.sqlite"), resourcesPath: root,
-          logDirectory: root, logLevel: "info", runtimeExecutable: process.execPath, offlineMemoryRuntimeDirectory: bundled,
+          logDirectory: root, logLevel: "info", runtimeExecutable: process.execPath,
+          offlineMemoryRuntimeDirectory: options.noOfflineRuntime ? undefined : bundled,
+          platform: options.platform,
         });
       } finally {
         processes.push(...children);
@@ -119,10 +145,68 @@ async function fixture(options: {
     async version() {
       return (await (await fetch(config.memoryBaseUrl + "/api/v1/health")).json() as { serviceVersion: string }).serviceVersion;
     },
+    async repairCalls(): Promise<string[][]> {
+      return readFile(repairCallsPath, "utf8").then(
+        (text) => text.trim().split("\n").filter(Boolean).map((line) => JSON.parse(line) as string[]),
+        () => [],
+      );
+    },
   };
 }
 
 describe("bundled Memory upgrades", () => {
+  it("repairs an old Windows launcher before reusing a healthy same-version service", async () => {
+    const running = await fixture({ version: "2.1.1", platform: "win32" });
+    await running.ensure();
+    expect(await running.repairCalls()).toEqual([["service", "repair-launcher", "--home", dirname(running.config.configPath)]]);
+    expect(running.children).toHaveLength(0);
+    expect(running.old.process.exitCode).toBeNull();
+    expect(await running.version()).toBe("2.1.1");
+  });
+
+  it("waits for a migrating Windows database owner before repairing its launcher", async () => {
+    const running = await fixture({ version: "2.1.1", platform: "win32", delay: 400 });
+    await running.ensure();
+    expect(await running.repairCalls()).toHaveLength(1);
+    expect(running.children).toHaveLength(0);
+    expect(running.old.process.exitCode).toBeNull();
+  });
+
+  it("starts a Desktop child after launcher repair stops the legacy service", async () => {
+    const running = await fixture({ version: "2.1.1", platform: "win32", repairStopsService: true });
+    await running.ensure();
+    expect(await running.repairCalls()).toHaveLength(1);
+    expect(running.old.process.exitCode).toBe(0);
+    expect(running.children).toHaveLength(1);
+    expect(running.children[0]?.persistOnDesktopExit).toBe(true);
+    expect(await running.version()).toBe("2.1.1");
+  });
+
+  it.each(["darwin", "linux"] as const)("does not request Windows launcher repair on %s", async (platform) => {
+    const running = await fixture({ version: "2.1.1", platform });
+    await running.ensure();
+    expect(await running.repairCalls()).toEqual([]);
+  });
+
+  it("does not request launcher repair without previous runtime markers", async () => {
+    const running = await fixture({ version: "2.1.1", platform: "win32", noRuntimeMarkers: true });
+    await running.ensure();
+    expect(await running.repairCalls()).toEqual([]);
+  });
+
+  it("does not request launcher repair without an offline bundled runtime", async () => {
+    const running = await fixture({ version: "2.1.1", platform: "win32", noOfflineRuntime: true });
+    await running.ensure();
+    expect(await running.repairCalls()).toEqual([]);
+  });
+
+  it("reports a failed Windows launcher repair instead of reusing the healthy endpoint", async () => {
+    const running = await fixture({ version: "2.1.1", platform: "win32", repairFails: true });
+    await expect(running.ensure()).rejects.toThrow("launcher repair failed");
+    expect(running.children).toHaveLength(0);
+    expect(running.old.process.exitCode).toBeNull();
+  });
+
   it("replaces a healthy older Desktop runtime before reusing its endpoint", async () => {
     const running = await fixture();
     await running.ensure();

--- a/Memory/src/cli/commands.ts
+++ b/Memory/src/cli/commands.ts
@@ -23,6 +23,7 @@ import { DEFAULT_MEMORY_URL, loadCliMemoryConfig } from "./config.js";
 import { PROJECT_VERSION } from "./project-version.js";
 import {
   currentInstalledRuntime,
+  repairInstalledWindowsMemoryService,
   startInstalledMemoryService,
   stopInstalledMemoryService
 } from "./runtime-installer.js";
@@ -35,6 +36,7 @@ export interface CommandContext {
   argv: string[];
   fetch?: typeof fetch;
   stopInstalledService?: (home: string) => Promise<Record<string, unknown>>;
+  repairInstalledService?: (home: string) => Promise<Record<string, unknown>>;
 }
 
 export async function runCommand(context: CommandContext): Promise<unknown> {
@@ -73,8 +75,9 @@ export async function runCommand(context: CommandContext): Promise<unknown> {
     const home = optionString(options, "home") ?? "~/.memmy";
     if (words[1] === "start") return startInstalledMemoryService(home);
     if (words[1] === "stop") return (context.stopInstalledService ?? stopInstalledMemoryService)(home);
+    if (words[1] === "repair-launcher") return (context.repairInstalledService ?? repairInstalledWindowsMemoryService)(home);
     if (words[1] === "status") return { ok: true, runtime: await currentInstalledRuntime(home) ?? null };
-    throw new Error("service requires start, stop, or status");
+    throw new Error("service requires start, stop, status, or repair-launcher");
   }
 
   if (words[0] === "raw") {
@@ -600,6 +603,7 @@ function helpText(): string {
     "  upgrade [--version <ver>]    Upgrade Memory and installed agent adapters",
     "  stop                         Stop the background Memory service",
     "  service start|stop|status    Control the installed user service",
+    "  service repair-launcher     Repair a legacy Windows task without starting it",
     "  serve                        Explain how to connect to an external Memory service",
     "  health                       Check Memory service health",
     "  reload-config                Reload runtime model config from config.yaml",

--- a/Memory/src/cli/runtime-installer.ts
+++ b/Memory/src/cli/runtime-installer.ts
@@ -32,6 +32,7 @@ export interface MemoryRuntimeInstallOptions {
   releaseManifest?: string;
   releaseBaseUrl?: string;
   nodeExecutable?: string;
+  /** Do not create/start an OS service; an existing legacy Windows task is repaired in place. */
   skipServiceRegistration?: boolean;
   skipHealthCheck?: boolean;
   /** Maximum time to wait for the newly activated service to report its version. */
@@ -120,10 +121,15 @@ export async function installMemoryRuntime(options: MemoryRuntimeInstallOptions 
     }
 
     const switching = !previous || previous.runtimeDir !== runtimeDir;
-    if (switching && previous && !options.skipServiceRegistration) stopUserService();
+    const repairLegacyTask = Boolean(options.skipServiceRegistration && previous && isLegacyWindowsTask(home));
+    if (!options.skipServiceRegistration || repairLegacyTask) {
+      // End an already running .cmd task as well as any surviving legacy service.
+      if (process.platform === "win32") await stopInstalledMemoryService(home);
+      else if (switching && previous) stopUserService();
+    }
     await writeJsonAtomic(currentPath, pointer);
     await writeStableLauncher(home, serviceHome, pointer.runtimeExecutable!);
-    if (!options.skipServiceRegistration) registerAndStartUserService(home, serviceHome);
+    if (!options.skipServiceRegistration || repairLegacyTask) registerAndStartUserService(home, serviceHome, !options.skipServiceRegistration);
 
     if (!options.skipHealthCheck) {
       try {
@@ -133,7 +139,10 @@ export async function installMemoryRuntime(options: MemoryRuntimeInstallOptions 
           healthCheckTimeoutMs
         );
       } catch (error) {
-        if (!options.skipServiceRegistration && previous) stopUserService();
+        if (!options.skipServiceRegistration && previous) {
+          if (process.platform === "win32") await stopInstalledMemoryService(home);
+          else stopUserService();
+        }
         if (previous) {
           await writeJsonAtomic(currentPath, previous);
           await writeStableLauncher(home, serviceHome, previous.runtimeExecutable ?? process.execPath);
@@ -184,15 +193,40 @@ export async function installedAgents(home = "~/.memmy"): Promise<string[]> {
 export async function startInstalledMemoryService(home = "~/.memmy"): Promise<Record<string, unknown>> {
   const resolvedHome = resolveHome(home);
   const serviceHome = join(resolvedHome, "memory-service");
-  const pointer = await currentInstalledRuntime(resolvedHome);
-  if (!pointer) throw new Error("Memory is not installed");
-  await validateRuntime(pointer.runtimeDir, pointer.version, pointer.target, pointer.protocolVersion);
-  const launcher = launcherPaths(resolvedHome);
-  if (!existsSync(launcher.command) || !existsSync(launcher.script)) {
+  const installLock = await acquireInstallLock(join(serviceHome, "install.lock"));
+  try {
+    const pointer = await currentInstalledRuntime(resolvedHome);
+    if (!pointer) throw new Error("Memory is not installed");
+    await validateRuntime(pointer.runtimeDir, pointer.version, pointer.target, pointer.protocolVersion);
+    if (process.platform === "win32") await stopInstalledMemoryService(resolvedHome);
     await writeStableLauncher(resolvedHome, serviceHome, pointer.runtimeExecutable ?? process.execPath);
+    registerAndStartUserService(resolvedHome, serviceHome);
+    return { ok: true, action: "start", ...pointer };
+  } finally {
+    await installLock.release();
   }
-  registerAndStartUserService(resolvedHome, serviceHome);
-  return { ok: true, action: "start", ...pointer };
+}
+
+/** Repair only this installation's legacy login task, leaving startup to Desktop. */
+export async function repairInstalledWindowsMemoryService(home = "~/.memmy"): Promise<Record<string, unknown>> {
+  const resolvedHome = resolveHome(home);
+  if (process.platform !== "win32" || !(await currentInstalledRuntime(resolvedHome))) {
+    return { ok: true, repaired: false };
+  }
+  const serviceHome = join(resolvedHome, "memory-service");
+  const installLock = await acquireInstallLock(join(serviceHome, "install.lock"));
+  try {
+    if (!isLegacyWindowsTask(resolvedHome)) return { ok: true, repaired: false };
+    const pointer = await currentInstalledRuntime(resolvedHome);
+    if (!pointer) throw new Error("Memory is not installed");
+    await validateRuntime(pointer.runtimeDir, pointer.version, pointer.target, pointer.protocolVersion);
+    await stopInstalledMemoryService(resolvedHome);
+    await writeStableLauncher(resolvedHome, serviceHome, pointer.runtimeExecutable ?? process.execPath);
+    registerAndStartUserService(resolvedHome, serviceHome, false);
+    return { ok: true, repaired: true };
+  } finally {
+    await installLock.release();
+  }
 }
 
 export interface UserServiceRestartCommand {
@@ -357,20 +391,26 @@ async function reuseInstalledRuntime(
   healthCheckTimeoutMs: number
 ): Promise<Record<string, unknown>> {
   if (options.dryRun) return { ok: true, reused: true, dryRun: true, ...pointer };
-  await validateRuntime(pointer.runtimeDir, pointer.version, pointer.target, pointer.protocolVersion);
-  const launcher = launcherPaths(home);
-  if (!existsSync(launcher.command) || !existsSync(launcher.script)) {
+  const installLock = await acquireInstallLock(join(serviceHome, "install.lock"));
+  try {
+    // Another installer may have activated a newer runtime while we waited.
+    pointer = await currentInstalledRuntime(home) ?? pointer;
+    await validateRuntime(pointer.runtimeDir, pointer.version, pointer.target, pointer.protocolVersion);
+    const repairLegacyTask = Boolean(options.skipServiceRegistration && isLegacyWindowsTask(home));
+    if (process.platform === "win32" && (!options.skipServiceRegistration || repairLegacyTask)) await stopInstalledMemoryService(home);
     await writeStableLauncher(home, serviceHome, pointer.runtimeExecutable ?? options.nodeExecutable ?? process.execPath);
+    if (!options.skipServiceRegistration || repairLegacyTask) registerAndStartUserService(home, serviceHome, !options.skipServiceRegistration);
+    if (!options.skipHealthCheck) {
+      await waitForRuntimeHealth(
+        options.endpoint ?? "http://127.0.0.1:18960",
+        pointer.version,
+        healthCheckTimeoutMs
+      );
+    }
+    return { ok: true, reused: true, ...pointer };
+  } finally {
+    await installLock.release();
   }
-  if (!options.skipServiceRegistration) registerAndStartUserService(home, serviceHome);
-  if (!options.skipHealthCheck) {
-    await waitForRuntimeHealth(
-      options.endpoint ?? "http://127.0.0.1:18960",
-      pointer.version,
-      healthCheckTimeoutMs
-    );
-  }
-  return { ok: true, reused: true, ...pointer };
 }
 
 async function resolveReleaseManifest(
@@ -525,10 +565,10 @@ async function sha256File(path: string): Promise<string> {
   });
   return hash.digest("hex");
 }
-function launcherPaths(home: string): { command: string; script: string } {
+function launcherPaths(home: string): { command: string; script: string; hidden?: string } {
   const bin = join(home, "bin");
   return process.platform === "win32"
-    ? { command: join(bin, "memmy-memory-service.cmd"), script: join(bin, "memmy-memory-service.cjs") }
+    ? { command: join(bin, "memmy-memory-service.cmd"), script: join(bin, "memmy-memory-service.cjs"), hidden: join(bin, "memmy-memory-service.js") }
     : { command: join(bin, "memmy-memory-service"), script: join(bin, "memmy-memory-service.cjs") };
 }
 
@@ -537,26 +577,77 @@ async function writeStableLauncher(home: string, serviceHome: string, nodeExecut
   await mkdir(dirname(paths.script), { recursive: true });
   const script = [
     "\"use strict\";",
-    "const { readFileSync } = require(\"node:fs\");",
+    "const { readFileSync, mkdirSync, openSync, closeSync, appendFileSync } = require(\"node:fs\");",
     "const { spawn } = require(\"node:child_process\");",
-    `const pointer = JSON.parse(readFileSync(${JSON.stringify(join(serviceHome, "current.json"))}, "utf8"));`,
     "const path = require(\"node:path\");",
+    "const windows = process.platform === \"win32\";",
+    `const logs = ${JSON.stringify(join(serviceHome, "logs"))};`,
+    "function fail(error) {",
+    "  if (windows) appendFileSync(path.join(logs, \"service-error.log\"), String(error.stack || error.message || error) + \"\\n\");",
+    "  else console.error(error);",
+    "  process.exit(1);",
+    "}",
+    "try {",
+    "if (windows) mkdirSync(logs, { recursive: true });",
+    `const pointer = JSON.parse(readFileSync(${JSON.stringify(join(serviceHome, "current.json"))}, "utf8"));`,
     `const env = { ...process.env, MEMMY_HOME: ${JSON.stringify(home)}, MEMMY_CONFIG: ${JSON.stringify(join(home, "config.yaml"))}, MEMMY_EMBEDDING_MODEL_ROOT: path.join(pointer.runtimeDir, "embedding-models") };`,
-    "const child = spawn(process.execPath, [pointer.entrypoint, ...process.argv.slice(2)], { stdio: \"inherit\", windowsHide: false, env });",
-    "child.once(\"error\", (error) => { console.error(error.message); process.exit(1); });",
+    "const handles = [];",
+    "let child;",
+    "try {",
+    "  if (windows) for (const file of [\"service.log\", \"service-error.log\"]) handles.push(openSync(path.join(logs, file), \"a\"));",
+    "  child = spawn(process.execPath, [pointer.entrypoint, ...process.argv.slice(2)], { stdio: windows ? [\"ignore\", ...handles] : \"inherit\", windowsHide: true, env });",
+    "} finally { for (const handle of handles) closeSync(handle); }",
+    "child.once(\"error\", fail);",
     "child.once(\"exit\", (code, signal) => { if (signal) process.kill(process.pid, signal); else process.exit(code ?? 0); });",
+    "} catch (error) { fail(error); }",
     ""
   ].join("\n");
   await writeFile(paths.script, script, { encoding: "utf8", mode: 0o700 });
   if (process.platform === "win32") {
     await writeFile(paths.command, `@echo off\r\nset ELECTRON_RUN_AS_NODE=1\r\n"${nodeExecutable}" "${paths.script}" %*\r\n`, "utf8");
+    // WScript is a GUI-subsystem host. Wait for Node so the scheduled task owns
+    // the entire service lifetime, rather than leaving an untracked child behind.
+    const hiddenScript = [
+      'var shell = new ActiveXObject("WScript.Shell");',
+      'var environment = shell.Environment("Process");',
+      'environment.Item("ELECTRON_RUN_AS_NODE") = "1";',
+      `WScript.Quit(shell.Run(${JSON.stringify(`"${nodeExecutable}" "${paths.script}"`)}, 0, true));`,
+      ""
+    ].join("\r\n").replace(/[^\x00-\x7f]/g, (char) => `\\u${char.charCodeAt(0).toString(16).padStart(4, "0")}`);
+    await writeFile(paths.hidden!, hiddenScript, "utf8");
   } else {
     await writeFile(paths.command, `#!/bin/sh\nexec env ELECTRON_RUN_AS_NODE=1 ${shellQuote(nodeExecutable)} ${shellQuote(paths.script)} "$@"\n`, { encoding: "utf8", mode: 0o700 });
     await chmod(paths.command, 0o700);
   }
 }
 
-function registerAndStartUserService(home: string, serviceHome: string): void {
+function isLegacyWindowsTask(home: string): boolean {
+  if (process.platform !== "win32") return false;
+  // COM returns Unicode paths. Encode stdout as ASCII rather than depending on
+  // schtasks' console code page when a Windows home contains non-ASCII names.
+  const query = [
+    "$ErrorActionPreference = 'Stop'",
+    "$scheduler = New-Object -ComObject Schedule.Service",
+    "$scheduler.Connect()",
+    "$actions = $scheduler.GetFolder('\\').GetTask('Memmy Memory Service').Definition.Actions",
+    "if ($actions.Count -ne 1) { exit 2 }",
+    "$action = $actions.Item(1)",
+    "if ($action.Type -ne 0) { exit 2 }",
+    "[Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes([string]$action.Path))"
+  ].join("; ");
+  const result = spawnSync("powershell.exe", ["-NoProfile", "-NonInteractive", "-Command", query], {
+    encoding: "utf8", windowsHide: true, timeout: 10_000
+  });
+  if (result.status !== 0) return false;
+  const encoded = result.stdout.trim();
+  if (!encoded || !/^[A-Za-z0-9+/]+={0,2}$/.test(encoded)) return false;
+  const command = Buffer.from(encoded, "base64").toString("utf8");
+  // Do not rewrite a task belonging to another home or an already hidden host.
+  const normalize = (value: string) => value.replace(/^"|"$/g, "").replace(/\//g, "\\").toLowerCase();
+  return normalize(command) === normalize(launcherPaths(home).command);
+}
+
+function registerAndStartUserService(home: string, serviceHome: string, start = true): void {
   const launcher = launcherPaths(home).command;
   const logs = join(serviceHome, "logs");
   mkdirSyncForLifecycle(logs);
@@ -588,8 +679,18 @@ function registerAndStartUserService(home: string, serviceHome: string): void {
     return;
   }
   if (process.platform === "win32") {
-    runLifecycle("schtasks", ["/Create", "/TN", "Memmy Memory Service", "/TR", `\"${launcher}\"`, "/SC", "ONLOGON", "/F"]);
-    runLifecycle("schtasks", ["/Run", "/TN", "Memmy Memory Service"]);
+    const taskPath = join(serviceHome, "service-task.xml");
+    const host = join(process.env.SystemRoot || "C:\\Windows", "System32", "wscript.exe");
+    const args = `/B /Nologo /E:JScript "${launcherPaths(home).hidden!}"`;
+    writeFileSyncForLifecycle(taskPath, `<?xml version="1.0" encoding="UTF-8"?>
+<Task version="1.2" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">
+<Triggers><LogonTrigger><Enabled>true</Enabled></LogonTrigger></Triggers>
+<Principals><Principal id="User"><LogonType>InteractiveToken</LogonType><RunLevel>LeastPrivilege</RunLevel></Principal></Principals>
+<Settings><MultipleInstancesPolicy>IgnoreNew</MultipleInstancesPolicy><DisallowStartIfOnBatteries>false</DisallowStartIfOnBatteries><StopIfGoingOnBatteries>false</StopIfGoingOnBatteries><ExecutionTimeLimit>PT0S</ExecutionTimeLimit></Settings>
+<Actions Context="User"><Exec><Command>${xmlEscape(host)}</Command><Arguments>${xmlEscape(args)}</Arguments></Exec></Actions>
+</Task>\n`);
+    runLifecycle("schtasks", ["/Create", "/TN", "Memmy Memory Service", "/XML", taskPath, "/F"]);
+    if (start) runLifecycle("schtasks", ["/Run", "/TN", "Memmy Memory Service"]);
     return;
   }
   throw new Error(`unsupported platform: ${process.platform}`);
@@ -653,7 +754,7 @@ async function waitForRuntimeHealth(
 async function cleanupFailedFirstInstall(input: {
   currentPath: string;
   installationPath: string;
-  launcher: { command: string; script: string };
+  launcher: { command: string; script: string; hidden?: string };
   runtimeDir: string;
   runtimeCreated: boolean;
   serviceHome: string;
@@ -666,6 +767,8 @@ async function cleanupFailedFirstInstall(input: {
     rm(input.currentPath, { force: true }).catch(() => undefined),
     rm(input.launcher.command, { force: true }).catch(() => undefined),
     rm(input.launcher.script, { force: true }).catch(() => undefined),
+    ...(input.launcher.hidden ? [rm(input.launcher.hidden, { force: true }).catch(() => undefined)] : []),
+    rm(join(input.serviceHome, "service-task.xml"), { force: true }).catch(() => undefined),
     rm(input.installationPath, { force: true }).catch(() => undefined),
     rm(join(input.serviceHome, "runtime.json"), { force: true }).catch(() => undefined),
     ...(input.runtimeCreated

--- a/Memory/src/server/service-restart.ts
+++ b/Memory/src/server/service-restart.ts
@@ -5,6 +5,7 @@ export const MEMORY_RESTART_IPC_TYPE = "memmy-memory:restart";
 
 export interface MemoryServiceRestartDependencies {
   env?: NodeJS.ProcessEnv;
+  platform?: NodeJS.Platform;
   send?: ((message: unknown, callback: (error: Error | null) => void) => void) | null;
   restartInstalled?: () => void | Promise<void>;
   restartLocal?: () => void | Promise<void>;
@@ -15,6 +16,13 @@ export async function requestMemoryServiceRestart(
 ): Promise<void> {
   const env = dependencies.env ?? process.env;
   if (env[DESKTOP_MANAGED_MEMORY_ENV] !== "1") {
+    if ((dependencies.platform ?? process.platform) === "win32") {
+      // Ending the scheduled task can also terminate a spawned restart helper.
+      // Rebuild locally so the running task continues supervising this process.
+      if (!dependencies.restartLocal) throw new Error("Windows Memory restart is unavailable");
+      await dependencies.restartLocal();
+      return;
+    }
     return Promise.resolve(
       (dependencies.restartInstalled ?? restartInstalledMemoryService)()
     );

--- a/Memory/tests/runtime-installer-windows.integration.test.ts
+++ b/Memory/tests/runtime-installer-windows.integration.test.ts
@@ -1,0 +1,172 @@
+import { spawnSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+import { describe, expect, it } from "vitest";
+import { installMemoryRuntime, runtimeTarget } from "../src/cli/runtime-installer.js";
+
+// Opt in on an interactive Windows desktop with permission to create a user task:
+// MEMMY_WINDOWS_SERVICE_INTEGRATION=1 npm test -w @memmy/memory -- tests/runtime-installer-windows.integration.test.ts
+// MainWindowHandle checks cannot replace a manual check for transient console flashes.
+const enabled = process.platform === "win32" && process.env.MEMMY_WINDOWS_SERVICE_INTEGRATION === "1";
+
+describe.skipIf(!enabled)("Windows scheduled Memory launcher integration", () => {
+  it("remains supervised, ignores duplicate runs, and stops and starts its process tree", async () => {
+    const root = mkdtempSync(join(tmpdir(), "memmy-windows-task-test-"));
+    const home = join(root, "memory home 测试");
+    const runtimeDirectory = join(root, "runtime");
+    const taskName = `Memmy Memory Integration ${randomUUID()}`;
+    const startsPath = join(root, "starts.jsonl");
+    const trackedPids = new Set<number>();
+    let taskRegistered = false;
+    const entrypoint = join(runtimeDirectory, "dist", "src", "server", "index.js");
+    mkdirSync(join(runtimeDirectory, "dist", "src", "server"), { recursive: true });
+    writeFileSync(join(runtimeDirectory, "memory-runtime.json"), JSON.stringify({
+      version: "2.1.1", protocolVersion: 1, target: runtimeTarget(process.platform, process.arch),
+    }));
+    writeFileSync(entrypoint, [
+      'const { appendFileSync } = require("node:fs");',
+      `appendFileSync(${JSON.stringify(startsPath)}, JSON.stringify({ pid: process.pid, parentPid: process.ppid, electronRunAsNode: process.env.ELECTRON_RUN_AS_NODE }) + "\\n");`,
+      'console.log("fixture stdout " + process.pid);',
+      'console.error("fixture stderr " + process.pid);',
+      "setInterval(() => {}, 1000);",
+      // Bound an orphan's lifetime even if the test runner itself is interrupted.
+      "setTimeout(() => process.exit(0), 120000).unref();",
+    ].join("\n"));
+
+    try {
+      await installMemoryRuntime({
+        home, runtimeDirectory, nodeExecutable: process.execPath,
+        skipServiceRegistration: true, skipHealthCheck: true,
+      });
+      const launcher = join(home, "bin", "memmy-memory-service.js");
+      expect(existsSync(launcher)).toBe(true);
+      const xmlPath = join(root, "integration-task.xml");
+      // Register only this unique test task. The product installer's registration
+      // path deliberately stays disabled so an installed Memmy service is untouched.
+      writeFileSync(xmlPath, taskXml(launcher), "utf8");
+      windowsCommand("schtasks.exe", ["/Create", "/TN", taskName, "/XML", xmlPath, "/F"]);
+      taskRegistered = true;
+      windowsCommand("schtasks.exe", ["/Run", "/TN", taskName]);
+      await waitUntil(() => readStarts(startsPath).length === 1, "first fixture startup");
+      const first = readStarts(startsPath)[0]!;
+      trackedPids.add(first.pid);
+      trackedPids.add(first.parentPid);
+      expect(first.electronRunAsNode).toBe("1");
+      await waitUntil(() => taskState(taskName) === 4, "TASK_STATE_RUNNING");
+      expect(mainWindowHandle(first.pid)).toBe("0");
+      expect(mainWindowHandle(first.parentPid)).toBe("0");
+
+      windowsCommand("schtasks.exe", ["/Run", "/TN", taskName]);
+      // Observe a full second while the original fixture remains alive.
+      for (let attempt = 0; attempt < 5; attempt += 1) {
+        await delay(200);
+        expect(readStarts(startsPath)).toHaveLength(1);
+        expect(processAlive(first.pid)).toBe(true);
+      }
+      expect(taskState(taskName)).toBe(4);
+
+      windowsCommand("schtasks.exe", ["/End", "/TN", taskName]);
+      await waitUntil(() => !processAlive(first.pid) && !processAlive(first.parentPid), "stopped launcher descendants");
+      await waitUntil(() => taskState(taskName) !== 4, "stopped task");
+
+      windowsCommand("schtasks.exe", ["/Run", "/TN", taskName]);
+      await waitUntil(() => readStarts(startsPath).length === 2, "second fixture startup");
+      const second = readStarts(startsPath)[1]!;
+      trackedPids.add(second.pid);
+      trackedPids.add(second.parentPid);
+      expect(processAlive(second.pid)).toBe(true);
+      await waitUntil(() => taskState(taskName) === 4, "restarted task");
+      const logs = join(home, "memory-service", "logs");
+      await waitUntil(() => [first.pid, second.pid].every((pid) =>
+        readText(join(logs, "service.log")).includes(`fixture stdout ${pid}`)
+        && readText(join(logs, "service-error.log")).includes(`fixture stderr ${pid}`)), "appended stdout and stderr");
+      windowsCommand("schtasks.exe", ["/End", "/TN", taskName]);
+      await waitUntil(() => !processAlive(second.pid) && !processAlive(second.parentPid), "stopped restarted descendants");
+    } finally {
+      let cleanupError: unknown;
+      if (taskRegistered) {
+        windowsCommand("schtasks.exe", ["/End", "/TN", taskName], true);
+        try {
+          windowsCommand("schtasks.exe", ["/Delete", "/TN", taskName, "/F"]);
+        } catch (error) { cleanupError = error; }
+      }
+      for (const start of readStarts(startsPath)) {
+        trackedPids.add(start.pid);
+        trackedPids.add(start.parentPid);
+      }
+      // If /End fails the assertion, clean up only recorded fixture processes
+      // whose command lines still reference this unique temporary directory.
+      for (const pid of trackedPids) {
+        powershell(`$fixture = Get-CimInstance Win32_Process -Filter 'ProcessId = ${pid}'; if ($fixture -and $fixture.CommandLine -and $fixture.CommandLine.Contains(${psQuote(root)})) { Stop-Process -Id ${pid} -Force -ErrorAction SilentlyContinue }`, true);
+      }
+      rmSync(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+      if (cleanupError) throw cleanupError;
+    }
+  }, 90_000);
+});
+
+interface FixtureStart { pid: number; parentPid: number; electronRunAsNode?: string; }
+
+function readText(path: string): string {
+  return existsSync(path) ? readFileSync(path, "utf8") : "";
+}
+
+function readStarts(path: string): FixtureStart[] {
+  // A writer may still be appending the last line while the test polls.
+  return readText(path).split("\n").slice(0, -1).filter(Boolean).map((line) => JSON.parse(line) as FixtureStart);
+}
+
+function windowsCommand(command: string, args: string[], allowFailure = false): string {
+  if (!enabled) throw new Error("Windows service integration is not enabled");
+  const result = spawnSync(command, args, { encoding: "utf8", windowsHide: true, timeout: 10_000 });
+  if (!allowFailure && result.status !== 0) {
+    throw new Error(`${command} failed: ${result.stderr || result.stdout || result.error?.message}`);
+  }
+  return result.stdout?.trim() ?? "";
+}
+
+function powershell(command: string, allowFailure = false): string {
+  return windowsCommand("powershell.exe", ["-NoProfile", "-NonInteractive", "-Command", command], allowFailure);
+}
+
+function taskState(taskName: string): number {
+  return Number(powershell(`$scheduler = New-Object -ComObject Schedule.Service; $scheduler.Connect(); [int]$scheduler.GetFolder('\\').GetTask(${psQuote(taskName)}).State`));
+}
+
+function mainWindowHandle(pid: number): string {
+  return powershell(`(Get-Process -Id ${pid} -ErrorAction Stop).MainWindowHandle.ToInt64()`);
+}
+
+function processAlive(pid: number): boolean {
+  try { process.kill(pid, 0); return true; } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ESRCH") return false;
+    throw error;
+  }
+}
+
+async function waitUntil(condition: () => boolean, label: string): Promise<void> {
+  const deadline = Date.now() + 15_000;
+  while (Date.now() < deadline) {
+    if (condition()) return;
+    await delay(100);
+  }
+  throw new Error(`Timed out waiting for ${label}`);
+}
+
+function psQuote(value: string): string { return `'${value.replace(/'/g, "''")}'`; }
+function xmlEscape(value: string): string {
+  return value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;").replace(/'/g, "&apos;");
+}
+
+function taskXml(launcher: string): string {
+  const wscript = join(process.env.SystemRoot ?? "C:\\Windows", "System32", "wscript.exe");
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<Task version="1.2" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">
+<Principals><Principal id="Author"><LogonType>InteractiveToken</LogonType><RunLevel>LeastPrivilege</RunLevel></Principal></Principals>
+<Settings><MultipleInstancesPolicy>IgnoreNew</MultipleInstancesPolicy><DisallowStartIfOnBatteries>false</DisallowStartIfOnBatteries><StopIfGoingOnBatteries>false</StopIfGoingOnBatteries><ExecutionTimeLimit>PT0S</ExecutionTimeLimit></Settings>
+<Actions Context="Author"><Exec><Command>${xmlEscape(wscript)}</Command><Arguments>/B /Nologo /E:JScript ${xmlEscape(`"${launcher}"`)}</Arguments></Exec></Actions>
+</Task>\n`;
+}

--- a/Memory/tests/runtime-installer-windows.test.ts
+++ b/Memory/tests/runtime-installer-windows.test.ts
@@ -1,0 +1,230 @@
+import { EventEmitter } from "node:events";
+import * as fs from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { runInNewContext } from "node:vm";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { installMemoryRuntime, repairInstalledWindowsMemoryService, startInstalledMemoryService, stopInstalledMemoryService } from "../src/cli/runtime-installer.js";
+import { runCommand } from "../src/cli/commands.js";
+
+const lifecycle = vi.hoisted(() => vi.fn(() => ({ status: 0, stdout: "", stderr: "" })));
+vi.mock("node:child_process", async (importOriginal) => ({
+  ...await importOriginal<typeof import("node:child_process")>(),
+  spawnSync: lifecycle,
+}));
+
+let root: string;
+let home: string;
+let runtimeDirectory: string;
+const realProcess = process;
+
+beforeEach(() => {
+  root = fs.mkdtempSync(join(tmpdir(), "memmy-windows-launcher-"));
+  home = join(root, "中文 home & data");
+  runtimeDirectory = join(root, "runtime");
+  fs.mkdirSync(join(runtimeDirectory, "dist", "src", "server"), { recursive: true });
+  fs.writeFileSync(join(runtimeDirectory, "dist", "src", "server", "index.js"), "// fixture\n");
+  fs.writeFileSync(join(runtimeDirectory, "memory-runtime.json"), JSON.stringify({
+    version: "2.1.0", protocolVersion: 1, target: `windows-${process.arch}`,
+  }));
+  vi.stubGlobal("process", { ...realProcess, platform: "win32" });
+  lifecycle.mockClear();
+  lifecycle.mockReset();
+  lifecycle.mockReturnValue({ status: 0, stdout: "", stderr: "" });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+async function install(skipServiceRegistration = false) {
+  return installMemoryRuntime({ home, runtimeDirectory, skipServiceRegistration, skipHealthCheck: true });
+}
+
+function registeredXml(): string {
+  const call = lifecycle.mock.calls.find((args: unknown[]) => (args[1] as string[]).includes("/Create")) as unknown[] | undefined;
+  expect(call, "scheduled task registration").toBeDefined();
+  const args = call![1] as string[];
+  expect(args).toContain("/XML");
+  return fs.readFileSync(args[args.indexOf("/XML") + 1]!, "utf8");
+}
+
+describe("Windows standalone Memory service", () => {
+  it("routes Desktop's repair command to the selected installation", async () => {
+    const repairInstalledService = vi.fn().mockResolvedValue({ ok: true, repaired: false });
+    await expect(runCommand({ argv: ["service", "repair-launcher", "--home", home], repairInstalledService }))
+      .resolves.toEqual({ ok: true, repaired: false });
+    expect(repairInstalledService).toHaveBeenCalledWith(home);
+  });
+  it("registers a console-free, supervised task without a runtime limit", async () => {
+    await install();
+    const xml = registeredXml();
+    expect(xml).toContain("wscript.exe");
+    expect(xml).toContain("/B /Nologo /E:JScript");
+    expect(xml).toContain("memmy-memory-service.js");
+    expect(xml).not.toContain(".cmd");
+    expect(xml).toContain("<ExecutionTimeLimit>PT0S</ExecutionTimeLimit>");
+    expect(xml).toContain("<MultipleInstancesPolicy>IgnoreNew</MultipleInstancesPolicy>");
+    expect(xml).toContain("<DisallowStartIfOnBatteries>false</DisallowStartIfOnBatteries>");
+    expect(xml).toContain("<StopIfGoingOnBatteries>false</StopIfGoingOnBatteries>");
+    expect(xml).toContain("<LogonType>InteractiveToken</LogonType>");
+    expect(xml).toContain("&amp;");
+    for (const call of lifecycle.mock.calls as unknown[][]) {
+      expect(call[2]).toMatchObject({ windowsHide: true });
+    }
+  });
+
+  it("keeps the hidden script host waiting and returns the runtime exit code", async () => {
+    await install(true);
+    const script = fs.readFileSync(join(home, "bin", "memmy-memory-service.js"), "utf8");
+    // WSH's JScript encoding must not depend on the user's ANSI code page.
+    expect(script).toMatch(/^[\x00-\x7f]*$/);
+    const run = vi.fn(() => 7);
+    const quit = vi.fn();
+    const environment = { Item: vi.fn() };
+    // COM property-put syntax is a JScript extension, exercised by the native
+    // Windows integration test; V8 can execute the surrounding host lifecycle.
+    expect(script).toContain('environment.Item("ELECTRON_RUN_AS_NODE") = "1";');
+    runInNewContext(script.replace('environment.Item("ELECTRON_RUN_AS_NODE") = "1";', ""), {
+      ActiveXObject: function () { return { Environment: () => environment, Run: run }; },
+      WScript: { Quit: quit },
+    });
+    expect(run).toHaveBeenCalledWith(expect.stringContaining(`"${join(home, "bin", "memmy-memory-service.cjs")}"`), 0, true);
+    expect(quit).toHaveBeenCalledWith(7);
+  });
+
+  it("appends stdout and stderr, hides the child, and waits for its exit", async () => {
+    await install(true);
+    const logs = join(home, "memory-service", "logs");
+    fs.mkdirSync(logs, { recursive: true });
+    fs.writeFileSync(join(logs, "service.log"), "previous output\n");
+    const child = new EventEmitter();
+    const spawn = vi.fn((_executable, _args, options) => {
+      expect(options).toMatchObject({ windowsHide: true, env: { MEMMY_HOME: home } });
+      expect(options.detached).not.toBe(true);
+      expect(options.stdio[0]).toBe("ignore");
+      fs.writeSync(options.stdio[1], "background output\n");
+      fs.writeSync(options.stdio[2], "background error\n");
+      return child;
+    });
+    const exit = vi.fn();
+    runInNewContext(fs.readFileSync(join(home, "bin", "memmy-memory-service.cjs"), "utf8"), {
+      require: (id: string) => id === "node:child_process" ? { spawn } : id === "node:fs" ? fs : { join },
+      process: { ...realProcess, platform: "win32", argv: [realProcess.execPath, "launcher.cjs"], exit },
+      console,
+    });
+    expect(spawn).toHaveBeenCalledOnce();
+    expect(exit).not.toHaveBeenCalled();
+    child.emit("exit", 7, null);
+    expect(exit).toHaveBeenCalledWith(7);
+    expect(fs.readFileSync(join(logs, "service.log"), "utf8")).toBe("previous output\nbackground output\n");
+    expect(fs.readFileSync(join(logs, "service-error.log"), "utf8")).toContain("background error");
+  });
+
+  it.each(["invalid pointer", "spawn failure"])("records launcher errors without a console: %s", async (failure) => {
+    await install(true);
+    if (failure === "invalid pointer") fs.writeFileSync(join(home, "memory-service", "current.json"), "invalid json");
+    const child = new EventEmitter();
+    const exit = vi.fn();
+    runInNewContext(fs.readFileSync(join(home, "bin", "memmy-memory-service.cjs"), "utf8"), {
+      require: (id: string) => id === "node:child_process" ? { spawn: () => child } : id === "node:fs" ? fs : { join },
+      process: { ...realProcess, platform: "win32", argv: [realProcess.execPath, "launcher.cjs"], exit },
+      console,
+    });
+    if (failure === "spawn failure") child.emit("error", new Error("could not start runtime"));
+    expect(exit).toHaveBeenCalledWith(1);
+    expect(fs.readFileSync(join(home, "memory-service", "logs", "service-error.log"), "utf8"))
+      .toContain(failure === "spawn failure" ? "could not start runtime" : "SyntaxError");
+  });
+
+  it("removes the hidden host and task XML after failed first activation", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("connection refused")));
+    await expect(installMemoryRuntime({ home, runtimeDirectory, healthCheckTimeoutMs: 10 }))
+      .rejects.toThrow("activation health check");
+    expect(fs.existsSync(join(home, "bin", "memmy-memory-service.js"))).toBe(false);
+    expect(fs.existsSync(join(home, "memory-service", "service-task.xml"))).toBe(false);
+    expect(fs.existsSync(join(home, "memory-service", "current.json"))).toBe(false);
+  });
+
+  it("leaves an existing installation untouched in reuse dry-run mode", async () => {
+    await install(true);
+    const script = join(home, "bin", "memmy-memory-service.cjs");
+    fs.writeFileSync(script, "legacy launcher");
+    lifecycle.mockClear();
+    await installMemoryRuntime({ home, runtimeDirectory, preferInstalledCompatible: true, dryRun: true });
+    expect(fs.readFileSync(script, "utf8")).toBe("legacy launcher");
+    expect(lifecycle).not.toHaveBeenCalled();
+  });
+
+  it.each(["repair", "desktop reuse", "desktop upgrade"])("repairs a retained legacy task without starting it: %s", async (action) => {
+    await install(true);
+    const legacyCommand = `"${join(home, "bin", "memmy-memory-service.cmd")}"`;
+    lifecycle.mockReturnValue({ status: 0, stdout: Buffer.from(legacyCommand, "utf8").toString("base64"), stderr: "" });
+    lifecycle.mockClear();
+    if (action === "repair") await repairInstalledWindowsMemoryService(home);
+    else if (action === "desktop reuse") await installMemoryRuntime({ home, runtimeDirectory, preferInstalledCompatible: true, skipServiceRegistration: true, skipHealthCheck: true });
+    else {
+      fs.writeFileSync(join(runtimeDirectory, "memory-runtime.json"), JSON.stringify({ version: "2.2.0", protocolVersion: 1, target: `windows-${process.arch}` }));
+      await install(true);
+    }
+    expect(registeredXml()).toContain("wscript.exe");
+    const commands = (lifecycle.mock.calls as unknown[][]).map((call) => (call[1] as string[])[0]);
+    expect(commands).toContain("/End");
+    expect(commands).not.toContain("/Run");
+  });
+
+  it.each(["", "C:\\other\\memmy-memory-service.cmd", "wscript.exe"])("does not change unrelated or already hidden tasks: %s", async (command) => {
+    await install(true);
+    lifecycle.mockReturnValue({ status: 0, stdout: Buffer.from(command, "utf8").toString("base64"), stderr: "" });
+    lifecycle.mockClear();
+    await expect(repairInstalledWindowsMemoryService(home)).resolves.toMatchObject({ repaired: false });
+    expect(lifecycle).toHaveBeenCalledOnce();
+    expect((lifecycle.mock.calls as unknown[][])[0]).toEqual([
+      "powershell.exe", expect.arrayContaining([expect.stringContaining(".Definition.Actions")]),
+      expect.objectContaining({ windowsHide: true, timeout: 10_000 })
+    ]);
+  });
+
+  it.each(["reuse", "start", "upgrade"])("repairs old launchers and stops the old task before %s", async (action) => {
+    await install(true);
+    const pointerPath = join(home, "memory-service", "current.json");
+    const pointer = fs.readFileSync(pointerPath, "utf8");
+    fs.writeFileSync(join(home, "config.yaml"), "# preserve config\n");
+    fs.writeFileSync(join(home, "memory.sqlite"), "preserve data");
+    fs.writeFileSync(join(home, "bin", "memmy-memory-service.cjs"), "old visible launcher");
+    fs.writeFileSync(join(home, "bin", "memmy-memory-service.cmd"), "old visible command");
+    lifecycle.mockClear();
+    if (action === "start") await startInstalledMemoryService(home);
+    else if (action === "reuse") await installMemoryRuntime({ home, runtimeDirectory, preferInstalledCompatible: true, skipHealthCheck: true });
+    else {
+      fs.writeFileSync(join(runtimeDirectory, "memory-runtime.json"), JSON.stringify({ version: "2.2.0", protocolVersion: 1, target: `windows-${process.arch}` }));
+      await install();
+    }
+    expect(fs.readFileSync(join(home, "bin", "memmy-memory-service.cjs"), "utf8")).not.toContain("old visible");
+    expect(fs.readFileSync(join(home, "bin", "memmy-memory-service.cmd"), "utf8")).not.toContain("old visible");
+    expect(registeredXml()).not.toContain(".cmd");
+    const commands = (lifecycle.mock.calls as unknown[][]).map((call) => (call[1] as string[])[0]);
+    expect(commands.indexOf("/End")).toBeGreaterThanOrEqual(0);
+    expect(commands.indexOf("/End")).toBeLessThan(commands.indexOf("/Create"));
+    expect(commands.indexOf("/Create")).toBeLessThan(commands.indexOf("/Run"));
+    if (action !== "upgrade") expect(fs.readFileSync(pointerPath, "utf8")).toBe(pointer);
+    expect(fs.readFileSync(join(home, "config.yaml"), "utf8")).toBe("# preserve config\n");
+    expect(fs.readFileSync(join(home, "memory.sqlite"), "utf8")).toBe("preserve data");
+  });
+
+  it("ends the task and shuts down a surviving old service before starting again", async () => {
+    await install(true);
+    fs.writeFileSync(join(home, "memory-service", "runtime.json"), JSON.stringify({ endpoint: "http://127.0.0.1:18960" }));
+    const request = vi.fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ protocolVersion: 1 }) })
+      .mockResolvedValueOnce({ ok: true })
+      .mockRejectedValue(new Error("connection refused"));
+    vi.stubGlobal("fetch", request);
+    await startInstalledMemoryService(home);
+    expect(request).toHaveBeenCalledWith("http://127.0.0.1:18960/api/v1/admin/shutdown", expect.objectContaining({ method: "POST" }));
+    await stopInstalledMemoryService(home);
+    expect((lifecycle.mock.calls as unknown[][]).at(-1)?.[1]).toEqual(["/End", "/TN", "Memmy Memory Service"]);
+  });
+});

--- a/Memory/tests/service-restart.test.ts
+++ b/Memory/tests/service-restart.test.ts
@@ -14,6 +14,7 @@ describe("Memory service restart dispatch", () => {
 
     await requestMemoryServiceRestart({
       env: { [DESKTOP_MANAGED_MEMORY_ENV]: "1" },
+      platform: "win32",
       send,
       restartInstalled,
     });
@@ -25,12 +26,48 @@ describe("Memory service restart dispatch", () => {
     expect(restartInstalled).not.toHaveBeenCalled();
   });
 
-  it("uses the user service manager for a standalone service", async () => {
+  it.each(["darwin", "linux"] as const)("uses the user service manager for a standalone service on %s", async (platform) => {
     const restartInstalled = vi.fn();
 
-    await requestMemoryServiceRestart({ env: {}, restartInstalled });
+    await requestMemoryServiceRestart({ env: {}, platform, restartInstalled });
 
     expect(restartInstalled).toHaveBeenCalledOnce();
+  });
+
+  it("rebuilds a standalone Windows service within its supervised process", async () => {
+    const restartLocal = vi.fn();
+    const restartInstalled = vi.fn();
+
+    await requestMemoryServiceRestart({ env: {}, platform: "win32", restartLocal, restartInstalled });
+
+    expect(restartLocal).toHaveBeenCalledOnce();
+    expect(restartInstalled).not.toHaveBeenCalled();
+  });
+
+  it("rejects a standalone Windows restart when local rebuilding is unavailable", async () => {
+    const restartInstalled = vi.fn();
+
+    await expect(requestMemoryServiceRestart({
+      env: {},
+      platform: "win32",
+      restartInstalled,
+    })).rejects.toThrow("Windows Memory restart is unavailable");
+
+    expect(restartInstalled).not.toHaveBeenCalled();
+  });
+
+  it("preserves errors while rebuilding a standalone Windows service", async () => {
+    const restartLocal = vi.fn().mockRejectedValue(new Error("rebuild failed"));
+    const restartInstalled = vi.fn();
+
+    await expect(requestMemoryServiceRestart({
+      env: {},
+      platform: "win32",
+      restartLocal,
+      restartInstalled,
+    })).rejects.toThrow("rebuild failed");
+
+    expect(restartInstalled).not.toHaveBeenCalled();
   });
 
   it("rebuilds a persistent service after its Desktop IPC channel closes", async () => {


### PR DESCRIPTION
Memmy v1.1.2 on Windows can leave a persistent CMD window showing Memory capture and summary logs. The login task launches a `.cmd` directly, and the service launcher inherits its console. Hiding the installer's `schtasks` call cannot hide a task started independently by Task Scheduler.

This change starts the task through a hidden WScript host that waits for Node, keeps the service child attached, and appends stdout/stderr and launcher errors to `memory-service/logs/service.log` and `service-error.log`. Task settings ignore duplicate runs, remove the execution time limit, and allow background operation on battery. Windows standalone restart uses the existing local service rebuild loop so it does not depend on a helper surviving termination of its own task.

Existing launchers are refreshed on install, compatible reuse and start. Desktop also repairs a retained legacy task before returning early for a healthy compatible runtime, waits for a live database owner to finish startup/migrations first, and re-probes before taking ownership. Repair matches only the old task command for the current home, updates its definition without starting it, and preserves configuration, data and compatible runtime selection.

Validation:
- Regression tests were observed failing before implementation for task entry/logging/refresh/stop behavior, Windows restart dispatch and Desktop's same-version reuse path.
- Targeted Memory/CLI suites: 79 passed, 1 Windows-only integration test skipped on macOS.
- Targeted Desktop lifecycle suites: 64 passed.

Windows native validation remains required: this development host is macOS. An opt-in integration test creates a unique temporary task and checks the real WScript/Node process tree, duplicate runs, stop/start, Unicode paths, output logs and main-window handles. On an interactive Windows desktop, run in PowerShell:

```powershell
$env:MEMMY_WINDOWS_SERVICE_INTEGRATION = '1'
npm test -w @memmy/memory -- tests/runtime-installer-windows.integration.test.ts
```

Also visually confirm there is no transient console flash during install/login/restart. The integration test never registers the product's default task.

Target: `release/v1.1.3`. No version publication or merge is included.
