### PR TITLE
fix(desktop): keep startup alive until renderer handoff

### DIFF
--- a/App/frontend/desktop/src/components/modal.tsx
+++ b/App/frontend/desktop/src/components/modal.tsx
@@ -36,6 +36,7 @@ export interface ModalProps {
 export function Modal(props: ModalProps) {
   const titleId = useId();
   const dialogRef = useRef<HTMLElement | null>(null);
+  const backdropPressRef = useRef(false);
   const wasOpenRef = useRef(false);
   const showHeader = props.showHeader ?? true;
   const showCloseButton = props.showCloseButton ?? Boolean(props.onClose);
@@ -82,7 +83,22 @@ export function Modal(props: ModalProps) {
     <div
       className={["modal-backdrop", props.backdropClassName].filter(Boolean).join(" ")}
       role="presentation"
-      onClick={(event) => shouldCloseModalByBackdrop(event) && props.onClose?.()}
+      onPointerDown={(event) => {
+        backdropPressRef.current = event.target === event.currentTarget;
+      }}
+      onPointerUp={(event) => {
+        backdropPressRef.current = backdropPressRef.current && event.target === event.currentTarget;
+      }}
+      onPointerCancel={() => {
+        backdropPressRef.current = false;
+      }}
+      onClick={(event) => {
+        const shouldClose = backdropPressRef.current && shouldCloseModalByBackdrop(event);
+        backdropPressRef.current = false;
+        if (shouldClose) {
+          props.onClose?.();
+        }
+      }}
     >
       <section
         ref={dialogRef}

--- a/App/frontend/desktop/src/components/tests/Modal.test.tsx
+++ b/App/frontend/desktop/src/components/tests/Modal.test.tsx
@@ -1,7 +1,13 @@
+// @vitest-environment happy-dom
+
 /** Modal tests. */
+import { act } from "react";
+import { createRoot } from "react-dom/client";
 import { renderToString } from "react-dom/server";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { Modal, shouldCloseModalByBackdrop, shouldCloseModalByKey, shouldInitializeModalFocus } from "../modal.js";
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
 describe("Modal", () => {
   it("renders a centered dialog without right-side drawer classes", () => {
@@ -81,5 +87,47 @@ describe("Modal", () => {
 
     expect(shouldCloseModalByBackdrop({ target: backdrop, currentTarget: backdrop } as never)).toBe(true);
     expect(shouldCloseModalByBackdrop({ target: {}, currentTarget: backdrop } as never)).toBe(false);
+  });
+
+  it("does not close when a text-selection drag starts inside the modal and ends on the backdrop", () => {
+    const container = document.createElement("div");
+    const root = createRoot(container);
+    const onClose = vi.fn();
+    document.body.append(container);
+
+    try {
+      act(() => root.render(
+        <Modal open title="Model configuration" onClose={onClose}>
+          <span>gpt-5.4</span>
+        </Modal>
+      ));
+
+      const backdrop = container.querySelector<HTMLElement>(".modal-backdrop")!;
+      const modelId = container.querySelector<HTMLElement>(".modal-body span")!;
+
+      act(() => {
+        modelId.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true }));
+        backdrop.dispatchEvent(new PointerEvent("pointerup", { bubbles: true }));
+        backdrop.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      });
+      expect(onClose).not.toHaveBeenCalled();
+
+      act(() => {
+        backdrop.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true }));
+        modelId.dispatchEvent(new PointerEvent("pointerup", { bubbles: true }));
+        backdrop.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      });
+      expect(onClose).not.toHaveBeenCalled();
+
+      act(() => {
+        backdrop.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true }));
+        backdrop.dispatchEvent(new PointerEvent("pointerup", { bubbles: true }));
+        backdrop.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      });
+      expect(onClose).toHaveBeenCalledOnce();
+    } finally {
+      act(() => root.unmount());
+      container.remove();
+    }
   });
 });

