### PR TITLE
fix(agent-source): stop splitText re-emitting flushed text

### DIFF
--- a/AgentSourceCore/src/index.test.ts
+++ b/AgentSourceCore/src/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { conversationContentHash, orderedTurns, splitTurn, type ConversationMessage } from "./index.js";
+import { conversationContentHash, estimateTokens, orderedTurns, splitTurn, type ConversationMessage } from "./index.js";
 
 const message = (id: string, role: ConversationMessage["role"], content: string, createdAt: string): ConversationMessage => ({
   messageId: id, sourceId: "fixture", conversationId: "conversation", role, content, createdAt,
@@ -28,5 +28,31 @@ describe("agent source core", () => {
     expect(new Set(parts.map((part) => part.contentHash)).size).toBe(parts.length);
     expect(parts.every((part) => Buffer.byteLength(part.content) <= 1_000_000)).toBe(true);
     expect(conversationContentHash(turn.messages)).toHaveLength(64);
+  });
+
+  it("does not re-emit flushed text when splitting multi-line content", () => {
+    const lines = Array.from({ length: 350 }, (_, index) => `line ${index} ${"y".repeat(40)}`);
+    const content = lines.join("\n");
+    const turn = { sourceId: "fixture", conversationId: "conversation", turnIndex: 0, messages: [message("u", "user", content, "2026-01-01T00:00:00Z"), message("a", "assistant", "ok", "2026-01-01T00:00:01Z")] };
+    const parts = splitTurn(turn, 4000, 1_000_000);
+    const emitted = parts.reduce((total, part) => total + part.content.length, 0);
+    expect(emitted).toBeLessThan(content.length * 2);
+    for (const line of lines) expect(parts.filter((part) => part.content.includes(line))).toHaveLength(1);
+  });
+
+  it("keeps every multi-line part within the token budget", () => {
+    const content = Array.from({ length: 350 }, (_, index) => `line ${index} ${"y".repeat(40)}`).join("\n");
+    const turn = { sourceId: "fixture", conversationId: "conversation", turnIndex: 0, messages: [message("u", "user", content, "2026-01-01T00:00:00Z"), message("a", "assistant", "ok", "2026-01-01T00:00:01Z")] };
+    const parts = splitTurn(turn, 4000, 1_000_000);
+    expect(parts.every((part) => estimateTokens(part.content) <= 4000)).toBe(true);
+  });
+
+  it("splits multibyte content on byte boundaries without losing characters", () => {
+    const content = Array.from({ length: 200 }, () => "汉字测试").join("\n");
+    const turn = { sourceId: "fixture", conversationId: "conversation", turnIndex: 0, messages: [message("u", "user", content, "2026-01-01T00:00:00Z"), message("a", "assistant", "ok", "2026-01-01T00:00:01Z")] };
+    const parts = splitTurn(turn, 1_000_000, 512);
+    expect(parts.every((part) => Buffer.byteLength(part.content) <= 512)).toBe(true);
+    const emitted = parts.reduce((total, part) => total + (part.content.match(/汉/gu) ?? []).length, 0);
+    expect(emitted).toBe(200);
   });
 });

--- a/AgentSourceCore/src/index.ts
+++ b/AgentSourceCore/src/index.ts
@@ -361,7 +361,7 @@ function splitText(value: string, maxTokens: number, maxBytes: number): string[]
       }
       if (part) chunks.push(part);
     } else {
-      current = candidate;
+      current = current ? candidate : line;
     }
   }
   if (current) chunks.push(...splitUtf8(current, maxBytes));

