### PR TITLE
fix(desktop): keep legacy plugin migration out of Memory startup

### DIFF
--- a/App/shell/desktop/src/main/runtime-services.ts
+++ b/App/shell/desktop/src/main/runtime-services.ts
@@ -864,6 +864,9 @@ export function bundledMemoryInstallArguments(
     "--memmy-config-preexisting", String(memmyConfigPreexisting),
     "--node-executable", executable,
     "--non-interactive",
+    // Desktop has prepared its config. Legacy plugin import needs a separate
+    // explicit CLI install so config selection or old data cannot block startup.
+    "--skip-legacy-migration",
     "--use-compatible-installed",
     "--health-check-timeout-ms", String(MEMORY_STARTUP_TIMEOUT_MS)
   ];

--- a/App/shell/desktop/tests/bundled-memory-install.test.ts
+++ b/App/shell/desktop/tests/bundled-memory-install.test.ts
@@ -1,0 +1,76 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import YAML from "yaml";
+import { runCommand } from "../../../../Memory/src/cli/commands.js";
+import { runtimeTarget } from "../../../../Memory/src/cli/runtime-installer.js";
+import { MEMORY_PROTOCOL_VERSION, MEMORY_SERVICE_VERSION } from "../../../../Memory/src/version.js";
+import { bundledMemoryInstallArguments, preparePackagedRuntimeConfig } from "../src/main/runtime-services.js";
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe("bundled Memory installation", () => {
+  it.each([false, true])("installs without importing legacy plugins when a Memmy config preexisted: %s", async (configPreexisted) => {
+    const root = await mkdtemp(join(tmpdir(), "memmy-bundled-install-"));
+    roots.push(root);
+    const runtimeDirectory = join(root, "bundle");
+    const entrypoint = join("dist", "src", "server", "index.js");
+    await mkdir(join(runtimeDirectory, "dist", "src", "server"), { recursive: true });
+    await writeFile(join(runtimeDirectory, entrypoint), "// Synthetic runtime; never executed.\n");
+    await writeFile(join(runtimeDirectory, "memory-runtime.json"), JSON.stringify({
+      version: MEMORY_SERVICE_VERSION,
+      protocolVersion: MEMORY_PROTOCOL_VERSION,
+      target: runtimeTarget(process.platform, process.arch),
+      entrypoint
+    }));
+
+    // A fresh Desktop prepares config defaults before invoking the installer.
+    const runtimeConfig = await preparePackagedRuntimeConfig({
+      env: { MEMMY_HOME: join(root, "memmy") },
+      fillMissingAgentSecret: false
+    });
+    const existingData = "existing Memmy database must not be opened by installation";
+    if (configPreexisted) await writeFile(runtimeConfig.memoryDatabasePath, existingData);
+    const configBefore = await readFile(runtimeConfig.configPath, "utf8");
+    const legacyFiles: Array<[string, string]> = [];
+    for (const agent of ["openclaw", "hermes"]) {
+      const legacyDirectory = join(root, `.${agent}`, "memos-plugin");
+      await mkdir(join(legacyDirectory, "data"), { recursive: true });
+      legacyFiles.push(
+        [join(legacyDirectory, "config.yaml"), `llm:\n  model: legacy-${agent}\n`],
+        [join(legacyDirectory, "data", "memos.db"), "unreadable legacy database"]
+      );
+    }
+    await Promise.all(legacyFiles.map(([path, content]) => writeFile(path, content)));
+
+    const result = await runCommand({
+      argv: [
+        ...bundledMemoryInstallArguments(runtimeDirectory, runtimeConfig, configPreexisted, process.execPath),
+        "--legacy-root", root,
+        // Exercise installation without registering or launching an OS service.
+        "--skip-service-registration",
+        "--skip-health-check"
+      ]
+    });
+
+    expect(result).toMatchObject({ ok: true, command: "install", serviceOnly: true });
+    expect(result).not.toHaveProperty("migration");
+    const installed = JSON.parse(await readFile(join(root, "memmy", "memory-service", "current.json"), "utf8"));
+    expect(installed.version).toBe(MEMORY_SERVICE_VERSION);
+    expect(await readFile(installed.entrypoint, "utf8")).toBe("// Synthetic runtime; never executed.\n");
+    const configAfter = YAML.parse(await readFile(runtimeConfig.configPath, "utf8"));
+    expect(configAfter).toMatchObject(YAML.parse(configBefore));
+    expect(configAfter.memmyMemory).not.toHaveProperty("migratedFrom");
+    if (configPreexisted) {
+      expect(await readFile(runtimeConfig.memoryDatabasePath, "utf8")).toBe(existingData);
+    } else {
+      await expect(readFile(runtimeConfig.memoryDatabasePath)).rejects.toMatchObject({ code: "ENOENT" });
+    }
+    for (const [path, content] of legacyFiles) expect(await readFile(path, "utf8")).toBe(content);
+  });
+});


### PR DESCRIPTION
## Problem

On macOS Memmy 1.1.3, a fresh Desktop setup can finish opening while Memory stays stopped. Memory pages report `memory layer network error`, and restarting Memory can fail again.

The reproduced trigger is a machine with both OpenClaw and Hermes legacy Memory configurations and no preexisting Memmy configuration. Desktop prepares its defaults, then invokes the bundled CLI with `install --service-only --non-interactive --memmy-config-preexisting false`. Installation aborts before starting the service with:

```text
multiple legacy Memory configs were found (openclaw, hermes); rerun with --config-source openclaw|hermes
```

## Root cause

`installMemoryCli` runs legacy plugin migration before runtime installation. `--service-only` skips Agent skill installation but still imports old configuration/databases. Desktop cannot answer the configuration-source prompt; old database errors can also block installation even when Memmy already has a configuration. The network error is the downstream symptom of the service never starting.

This startup/migration coupling was introduced in [d1e6e7f](https://github.com/MemTensor/memmy-agent/commit/d1e6e7f487e17d9cc0cc0fdbf4569b880a18b606) and is present in the v1.1.2 and v1.1.3 code paths.

## Change and behavior impact

Pass the existing `--skip-legacy-migration` flag only from Desktop's bundled Memory installer. Desktop starts from its prepared Memmy configuration without making legacy plugin import a startup prerequisite.

This intentionally stops automatic legacy configuration/database import during Desktop startup, including single-source imports. Users who want to migrate legacy data must run an explicit standalone CLI install and select a source when required. Standalone CLI migration behavior and its selection safeguards remain unchanged.

## Validation

- Added two regression cases using real CLI parsing/setup/installation with synthetic legacy files. Both failed before the fix and passed afterward; assertions cover runtime activation, preservation of existing configuration values/database bytes, and unchanged legacy files.
- All 74 focused Desktop runtime, bundled installation, CLI setup, and legacy migration tests passed.
- Full verification passed: lint, type checking, affected workspace tests, smoke plan tests, build, distribution checks, and diff checks.
- Tested the installed macOS 1.1.3 bundle with Memory 2.1.1 in an isolated synthetic home: original arguments reproduced the failure; adding the flag allowed installation and a successful health response with SQLite ready. The test service exited cleanly.

The patch targets `main`. No replacement installer has been built or released, and the user's installed app, configuration, and memory databases were not modified.