--- a/App/frontend/desktop/src/styles.css
+++ b/App/frontend/desktop/src/styles.css
@@ -10602,7 +10602,7 @@ input[type="checkbox"].check-sky:checked::after {
   display: flex;
   min-height: 44px;
   align-items: center;
-  padding: 6px 14px 12px 30px;
+  padding: 6px 14px 12px 20px;
 }
 
 .memory-page-back-button {
@@ -10631,7 +10631,7 @@ input[type="checkbox"].check-sky:checked::after {
 }
 
 .memory-page-section-header {
-  padding: 0 14px 0 30px;
+  padding: 0 14px 0 20px;
   margin-bottom: 6px;
 }
 

--- a/App/frontend/desktop/src/theme/tests/style-alignment.test.ts
+++ b/App/frontend/desktop/src/theme/tests/style-alignment.test.ts
@@ -170,11 +170,11 @@ describe("prototype style alignment", () => {
     expect(memorySidebarRule).toContain("padding-top: 0;");
     expect(memoryToolbarRule).toContain("flex: 0 0 var(--codex-toolbar-height);");
     expect(memoryToolbarRule).toContain("min-height: var(--codex-toolbar-height);");
-    expect(memoryReturnRowRule).toContain("padding: 6px 14px 12px 30px;");
+    expect(memoryReturnRowRule).toContain("padding: 6px 14px 12px 20px;");
     expect(memoryBackButtonRule).toContain("height: 32px;");
     expect(memoryBackButtonRule).toContain("gap: 10px;");
     expect(memoryBackButtonRule).toContain("font-size: var(--codex-text-base);");
-    expect(memorySectionHeaderRule).toContain("padding: 0 14px 0 30px;");
+    expect(memorySectionHeaderRule).toContain("padding: 0 14px 0 20px;");
     expect(dragRegionRule).toContain("position: fixed;");
     expect(dragRegionRule).toContain("right: 0;");
     expect(dragRegionRule).toContain("left: 0;");

--- a/App/shell/desktop/src/main/main.ts
+++ b/App/shell/desktop/src/main/main.ts
@@ -149,6 +149,9 @@ let stopMemoryServiceForCurrentQuit = false;
 let quitCleanupForceExitTimer: ReturnType<typeof setTimeout> | null = null;
 let areIpcHandlersRegistered = false;
 let isBootReady = false;
+let bootStage = "pending";
+let bootStartedAt = 0;
+let isStartupFailureReported = false;
 let analyticsClientId: string | null = null;
 let analyticsAppEnv: "dev" | "prod" | null = null;
 let analyticsAppEdition: "cn" | "intl" | null = null;
@@ -309,6 +312,8 @@ async function stopPackagedRendererServer(): Promise<void> {
  */
 async function boot(): Promise<void> {
   try {
+    bootStartedAt = Date.now();
+    bootStage = "initializing";
     process.env.MEMMY_APP_EDITION = resolveCurrentDesktopEdition();
     initLogger();
     forceLightWindowChrome();
@@ -318,10 +323,19 @@ async function boot(): Promise<void> {
       return;
     }
 
+    if (isQuitting) return;
+    bootStage = "cli";
     showSplashWindow(); // Only show the splash on a normal boot (the update-handoff exit branch already returned above)
     registerIpcHandlers();
     await installBundledCliIfNeeded();
+    if (isQuitting) return;
+    bootStage = "renderer-server";
     await startPackagedRendererServerIfNeeded();
+    if (isQuitting) {
+      await stopPackagedRendererServer();
+      return;
+    }
+    bootStage = "data-migration";
     let windowsMigrationConsistency: WindowsDataMigrationConsistency | undefined;
     if (windowsDataLayout) {
       try {
@@ -334,6 +348,8 @@ async function boot(): Promise<void> {
         await writePackagedStartupLog(`boot:data-migration-state-failed-open:${JSON.stringify(recovery)}`);
       }
     }
+    if (isQuitting) return;
+    bootStage = "runtime-services";
     const appDatabaseFile = join(app.getPath("userData"), "app.sqlite");
     runtimeServices = await startManagedRuntimeServices({
       appPath: app.getAppPath(),
@@ -373,15 +389,29 @@ async function boot(): Promise<void> {
         ? join(process.resourcesPath, "memory-runtime")
         : undefined
     });
+    if (isQuitting) {
+      await runtimeServices.close({ stopMemory: stopMemoryServiceForCurrentQuit });
+      runtimeServices = null;
+      return;
+    }
+    bootStage = "local-api";
     runtimeConfig = await startLocalApi(runtimeServices);
-    isBootReady = true;
+    if (isQuitting) {
+      await localBackend?.close();
+      localBackend = null;
+      return;
+    }
+    bootStage = "renderer";
     const initialWindow = createInitialWindow();
+    watchStartupRenderer(initialWindow);
+    isBootReady = true;
     triggerAgentSourceAutoInject("boot");
     if (process.platform === "darwin") {
       syncMenuBarTray(resolveMenuBarIconEnabled());
     }
     setDevelopmentDockIcon();
     const rendererVerified = !windowsDataLayout || await waitForInitialRendererVerification(initialWindow);
+    if (isQuitting || isStartupFailureReported) return;
     await writePackagedStartupLog(rendererVerified ? "boot:ready" : "boot:ready-data-migration-verification-deferred");
     if (windowsDataLayout && rendererVerified) {
       await recordWindowsDataLayoutAfterBoot(
@@ -407,9 +437,8 @@ async function boot(): Promise<void> {
       void pruneWindowsLegacyUpdateCaches();
     }, UPDATES_PRUNE_STARTUP_DELAY_MS);
   } catch (error) {
-    await runtimeServices?.close();
-    runtimeServices = null;
-    throw error;
+    // Report first; before-quit owns runtime cleanup and its force-exit deadline.
+    await handleStartupFailure(error);
   }
 }
 
@@ -3326,10 +3355,11 @@ function normalizeMicrophoneAccessStatus(status: ElectronMediaAccessStatus): Mic
 // Startup splash: covers the blank gap between "process starts up" and "main window appears"
 // (spinning up local services + a few seconds of first-screen loading).
 let splashWindow: BrowserWindow | null = null;
-let splashCloseTimer: ReturnType<typeof setTimeout> | null = null;
-// Fallback: regardless of whether the close signal arrives, force-close after at most this long, so
-// it never blocks the UI permanently.
-const SPLASH_MAX_VISIBLE_MS = 15 * 1000;
+let splashTimer: ReturnType<typeof setTimeout> | null = null;
+let startupRendererCleanup: (() => void) | null = null;
+// Slow startup is diagnostic, not an application lifetime limit. The runtime owns its timeouts.
+const STARTUP_SLOW_MS = 15 * 1000;
+const STARTUP_RENDERER_TIMEOUT_MS = 30_000;
 const UPDATE_SPLASH_MAX_VISIBLE_MS = 60 * 1000;
 
 /**
@@ -3339,12 +3369,17 @@ const UPDATE_SPLASH_MAX_VISIBLE_MS = 60 * 1000;
  */
 function showSplashWindow(): void {
   const language = resolveCurrentStartupSplashLanguage();
-  showSplashHtml(resolveStartupSplashHtml(language), 300, 200, SPLASH_MAX_VISIBLE_MS);
+  showSplashHtml(resolveStartupSplashHtml(language), 300, 200, STARTUP_SLOW_MS, (splash) => {
+    void writePackagedStartupLog(`boot:slow:${JSON.stringify({ stage: bootStage, elapsedMs: Date.now() - bootStartedAt })}`);
+    void splash.loadURL(`data:text/html;charset=utf-8,${encodeURIComponent(resolveStartupSplashHtml(language, true))}`)
+      .catch((error: unknown) => console.warn("slow startup splash update failed:", error));
+  }, true);
 }
 
 function showUpdateInstallSplashWindow(version?: string): void {
   const language = resolveCurrentStartupSplashLanguage();
-  showSplashHtml(resolveUpdateSplashHtml(language, version), 360, 220, UPDATE_SPLASH_MAX_VISIBLE_MS);
+  showSplashHtml(resolveUpdateSplashHtml(language, version), 360, 220, UPDATE_SPLASH_MAX_VISIBLE_MS,
+    () => closeSplashWindow("update-timeout"));
 }
 
 function resolveCurrentStartupSplashLanguage(): StartupSplashLanguage {
@@ -3354,7 +3389,7 @@ function resolveCurrentStartupSplashLanguage(): StartupSplashLanguage {
   );
 }
 
-function showSplashHtml(html: string, width: number, height: number, maxVisibleMs: number): void {
+function showSplashHtml(html: string, width: number, height: number, timeoutMs: number, onTimeout: (splash: BrowserWindow) => void, quitOnUserClose = false): void {
   try {
     if (splashWindow && !splashWindow.isDestroyed()) {
       return;
@@ -3375,14 +3410,28 @@ function showSplashHtml(html: string, width: number, height: number, maxVisibleM
       backgroundColor: "#1f2937"
     });
     splashWindow = splash;
+    if (quitOnUserClose) {
+      splash.on("close", (event) => {
+        // Programmatic handoff clears splashWindow first; native close is an explicit exit.
+        if (splashWindow !== splash || isQuitting) return;
+        event.preventDefault();
+        void writePackagedStartupLog("quit:startup-splash-user-close");
+        app.quit();
+      });
+    }
     splash.once("ready-to-show", () => {
-      if (!splash.isDestroyed()) {
+      if (!splash.isDestroyed() && !isQuitting) {
         splash.show();
       }
     });
-    void splash.loadURL(`data:text/html;charset=utf-8,${encodeURIComponent(html)}`);
-    splashCloseTimer = setTimeout(closeSplashWindow, maxVisibleMs);
-    splashCloseTimer.unref?.();
+    void splash.loadURL(`data:text/html;charset=utf-8,${encodeURIComponent(html)}`)
+      .catch((error: unknown) => console.warn("splash window load failed:", error));
+    splashTimer = setTimeout(() => {
+      splashTimer = null;
+      if (splashWindow !== splash || splash.isDestroyed() || isQuitting) return;
+      onTimeout(splash);
+    }, timeoutMs);
+    splashTimer.unref?.();
   } catch (error) {
     console.warn("splash window skipped:", error);
   }
@@ -3393,22 +3442,54 @@ function showSplashHtml(html: string, width: number, height: number, maxVisibleM
  *
  * @returns Nothing.
  */
-function closeSplashWindow(): void {
-  if (splashCloseTimer) {
-    clearTimeout(splashCloseTimer);
-    splashCloseTimer = null;
+function closeSplashWindow(reason = "requested"): void {
+  startupRendererCleanup?.();
+  if (splashTimer) {
+    clearTimeout(splashTimer);
+    splashTimer = null;
   }
   const splash = splashWindow;
   splashWindow = null;
   if (splash && !splash.isDestroyed()) {
+    void writePackagedStartupLog(`boot:splash-closed:${JSON.stringify({ reason, stage: bootStage, elapsedMs: Date.now() - bootStartedAt })}`);
     splash.close();
   }
+}
+
+function watchStartupRenderer(targetWindow: BrowserWindow | null): void {
+  const splash = splashWindow;
+  if (!splash || splash.isDestroyed() || !targetWindow || targetWindow.isDestroyed()) return;
+  const fail = (error: Error) => {
+    if (splashWindow !== splash || isQuitting) return;
+    startupRendererCleanup?.();
+    void handleStartupFailure(error);
+  };
+  const handleFailed = (_event: ElectronEvent, code: number, description: string, _url: string, isMainFrame: boolean) => {
+    if (!isMainFrame || code === -3) return; // ERR_ABORTED can be a normal navigation replacement.
+    fail(new Error(`Startup renderer failed to load (${code}): ${description}`));
+  };
+  const handleGone = (_event: ElectronEvent, details: { reason: string; exitCode: number }) => {
+    if (targetWindow.isDestroyed()) return;
+    fail(new Error(`Startup renderer exited: ${details.reason} (${details.exitCode})`));
+  };
+  const timer = setTimeout(() => {
+    fail(new Error(`Startup renderer did not present a window within ${STARTUP_RENDERER_TIMEOUT_MS}ms`));
+  }, STARTUP_RENDERER_TIMEOUT_MS);
+  timer.unref?.();
+  const cleanup = () => {
+    clearTimeout(timer);
+    targetWindow.webContents.removeListener("did-fail-load", handleFailed);
+    targetWindow.webContents.removeListener("render-process-gone", handleGone);
+    if (startupRendererCleanup === cleanup) startupRendererCleanup = null;
+  };
+  startupRendererCleanup = cleanup;
+  targetWindow.webContents.on("did-fail-load", handleFailed);
+  targetWindow.webContents.on("render-process-gone", handleGone);
 }
 
 function createInitialWindow(): BrowserWindow | null {
   if (resolveInitialWindowMode() === "pet") {
     setPetWindowMode(true);
-    closeSplashWindow(); // Pet mode starts fast; no splash needed
     return petWindow;
   }
 
@@ -3643,11 +3724,10 @@ function createMainWindow(target: RendererRouteTarget | null = null): BrowserWin
   };
   mainWindowWithMinimize.on("minimize", handleMainWindowMinimize);
 
-  void targetMainWindow.loadURL(resolveRendererUrl("full", target));
-  // Close the splash as soon as the main window is ready (dual signals + the timeout fallback above
-  // ensure it always gets closed).
-  targetMainWindow.once("ready-to-show", closeSplashWindow);
-  targetMainWindow.webContents.once("did-finish-load", closeSplashWindow);
+  void targetMainWindow.loadURL(resolveRendererUrl("full", target)).catch(handleRendererLoadFailure);
+  // The main window takes over from the splash when its renderer is ready.
+  targetMainWindow.once("ready-to-show", () => closeSplashWindow("main-ready-to-show"));
+  targetMainWindow.webContents.once("did-finish-load", () => closeSplashWindow("main-did-finish-load"));
 
   targetMainWindow.on("closed", () => {
     mainWindow = null;
@@ -3880,7 +3960,7 @@ function createPetWindow(target: RendererRouteTarget | null = null): BrowserWind
     configurePetWindowPriority(targetPetWindow);
   });
 
-  void targetPetWindow.loadURL(resolveRendererUrl("pet", target));
+  void targetPetWindow.loadURL(resolveRendererUrl("pet", target)).catch(handleRendererLoadFailure);
 
   targetPetWindow.on("closed", () => {
     const wasProgrammaticClose = programmaticPetWindowCloses.delete(targetPetWindow);
@@ -4238,6 +4318,7 @@ function showPetWindowAfterRendererLayout(): void {
   configurePetWindowPriority(petWindow);
   applyPetWindowBounds();
   petWindow.showInactive();
+  closeSplashWindow("pet-visible");
 }
 
 /**
@@ -4842,6 +4923,28 @@ app.on("second-instance", () => {
   }
 });
 
+async function handleStartupFailure(error: unknown): Promise<void> {
+  if (isStartupFailureReported) return;
+  isStartupFailureReported = true;
+  startupRendererCleanup?.();
+  console.error(error);
+  bootStage = "failed";
+  await writePackagedStartupLog(`boot:error\n${formatStartupError(error)}`);
+  if (isQuitting) return;
+  showPackagedStartupError(error);
+  closeSplashWindow("boot-error");
+  app.quit();
+}
+
+function handleRendererLoadFailure(error: unknown): void {
+  if (isQuitting || (error as { code?: string } | null)?.code === "ERR_ABORTED") return;
+  if (splashWindow && !splashWindow.isDestroyed()) {
+    void handleStartupFailure(error);
+    return;
+  }
+  console.warn("renderer load failed:", error);
+}
+
 app.whenReady().then(async () => {
   if (!(await waitForSingleInstanceLock())) {
     // An instance is already running: this instance exits directly, to avoid a second instance
@@ -4857,13 +4960,7 @@ app.whenReady().then(async () => {
   }
 
   await boot();
-}).catch(async (error: unknown) => {
-  console.error(error);
-  closeSplashWindow(); // Close the splash even on boot failure, so it does not stay stuck on screen
-  await writePackagedStartupLog(`boot:error\n${formatStartupError(error)}`);
-  showPackagedStartupError(error);
-  app.quit();
-});
+}).catch(handleStartupFailure);
 
 app.on("activate", () => {
   if (isQuitting || isQuitCleanupInProgress) {
@@ -4885,6 +4982,11 @@ app.on("activate", () => {
 });
 
 app.on("window-all-closed", () => {
+  if (isQuitting) return;
+  if (!isBootReady) {
+    void writePackagedStartupLog(`boot:window-all-closed-ignored:${bootStage}`);
+    return;
+  }
   if (process.platform !== "darwin") {
     app.quit();
   }
@@ -4906,6 +5008,7 @@ app.on("before-quit", (event) => {
 
   event.preventDefault();
   isQuitting = true;
+  closeSplashWindow("quit");
   hideAppShellForQuit();
   if (isQuitCleanupInProgress) {
     return;

--- a/App/shell/desktop/src/main/startup-splash.ts
+++ b/App/shell/desktop/src/main/startup-splash.ts
@@ -25,14 +25,16 @@ export function resolveStartupSplashLanguage(
   }
 }
 
-export function resolveStartupSplashHtml(language: StartupSplashLanguage): string {
-  const hint = language === "en-US" ? "Starting…" : "正在启动…";
+export function resolveStartupSplashHtml(language: StartupSplashLanguage, slow = false): string {
+  const hint = slow
+    ? language === "en-US" ? "Taking longer than usual. Please wait…" : "启动时间较长，请稍候…"
+    : language === "en-US" ? "Starting…" : "正在启动…";
   return `<!doctype html><html><head><meta charset="utf-8"><style>
 html,body{margin:0;height:100%;overflow:hidden;font-family:-apple-system,"Segoe UI",sans-serif;}
 body{display:flex;align-items:center;justify-content:center;background:#1f2937;color:#f9fafb;-webkit-user-select:none;cursor:default;}
 .box{display:flex;flex-direction:column;align-items:center;gap:16px;}
 .title{font-size:22px;font-weight:600;letter-spacing:1px;}
-.hint{font-size:13px;color:#9ca3af;}
+.hint{font-size:13px;color:#9ca3af;text-align:center;padding:0 16px;}
 .spinner{width:28px;height:28px;border:3px solid rgba(255,255,255,.2);border-top-color:#34d399;border-radius:50%;animation:spin .8s linear infinite;}
 @keyframes spin{to{transform:rotate(360deg);}}
 </style></head><body><div class="box"><div class="spinner"></div><div class="title">Memmy</div><div class="hint">${hint}</div></div></body></html>`;

--- a/App/shell/desktop/tests/startup-lifecycle.test.ts
+++ b/App/shell/desktop/tests/startup-lifecycle.test.ts
@@ -1,0 +1,285 @@
+import { EventEmitter } from "node:events";
+import { readFileSync } from "node:fs";
+import { createContext, runInContext } from "node:vm";
+import ts from "typescript";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { resolveStartupSplashHtml, resolveUpdateSplashHtml } from "../src/main/startup-splash.js";
+
+// Execute the real startup/window callbacks without importing Electron or starting user services.
+// The AST extraction keeps the race tests tied to main.ts rather than a copy of its implementation.
+const source = ts.createSourceFile("main.ts", readFileSync(new URL("../src/main/main.ts", import.meta.url), "utf8"), ts.ScriptTarget.Latest, true);
+const functionNames = new Set([
+  "boot", "showSplashWindow", "showUpdateInstallSplashWindow", "showSplashHtml", "closeSplashWindow",
+  "createInitialWindow", "createMainWindow", "showPetWindowAfterRendererLayout", "hideAppShellForQuit",
+  "watchStartupRenderer", "handleStartupFailure", "handleRendererLoadFailure"
+]);
+const variableNames = new Set([
+  "mainWindow", "petWindow", "runtimeServices", "runtimeConfig", "isBootReady", "isQuitting",
+  "isQuitCleanupInProgress", "isQuitCleanupComplete", "stopMemoryServiceForCurrentQuit",
+  "splashWindow", "splashCloseTimer", "splashTimer", "SPLASH_MAX_VISIBLE_MS", "STARTUP_SLOW_MS",
+  "UPDATE_SPLASH_MAX_VISIBLE_MS", "bootStage", "bootStartedAt", "isPetWindowReadyToShow",
+  "latestPetWindowLayout", "petMascotScreenAnchor", "startupRendererCleanup", "STARTUP_RENDERER_TIMEOUT_MS",
+  "isStartupFailureReported", "localBackend"
+]);
+const selected = source.statements.filter(statement => {
+  if (ts.isFunctionDeclaration(statement)) return functionNames.has(statement.name?.text ?? "");
+  if (ts.isVariableStatement(statement)) return statement.declarationList.declarations.some(declaration => variableNames.has(declaration.name.getText(source)));
+  if (!ts.isExpressionStatement(statement) || !ts.isCallExpression(statement.expression)) return false;
+  const call = statement.expression;
+  return call.expression.getText(source) === "app.on"
+    && ["window-all-closed", "before-quit"].includes((call.arguments[0] as ts.StringLiteral)?.text);
+});
+const readyStatement = source.statements.find(statement => ts.isExpressionStatement(statement)
+  && statement.expression.getText(source).startsWith("app.whenReady().then(")) as ts.ExpressionStatement;
+const failureHandler = (readyStatement.expression as ts.CallExpression).arguments[0]!.getText(source);
+const code = ts.transpileModule([
+  ...selected.map(statement => statement.getText(source)),
+  `globalThis.start = () => boot().catch(${failureHandler});`
+].join("\n").replaceAll("import.meta.dirname", '"test-main-directory"'), {
+  compilerOptions: { target: ts.ScriptTarget.ES2022, module: ts.ModuleKind.CommonJS }
+}).outputText;
+
+function setup(options: { delay?: number; error?: Error; apiError?: Error; cleanupHangs?: boolean; platform?: string; mode?: "full" | "pet" } = {}) {
+  vi.useFakeTimers();
+  vi.setSystemTime(0);
+  const events: string[] = [];
+  const windows = new Set<FakeWindow>();
+  const app = new EventEmitter() as EventEmitter & Record<string, any>;
+  let context: ReturnType<typeof createContext>;
+  class FakeWindow extends EventEmitter {
+    destroyed = false;
+    visible: boolean;
+    urls: string[] = [];
+    webContents = new EventEmitter();
+    constructor(settings: { show?: boolean } = {}) {
+      super();
+      this.visible = settings.show !== false;
+      windows.add(this);
+    }
+    static getAllWindows() { return [...windows]; }
+    isDestroyed() { return this.destroyed; }
+    show() { this.visible = true; }
+    showInactive() { this.visible = true; }
+    hide() { this.visible = false; }
+    loadURL(url: string) { this.urls.push(url); return Promise.resolve(); }
+    close() {
+      const event = { defaultPrevented: false, preventDefault() { this.defaultPrevented = true; } };
+      this.emit("close", event);
+      if (!event.defaultPrevented) this.destroy();
+    }
+    destroy() {
+      if (this.destroyed) return;
+      this.destroyed = true;
+      windows.delete(this);
+      this.emit("closed");
+      if (windows.size === 0) app.emit("window-all-closed");
+    }
+  }
+  const services = { close: vi.fn(() => options.cleanupHangs ? new Promise<void>(() => {}) : Promise.resolve()) };
+  const quit = vi.fn(() => {
+    events.push("quit");
+    const event = { defaultPrevented: false, preventDefault() { this.defaultPrevented = true; } };
+    app.emit("before-quit", event);
+  });
+  Object.assign(app, { quit, getPath: () => "test-user-data", getAppPath: () => "test-app", isPackaged: true });
+  const noop = () => {};
+  context = createContext({
+    app, BrowserWindow: FakeWindow, process: { platform: options.platform ?? "win32", env: {}, resourcesPath: "test-resources" },
+    console: { warn: vi.fn(), error: vi.fn() }, Date, setTimeout, clearTimeout,
+    join: (...parts: string[]) => parts.join("/"),
+    writePackagedStartupLog: async (message: string) => { events.push(message); },
+    formatStartupError: (error: Error) => error.message,
+    showPackagedStartupError: () => { events.push("error-dialog"); },
+    resolveCurrentDesktopEdition: () => "cn", initLogger: noop, forceLightWindowChrome: noop,
+    installPreparedRequiredUpdateBeforeBoot: async () => false,
+    registerIpcHandlers: noop, installBundledCliIfNeeded: async () => {}, startPackagedRendererServerIfNeeded: async () => {},
+    windowsDataLayout: null,
+    startManagedRuntimeServices: async () => {
+      if (options.delay) await new Promise(resolve => setTimeout(resolve, options.delay));
+      if (options.error) throw options.error;
+      return services;
+    },
+    startLocalApi: async () => { if (options.apiError) throw options.apiError; return {}; },
+    triggerAgentSourceAutoInject: noop, getCurrentLogLevel: () => "info",
+    setDevelopmentDockIcon: noop, startRequiredUpdateBackgroundChecks: noop,
+    pruneUpdatesDirectory: noop, pruneWindowsLegacyUpdateCaches: noop, UPDATES_PRUNE_STARTUP_DELAY_MS: 999_999,
+    syncMenuBarTray: noop, resolveMenuBarIconEnabled: () => false,
+    resolveCurrentStartupSplashLanguage: () => "zh-CN", resolveStartupSplashHtml, resolveUpdateSplashHtml,
+    resolveInitialWindowMode: () => options.mode ?? "full",
+    setPetWindowMode: () => { context.testPet = new FakeWindow({ show: false }); runInContext("petWindow = testPet", context); },
+    configurePetWindowPriority: noop, applyPetWindowBounds: noop,
+    resolveWindowsTaskbarIconPath: () => undefined, fullWindowOptions: {}, resolveFullWindowChromeOptions: () => ({}),
+    resolveFullWindowSize: () => ({}), screen: { getPrimaryDisplay: () => ({ workArea: {} }) }, createWebPreferences: () => ({}),
+    hideInWindowMenuBar: noop, updateFullWindowButtonPosition: noop, attachWindowOpenHandler: noop,
+    attachRendererContextMenu: noop, attachRendererShortcutGuards: noop, attachMainWindowFullScreenSync: noop,
+    handleMainWindowClose: noop, handleMainWindowMinimize: noop, resolveRendererUrl: () => "http://test-renderer.invalid",
+    shouldIgnoreStaleReopenQuit: () => false, hasSingleInstanceLock: true,
+    readStopMemoryServiceOnExitSetting: () => false, armQuitCleanupForceExitTimer: noop,
+    cleanupBeforeQuit: async () => {}, clearQuitCleanupForceExitTimer: noop, relaunchAfterQuitCleanupIfRequested: noop
+  });
+  runInContext(code, context);
+  return {
+    events, app, quit, services,
+    start: () => context.start() as Promise<void>,
+    run: (code: string) => runInContext(code, context),
+    splash: () => runInContext("splashWindow", context) as FakeWindow | null,
+    main: () => runInContext("mainWindow", context) as FakeWindow | null,
+    pet: () => runInContext("petWindow", context) as FakeWindow | null
+  };
+}
+
+afterEach(() => vi.useRealTimers());
+
+describe("desktop startup lifecycle", () => {
+  it("keeps the startup splash and process alive while runtime startup takes 20 seconds", async () => {
+    const test = setup({ delay: 20_000 });
+    const boot = test.start();
+    await vi.advanceTimersByTimeAsync(15_000);
+    expect(test.quit).not.toHaveBeenCalled();
+    expect(test.splash()?.isDestroyed()).toBe(false);
+    expect(test.splash()?.urls.at(-1)).toContain(encodeURIComponent("启动时间较长"));
+    expect(test.events.some(event => event.startsWith("boot:slow"))).toBe(true);
+    await vi.advanceTimersByTimeAsync(5_000);
+    await boot;
+    expect(test.main()).not.toBeNull();
+    test.main()!.emit("ready-to-show");
+    expect(test.splash()).toBeNull();
+    expect(test.quit).not.toHaveBeenCalled();
+    expect(test.events).toContain("boot:ready");
+  });
+
+  it("does not treat losing the only splash as a user-requested quit during boot", () => {
+    const test = setup();
+    test.run("showSplashWindow()");
+    test.splash()!.destroy();
+    expect(test.quit).not.toHaveBeenCalled();
+  });
+
+  it("closes a fast startup splash on renderer load and cancels the slow-start notice", async () => {
+    const test = setup();
+    await test.start();
+    test.main()!.webContents.emit("did-finish-load");
+    expect(test.splash()).toBeNull();
+    await vi.advanceTimersByTimeAsync(20_000);
+    expect(test.events.some(event => event.startsWith("boot:slow"))).toBe(false);
+    expect(test.quit).not.toHaveBeenCalled();
+  });
+
+  it("keeps the pet startup splash until the renderer layout makes the pet visible", async () => {
+    const test = setup({ mode: "pet" });
+    await test.start();
+    expect(test.pet()?.visible).toBe(false);
+    expect(test.splash()).not.toBeNull();
+    test.run("latestPetWindowLayout = {}; petMascotScreenAnchor = {}; showPetWindowAfterRendererLayout()");
+    expect(test.pet()?.visible).toBe(true);
+    expect(test.splash()).toBeNull();
+    expect(test.quit).not.toHaveBeenCalled();
+  });
+
+  it("records and displays a boot error before requesting quit", async () => {
+    const test = setup({ error: new Error("runtime startup failed") });
+    await test.start();
+    expect(test.events.indexOf("boot:error\nruntime startup failed")).toBeLessThan(test.events.indexOf("quit"));
+    expect(test.events.indexOf("error-dialog")).toBeLessThan(test.events.indexOf("quit"));
+    expect(test.splash()).toBeNull();
+    expect(test.quit).toHaveBeenCalled();
+  });
+
+  it("honors explicit quit during slow boot without showing a late main window", async () => {
+    const test = setup({ delay: 20_000 });
+    const boot = test.start();
+    await vi.advanceTimersByTimeAsync(1_000);
+    test.app.quit();
+    await vi.advanceTimersByTimeAsync(19_000);
+    await boot;
+    expect(test.quit).toHaveBeenCalled();
+    expect(test.main()).toBeNull();
+    expect(test.services.close).toHaveBeenCalled();
+    expect(test.events.some(event => event.startsWith("boot:slow"))).toBe(false);
+  });
+
+  it("treats a native close of the startup splash as explicit quit", async () => {
+    const test = setup({ delay: 20_000 });
+    const boot = test.start();
+    await vi.advanceTimersByTimeAsync(1_000);
+    test.splash()!.close();
+    expect(test.quit).toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(19_000);
+    await boot;
+    expect(test.main()).toBeNull();
+  });
+
+  it("reports local API failure without waiting for runtime cleanup to settle", async () => {
+    const test = setup({ apiError: new Error("local API failed"), cleanupHangs: true });
+    void test.start();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(test.events).toContain("boot:error\nlocal API failed");
+    expect(test.events).toContain("error-dialog");
+    expect(test.quit).toHaveBeenCalled();
+  });
+
+  it("starts the renderer deadline only after slow runtime startup has finished", async () => {
+    const test = setup({ delay: 40_000, mode: "pet" });
+    const boot = test.start();
+    await vi.advanceTimersByTimeAsync(40_000);
+    await boot;
+    expect(test.quit).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(29_999);
+    expect(test.quit).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(test.events.some(event => event.startsWith("boot:error\n") && event.includes("30000"))).toBe(true);
+    expect(test.events).toContain("error-dialog");
+    expect(test.splash()).toBeNull();
+    expect(test.quit).toHaveBeenCalled();
+  });
+
+  it.each(["full", "pet"] as const)("reports a %s renderer failure and cancels its timeout", async mode => {
+    const test = setup({ mode });
+    await test.start();
+    const window = mode === "pet" ? test.pet()! : test.main()!;
+    window.webContents.emit("did-fail-load", {}, -105, "NAME_NOT_RESOLVED", "http://test-renderer.invalid", true);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(test.events.some(event => event.startsWith("boot:error\n") && event.includes("NAME_NOT_RESOLVED"))).toBe(true);
+    expect(test.splash()).toBeNull();
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(test.events.filter(event => event.startsWith("boot:error\n"))).toHaveLength(1);
+  });
+
+  it("reports a renderer crash before the pet is visible", async () => {
+    const test = setup({ mode: "pet" });
+    await test.start();
+    test.pet()!.webContents.emit("render-process-gone", {}, { reason: "crashed", exitCode: 1 });
+    await vi.advanceTimersByTimeAsync(0);
+    expect(test.events.some(event => event.startsWith("boot:error\n") && event.includes("crashed"))).toBe(true);
+    expect(test.quit).toHaveBeenCalled();
+  });
+
+  it("ignores subframe load failures and aborted navigation during startup", async () => {
+    const test = setup();
+    await test.start();
+    test.main()!.webContents.emit("did-fail-load", {}, -105, "NAME_NOT_RESOLVED", "http://test.invalid", false);
+    test.main()!.webContents.emit("did-fail-load", {}, -3, "ERR_ABORTED", "http://test.invalid", true);
+    test.main()!.emit("ready-to-show");
+    await vi.advanceTimersByTimeAsync(40_000);
+    expect(test.quit).not.toHaveBeenCalled();
+  });
+
+  it("preserves the update splash's separate 60-second timeout", async () => {
+    const test = setup();
+    test.run("showUpdateInstallSplashWindow('1.1.3')");
+    await vi.advanceTimersByTimeAsync(59_999);
+    expect(test.splash()).not.toBeNull();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(test.splash()).toBeNull();
+    expect(test.events.some(event => event.startsWith("boot:slow"))).toBe(false);
+  });
+
+  it.each(["win32", "linux", "darwin"])("preserves %s close behavior after boot", async platform => {
+    const test = setup({ platform });
+    await test.start();
+    test.main()!.emit("ready-to-show");
+    test.main()!.close();
+    if (platform === "darwin") expect(test.quit).not.toHaveBeenCalled();
+    else expect(test.quit).toHaveBeenCalled();
+  });
+});

--- a/App/shell/desktop/tests/startup-splash.test.ts
+++ b/App/shell/desktop/tests/startup-splash.test.ts
@@ -50,6 +50,12 @@ describe("startup splash localization", () => {
     expect(chineseHtml).not.toContain("Starting…");
   });
 
+  it("renders a localized waiting message for slow startup", () => {
+    expect(resolveStartupSplashHtml("zh-CN", true)).toContain("启动时间较长，请稍候…");
+    expect(resolveStartupSplashHtml("en-US", true)).toContain("Taking longer than usual. Please wait…");
+    expect(resolveStartupSplashHtml("en-US", true)).not.toContain("启动时间较长");
+  });
+
   it("renders the update splash without exposing unescaped version text", () => {
     const englishHtml = resolveUpdateSplashHtml("en-US", "1.0.8<script>");
     const chineseHtml = resolveUpdateSplashHtml("zh-CN", "1.0.8");


### PR DESCRIPTION
## Summary

- Keep the desktop process alive while the gateway is still starting, so a slow browser capability probe cannot make the app exit silently when the splash closes.
- Keep the startup splash lifecycle aligned with renderer handoff.
- Add startup lifecycle and splash regression coverage.
- Include the existing modal interaction and sidebar alignment fixes carried by this branch.

## Validation

- npm --prefix App/shell/desktop exec vitest run tests/startup-lifecycle.test.ts tests/startup-splash.test.ts — 2 files, 26 tests passed.
- npm run test -w @memmy/frontend-desktop -- src/components/tests/Modal.test.tsx src/theme/tests/style-alignment.test.ts — 2 files, 23 tests passed.
- git diff --check passed.
- Branch was merged with upstream/v1.1.4 without conflicts.

Closes MemTensor/memmy-agent#362