--- a/AgentSourceCore/src/index.ts
+++ b/AgentSourceCore/src/index.ts
@@ -371,13 +371,16 @@ function splitText(value: string, maxTokens: number, maxBytes: number): string[]
 function splitUtf8(value: string, maxBytes: number): string[] {
   const parts: string[] = [];
   let current = "";
+  let currentBytes = 0;
   for (const character of value) {
-    const candidate = current + character;
-    if (current && Buffer.byteLength(candidate) > maxBytes) {
+    const characterBytes = Buffer.byteLength(character);
+    if (current && currentBytes + characterBytes > maxBytes) {
       parts.push(current);
       current = character;
+      currentBytes = characterBytes;
     } else {
-      current = candidate;
+      current += character;
+      currentBytes += characterBytes;
     }
   }
   if (current) parts.push(current);


### PR DESCRIPTION
## Problem

An agent-source scan can stop making progress forever when a conversation turn contains one large multi-line message. On my machine the memory service sat at ~85% CPU with RSS climbing to 900 MB for **4.5 hours** and wrote **zero** `scan_results` rows. The same input hangs the desktop app's scan process (`agent-source-scan-process.js`), which is what the "sync new" button in the cross-agent panel runs.

Smallest real trigger I captured: a 181 KB Claude Code message, and a 51 KB Pi message whose body is a single 350-line paragraph.

## Root cause

`splitText` computes `candidate` *before* the size check, flushes `current`, resets it to `""` — and then the trailing `else` reassigns `current = candidate`, which still holds the text that was just flushed:

```ts
const candidate = current ? `${current}\n${line}` : line;   // captured before the flush
if (current && (estimateTokens(candidate) > maxTokens || Buffer.byteLength(candidate) > maxBytes)) {
  chunks.push(...splitUtf8(current, maxBytes));
  current = "";                       // flush
}
if (line.length > maxChars || Buffer.byteLength(line) > maxBytes) {
  ...
} else {
  current = candidate;                // <-- puts the flushed text straight back
}
```

The accumulator never shrinks. Every subsequent line trips the limit again and pushes an ever-longer prefix into `chunks`, so output grows quadratically and total work cubically.

Sibling `splitUtf8` already handles this correctly — it does `current = character` after its flush. `splitText` was simply missing that step.

Measured on unfixed `main`, single-paragraph input of N lines:

| lines | input | time | parts | output | amplification |
|------:|------:|-----:|------:|-------:|--------------:|
| 350 | 17,389 | 1.4 s | 31 | 500,206 | 28.8x |
| 600 | 29,889 | 26.2 s | 281 | 6,418,456 | 214.7x |
| 800 | 39,889 | 66.9 s | 481 | 13,403,056 | 336.0x |

## Fix

```diff
-      current = candidate;
+      current = current ? candidate : line;
```

After a flush `current` is `""`, so restarting the accumulator from `line` is exactly the intended behaviour. On every path that did not flush, `current` is non-empty and the expression is a no-op.

## Why the existing test missed it

`splits oversized content with unique part hashes` uses `"x".repeat(30_000)` — a single line with no newlines. That takes the `line.length > maxChars` branch, which is correct, and never reaches the faulty `else`. The bug needs **multi-line** content whose accumulated `current` crosses the token limit.

## Tests added

Three tests in `AgentSourceCore/src/index.test.ts`. On unfixed `main` they report:

- `expected 500206 to be less than 34778` — content amplified 28.8x
- `expected false to be true` — parts exceeding the token budget
- `expected 19397 to be 200` — 200 CJK characters emitted 19,397 times

All five tests pass with the fix (`npm test -w AgentSourceCore`), and `tsc --noEmit` is clean. The 350-line size was chosen deliberately so the unfixed code fails on an assertion in ~1.4 s rather than stalling CI.

## Second commit (independent)

`perf(agent-source): count bytes incrementally in splitUtf8` — `splitUtf8` called `Buffer.byteLength(current + character)` per character, forcing V8 to flatten the growing cons string, so each call was O(n²) in chunk length. This is the multiplier that turned the bug above into a multi-hour hang.

Tracking a running byte count is equivalent because `for...of` always yields whole code points. Verified against the previous implementation over **72,690 cases** — 12,316 inputs (5,723 real captured agent messages, length-truncated slices of them, and synthetic edge cases covering lone surrogates, astral-plane characters, emoji ZWJ sequences and CJK) crossed with six `maxBytes` values from 8 to 512 KiB — **zero differing outputs**. Splitting a 16 KB chunk 20 times goes from 2058 ms to 11 ms.

It is independent of the correctness fix and can be dropped without affecting it.

## Verification on a real install

With both commits applied to the local memory-service runtime, a full initial scan of five sources finished in **5 min 10 s** (2,742 memories, 0 errors) where the same job had previously run 4.5 hours without completing; the following incremental scan took 68 s.

Note this only fixes the source. The desktop app ships two more compiled copies of this module — `Resources/memory-runtime/` and one inside `app.asar` — and the `app.asar` one cannot be patched locally because `ElectronAsarIntegrity` pins its SHA-256, so the UI scan button stays affected until a release carries this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jdi5HaeP7tYuApntyxPtXq
