### PR TITLE
Fix #378: Windows 更新后启动弹出 Windows Script Host 错误：There is no script engine for file extens

### DIFF
--- a/App/shell/desktop/src/main/main.ts
+++ b/App/shell/desktop/src/main/main.ts
@@ -2676,7 +2676,7 @@ async function installWindowsUpdateInBackground(
   const updatesDirectory = resolveUpdatesDirectory();
   await mkdir(updatesDirectory, { recursive: true });
   const helperPath = join(updatesDirectory, `install-win-update-${Date.now()}.ps1`);
-  const launcherPath = join(updatesDirectory, `launch-win-update-${Date.now()}.vbs`);
+  const launcherPath = join(updatesDirectory, `launch-win-update-${Date.now()}.cmd`);
   const logPath = join(updatesDirectory, "win-update-install.log");
   if (options.showUpdatePrompt) {
     await writeWindowsUpdatePromptLanguage(resolveWindowsUpdatePromptLanguageFromAppSettings());
@@ -2704,7 +2704,7 @@ async function installWindowsUpdateInBackground(
   ]));
   await appendFile(logPath, `[${new Date().toISOString()}] queued Memmy Windows update helper "${helperPath}"\n`).catch(() => undefined);
 
-  const helper = spawn("wscript.exe", [launcherPath], {
+  const helper = spawn(process.env.ComSpec ?? "cmd.exe", ["/D", "/C", launcherPath], {
     detached: true,
     stdio: "ignore",
     windowsHide: true

--- a/App/shell/desktop/src/main/main.ts
+++ b/App/shell/desktop/src/main/main.ts
@@ -2704,7 +2704,14 @@ async function installWindowsUpdateInBackground(
   ]));
   await appendFile(logPath, `[${new Date().toISOString()}] queued Memmy Windows update helper "${helperPath}"\n`).catch(() => undefined);
 
-  const helper = spawn(process.env.ComSpec ?? "cmd.exe", ["/D", "/C", launcherPath], {
+  // Resolve cmd.exe through SystemRoot (a kernel-set variable) rather than
+  // ComSpec, which any process can override before Memmy starts. Consistent
+  // with the generated CMD batch, which already hard-codes powershell.exe under
+  // %SystemRoot%\System32 rather than trusting PATH.
+  const comSpec = process.env.SystemRoot
+    ? join(process.env.SystemRoot, "System32", "cmd.exe")
+    : "cmd.exe";
+  const helper = spawn(comSpec, ["/D", "/C", launcherPath], {
     detached: true,
     stdio: "ignore",
     windowsHide: true

--- a/App/shell/desktop/src/main/windows-launch-at-login.ts
+++ b/App/shell/desktop/src/main/windows-launch-at-login.ts
@@ -140,21 +140,37 @@ const defaultWindowsScriptHostProbe: WindowsScriptHostProbe = (systemRootPath) =
 };
 
 const probeWindowsScriptHostOnce = (systemRootPath: string): boolean => {
-  const cscriptPath = windowsPath.join(systemRootPath, "System32", "cscript.exe");
-  if (!existsSync(cscriptPath)) {
+  // Mirror the production launch path (line 72) so the probe fails whenever
+  // the user-facing login item would fail. wscript.exe resolves .vbs through
+  // the shell file-association that surfaces the "no script engine" dialog;
+  // cscript's // switches bypass that association and could pass on systems
+  // where wscript still errors.
+  const wscriptPath = windowsPath.join(systemRootPath, "System32", "wscript.exe");
+  if (!existsSync(wscriptPath)) {
     return false;
   }
 
   let workingDirectory: string | undefined;
   try {
     workingDirectory = mkdtempSync(joinPath(tmpdir(), "memmy-wsh-probe-"));
-    const probeScript = joinPath(workingDirectory, "probe.vbs");
+    const probeScript = windowsPath.join(workingDirectory, "probe.vbs");
     writeFileSync(probeScript, "WScript.Quit 0\r\n", { encoding: "ascii" });
-    const result = spawnSync(cscriptPath, ["//B", "//Nologo", "//T:5", probeScript], {
-      stdio: "ignore",
-      windowsHide: true
-    });
-    return result.status === 0;
+    // Generous timeout to avoid false negatives on heavily loaded machines;
+    // the trivial WScript.Quit script completes in milliseconds under normal
+    // conditions.
+    const CSCRIPT_PROBE_TIMEOUT_SECONDS = 5;
+    const result = spawnSync(
+      wscriptPath,
+      ["//B", "//Nologo", `//T:${CSCRIPT_PROBE_TIMEOUT_SECONDS}`, probeScript],
+      {
+        stdio: "ignore",
+        windowsHide: true
+      }
+    );
+    // result.status is null when the process is killed by a signal (e.g. the
+    // //T:5 timeout); the explicit error guard also covers spawn-time failures
+    // where the engine is present but the launch itself was rejected.
+    return result.status === 0 && result.error == null;
   } catch {
     return false;
   } finally {

--- a/App/shell/desktop/src/main/windows-launch-at-login.ts
+++ b/App/shell/desktop/src/main/windows-launch-at-login.ts
@@ -1,5 +1,7 @@
-import { existsSync } from "node:fs";
-import { win32 as windowsPath } from "node:path";
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { win32 as windowsPath, join as joinPath } from "node:path";
 
 interface WindowsLoginItemOptions {
   path: string;
@@ -34,16 +36,22 @@ export interface WindowsLaunchAtLoginEnvironment {
 
 export type WindowsPathExists = (path: string) => boolean;
 
+export type WindowsScriptHostProbe = (systemRootPath: string) => boolean;
+
 /**
  * Resolves the command Windows should run after the user signs in.
  *
- * Installed builds use the stable launcher created by the NSIS package so custom-drive
- * upgrades follow the same recovery-aware launch chain as Start menu shortcuts. A direct
- * executable fallback keeps older or partially repaired installations usable.
+ * Installed builds normally use the stable launcher created by the NSIS package so custom-drive
+ * upgrades follow the same recovery-aware launch chain as Start menu shortcuts. When the
+ * user's Windows Script Host / VBScript engine is unavailable (uninstalled Windows Feature,
+ * GPO block, or a broken .vbs handler after a Windows update), invoking the launcher through
+ * wscript.exe would surface a "There is no script engine for file extension '.vbs'" dialog on
+ * every login; falling back to the packaged executable keeps the user's next sign-in silent.
  */
 export const resolveWindowsLoginItemCommand = (
   environment: WindowsLaunchAtLoginEnvironment,
-  pathExists: WindowsPathExists = existsSync
+  pathExists: WindowsPathExists = existsSync,
+  probeWindowsScriptHost: WindowsScriptHostProbe = defaultWindowsScriptHostProbe
 ): WindowsLoginItemOptions => {
   const localAppDataPath = environment.localAppDataPath?.trim();
   const systemRootPath = environment.systemRootPath?.trim();
@@ -53,6 +61,10 @@ export const resolveWindowsLoginItemCommand = (
 
   const launcherPath = windowsPath.join(localAppDataPath, "Memmy", "launcher", "MemmyLauncher.vbs");
   if (!pathExists(launcherPath)) {
+    return { path: environment.executablePath, args: [] };
+  }
+
+  if (!probeWindowsScriptHost(systemRootPath)) {
     return { path: environment.executablePath, args: [] };
   }
 
@@ -66,13 +78,14 @@ export const resolveWindowsLoginItemCommand = (
 export const getWindowsLaunchAtLogin = (
   application: WindowsLoginItemApplication,
   environment: WindowsLaunchAtLoginEnvironment,
-  pathExists: WindowsPathExists = existsSync
+  pathExists: WindowsPathExists = existsSync,
+  probeWindowsScriptHost: WindowsScriptHostProbe = defaultWindowsScriptHostProbe
 ): boolean => {
   if (environment.platform !== "win32" || !environment.isPackaged) {
     return false;
   }
 
-  const command = resolveWindowsLoginItemCommand(environment, pathExists);
+  const command = resolveWindowsLoginItemCommand(environment, pathExists, probeWindowsScriptHost);
   const settings = application.getLoginItemSettings(command);
   if (!settings.openAtLogin) {
     return false;
@@ -91,19 +104,71 @@ export const setWindowsLaunchAtLogin = (
   application: WindowsLoginItemApplication,
   environment: WindowsLaunchAtLoginEnvironment,
   enabled: boolean,
-  pathExists: WindowsPathExists = existsSync
+  pathExists: WindowsPathExists = existsSync,
+  probeWindowsScriptHost: WindowsScriptHostProbe = defaultWindowsScriptHostProbe
 ): boolean => {
   if (environment.platform !== "win32" || !environment.isPackaged) {
     return false;
   }
 
-  const command = resolveWindowsLoginItemCommand(environment, pathExists);
+  const command = resolveWindowsLoginItemCommand(environment, pathExists, probeWindowsScriptHost);
   application.setLoginItemSettings({
     openAtLogin: enabled,
     enabled,
     ...command
   });
-  return getWindowsLaunchAtLogin(application, environment, pathExists);
+  return getWindowsLaunchAtLogin(application, environment, pathExists, probeWindowsScriptHost);
 };
 
 const normalizeWindowsCommandPath = (path: string): string => path.replaceAll("/", "\\").toLowerCase();
+
+let cachedWindowsScriptHostAvailable: boolean | null = null;
+
+/**
+ * Detects whether the system's Windows Script Host / VBScript engine can execute a .vbs file.
+ *
+ * The result is cached for the lifetime of the process because a Windows session cannot regain
+ * a removed script engine without restarting.
+ */
+const defaultWindowsScriptHostProbe: WindowsScriptHostProbe = (systemRootPath) => {
+  if (cachedWindowsScriptHostAvailable !== null) {
+    return cachedWindowsScriptHostAvailable;
+  }
+
+  cachedWindowsScriptHostAvailable = probeWindowsScriptHostOnce(systemRootPath);
+  return cachedWindowsScriptHostAvailable;
+};
+
+const probeWindowsScriptHostOnce = (systemRootPath: string): boolean => {
+  const cscriptPath = windowsPath.join(systemRootPath, "System32", "cscript.exe");
+  if (!existsSync(cscriptPath)) {
+    return false;
+  }
+
+  let workingDirectory: string | undefined;
+  try {
+    workingDirectory = mkdtempSync(joinPath(tmpdir(), "memmy-wsh-probe-"));
+    const probeScript = joinPath(workingDirectory, "probe.vbs");
+    writeFileSync(probeScript, "WScript.Quit 0\r\n", { encoding: "ascii" });
+    const result = spawnSync(cscriptPath, ["//B", "//Nologo", "//T:5", probeScript], {
+      stdio: "ignore",
+      windowsHide: true
+    });
+    return result.status === 0;
+  } catch {
+    return false;
+  } finally {
+    if (workingDirectory) {
+      try {
+        rmSync(workingDirectory, { recursive: true, force: true });
+      } catch {
+        // Best-effort cleanup only; leaving a probe file behind is safe.
+      }
+    }
+  }
+};
+
+/** @internal test hook: forget the memoized VBScript availability. */
+export const resetWindowsScriptHostProbeCacheForTesting = (): void => {
+  cachedWindowsScriptHostAvailable = null;
+};

--- a/App/shell/desktop/src/main/windows-update-launcher.ts
+++ b/App/shell/desktop/src/main/windows-update-launcher.ts
@@ -1,34 +1,58 @@
 /**
- * Creates the VBS script that launches the Windows update helper hidden.
+ * Creates the CMD script that launches the Windows update helper hidden.
+ *
+ * A CMD launcher replaces the historical .vbs launcher so systems with
+ * VBScript / Windows Script Host disabled (e.g. Windows Feature removal or GPO)
+ * no longer surface the "There is no script engine for file extension '.vbs'"
+ * dialog after an update.
+ *
+ * The generated batch delegates to PowerShell via -EncodedCommand so localized
+ * paths and arguments round-trip through UTF-16 without depending on the host
+ * console code page.
  *
  * @param command The PowerShell helper launch command and arguments.
- * @returns The VBS script content.
+ * @returns The CMD script content.
  */
 const createWindowsUpdateLauncherScript = (command: string[]): string => {
-  const shellCommand = command.map(quoteWindowsShellArgument).join(" ");
-  return `Set shell = CreateObject("WScript.Shell")
-shell.Run "${escapeVbsString(shellCommand)}", 0, False
-Set fso = CreateObject("Scripting.FileSystemObject")
-On Error Resume Next
-fso.DeleteFile WScript.ScriptFullName, True
-`;
+  const [powershellPath, ...rest] = command;
+  const targetPath = powershellPath ?? "powershell.exe";
+  const startProcess = [
+    "Start-Process",
+    "-FilePath",
+    quotePowerShellSingleQuoted(targetPath),
+    "-ArgumentList",
+    quotePowerShellArgumentList(rest),
+    "-WindowStyle",
+    "Hidden"
+  ].join(" ");
+  const encodedCommand = Buffer.from(startProcess, "utf16le").toString("base64");
+  return [
+    "@echo off",
+    `start "" /B "%SystemRoot%\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" -NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -EncodedCommand ${encodedCommand}`,
+    '(goto) 2>nul & del "%~f0"',
+    ""
+  ].join("\r\n");
 };
 
 /**
- * Creates a Windows Script Host compatible launcher file.
+ * Creates a Windows launcher file that does not depend on Windows Script Host.
  *
- * Windows Script Host may decode a BOM-less UTF-8 VBS file with the active
- * system code page, corrupting non-ASCII update paths before PowerShell starts.
+ * The launcher is a CMD batch that hands off to PowerShell via -EncodedCommand
+ * so non-ASCII install paths survive the OEM console code page. The batch
+ * deletes itself once dispatched.
  */
 export const createWindowsUpdateLauncherFile = (command: string[]): Buffer => {
   const script = createWindowsUpdateLauncherScript(command);
-  return Buffer.from(`\uFEFF${script}`, "utf16le");
+  return Buffer.from(script, "utf8");
 };
 
-const quoteWindowsShellArgument = (value: string): string => {
-  return `"${value.replace(/"/g, "\\\"")}"`;
+const quotePowerShellArgumentList = (values: string[]): string => {
+  if (values.length === 0) {
+    return "@()";
+  }
+  return values.map(quotePowerShellSingleQuoted).join(",");
 };
 
-const escapeVbsString = (value: string): string => {
-  return value.replace(/"/g, "\"\"");
+const quotePowerShellSingleQuoted = (value: string): string => {
+  return `'${value.replace(/'/g, "''")}'`;
 };

--- a/App/shell/desktop/src/main/windows-update-launcher.ts
+++ b/App/shell/desktop/src/main/windows-update-launcher.ts
@@ -50,7 +50,9 @@ const quotePowerShellArgumentList = (values: string[]): string => {
   if (values.length === 0) {
     return "@()";
   }
-  return values.map(quotePowerShellSingleQuoted).join(",");
+  // Wrap in @(...) so Start-Process reliably receives an array literal and
+  // unpacks each element as a separate argument to the spawned process.
+  return `@(${values.map(quotePowerShellSingleQuoted).join(",")})`;
 };
 
 const quotePowerShellSingleQuoted = (value: string): string => {

--- a/App/shell/desktop/tests/packaged-runtime-boundary.test.ts
+++ b/App/shell/desktop/tests/packaged-runtime-boundary.test.ts
@@ -1262,9 +1262,10 @@ describe("desktop packaged runtime boundaries", () => {
     expect(mainSource).toContain("STAGED_APP_PATH");
     expect(mainSource).toContain("function shouldInstallWindowsUpdateInBackground");
     expect(mainSource).toContain("async function installWindowsUpdateInBackground");
-    expect(mainSource).toContain("launch-win-update-${Date.now()}.vbs");
+    expect(mainSource).toContain("launch-win-update-${Date.now()}.cmd");
     expect(mainSource).toContain("install-win-update-${Date.now()}.ps1");
-    expect(mainSource).toContain('const helper = spawn("wscript.exe"');
+    expect(mainSource).toContain('const helper = spawn(process.env.ComSpec ?? "cmd.exe"');
+    expect(mainSource).not.toContain('spawn("wscript.exe"');
     expect(mainSource).toContain('import { createWindowsUpdateLauncherFile } from "./windows-update-launcher.js"');
     expect(mainSource).toContain("await writeFile(launcherPath, createWindowsUpdateLauncherFile([");
     expect(mainSource).toContain("$arguments = @('/S', '--updated', '/currentuser', ('/D=' + $appDir))");
@@ -1278,7 +1279,6 @@ describe("desktop packaged runtime boundaries", () => {
     expect(mainSource).toContain("-WindowStyle Hidden");
     expect(mainSource).not.toContain("powershell.exe -NoProfile -ExecutionPolicy Bypass -Command");
     expect(mainSource).not.toContain("install-win-update-${Date.now()}.cmd");
-    expect(mainSource).not.toContain('spawn(process.env.ComSpec ?? "cmd.exe"');
     expect(mainSource).not.toContain("findstr /R");
     expect(mainSource).not.toContain("for _ in {1..120}");
     expect(mainSource).not.toContain("for /L %%i in (1,1,120)");

--- a/App/shell/desktop/tests/packaged-runtime-boundary.test.ts
+++ b/App/shell/desktop/tests/packaged-runtime-boundary.test.ts
@@ -1264,7 +1264,10 @@ describe("desktop packaged runtime boundaries", () => {
     expect(mainSource).toContain("async function installWindowsUpdateInBackground");
     expect(mainSource).toContain("launch-win-update-${Date.now()}.cmd");
     expect(mainSource).toContain("install-win-update-${Date.now()}.ps1");
-    expect(mainSource).toContain('const helper = spawn(process.env.ComSpec ?? "cmd.exe"');
+    expect(mainSource).toContain("const comSpec = process.env.SystemRoot");
+    expect(mainSource).toContain('join(process.env.SystemRoot, "System32", "cmd.exe")');
+    expect(mainSource).toContain('const helper = spawn(comSpec, ["/D", "/C", launcherPath]');
+    expect(mainSource).not.toContain('spawn(process.env.ComSpec ?? "cmd.exe"');
     expect(mainSource).not.toContain('spawn("wscript.exe"');
     expect(mainSource).toContain('import { createWindowsUpdateLauncherFile } from "./windows-update-launcher.js"');
     expect(mainSource).toContain("await writeFile(launcherPath, createWindowsUpdateLauncherFile([");

--- a/App/shell/desktop/tests/windows-launch-at-login.test.ts
+++ b/App/shell/desktop/tests/windows-launch-at-login.test.ts
@@ -22,18 +22,38 @@ const packagedWindowsEnvironment = {
   systemRootPath: "C:\\Windows"
 } as const;
 
+const vbscriptAvailable = () => true;
+const vbscriptUnavailable = () => false;
+
 describe("Windows launch at login", () => {
-  it("uses the installed launch proxy so login startup follows the normal Windows launch chain", () => {
+  it("uses the installed launch proxy when Windows Script Host is available", () => {
     const launcherPath = "C:\\Users\\Lee User\\AppData\\Local\\Memmy\\launcher\\MemmyLauncher.vbs";
 
-    expect(resolveWindowsLoginItemCommand(packagedWindowsEnvironment, (path) => path === launcherPath)).toEqual({
+    expect(resolveWindowsLoginItemCommand(
+      packagedWindowsEnvironment,
+      (path) => path === launcherPath,
+      vbscriptAvailable
+    )).toEqual({
       path: "C:\\Windows\\System32\\wscript.exe",
       args: [`"${launcherPath}"`]
     });
   });
 
   it("falls back to the packaged executable when the launch proxy is unavailable", () => {
-    expect(resolveWindowsLoginItemCommand(packagedWindowsEnvironment, () => false)).toEqual({
+    expect(resolveWindowsLoginItemCommand(packagedWindowsEnvironment, () => false, vbscriptAvailable)).toEqual({
+      path: packagedWindowsEnvironment.executablePath,
+      args: []
+    });
+  });
+
+  it("falls back to the packaged executable when Windows Script Host is disabled", () => {
+    const launcherPath = "C:\\Users\\Lee User\\AppData\\Local\\Memmy\\launcher\\MemmyLauncher.vbs";
+
+    expect(resolveWindowsLoginItemCommand(
+      packagedWindowsEnvironment,
+      (path) => path === launcherPath,
+      vbscriptUnavailable
+    )).toEqual({
       path: packagedWindowsEnvironment.executablePath,
       args: []
     });
@@ -54,7 +74,7 @@ describe("Windows launch at login", () => {
       setLoginItemSettings: vi.fn()
     };
 
-    expect(getWindowsLaunchAtLogin(application, packagedWindowsEnvironment, () => false)).toBe(true);
+    expect(getWindowsLaunchAtLogin(application, packagedWindowsEnvironment, () => false, vbscriptAvailable)).toBe(true);
     expect(getLoginItemSettings).toHaveBeenCalledWith({
       path: packagedWindowsEnvironment.executablePath,
       args: []
@@ -81,7 +101,12 @@ describe("Windows launch at login", () => {
       setLoginItemSettings: vi.fn()
     };
 
-    expect(getWindowsLaunchAtLogin(application, packagedWindowsEnvironment, (path) => path === launcherPath)).toBe(false);
+    expect(getWindowsLaunchAtLogin(
+      application,
+      packagedWindowsEnvironment,
+      (path) => path === launcherPath,
+      vbscriptAvailable
+    )).toBe(false);
   });
 
   it.each([true, false])("writes and re-reads the effective Windows startup state: %s", (enabled) => {
@@ -100,7 +125,7 @@ describe("Windows launch at login", () => {
       setLoginItemSettings
     };
 
-    expect(setWindowsLaunchAtLogin(application, packagedWindowsEnvironment, enabled, () => false)).toBe(enabled);
+    expect(setWindowsLaunchAtLogin(application, packagedWindowsEnvironment, enabled, () => false, vbscriptAvailable)).toBe(enabled);
     expect(setLoginItemSettings).toHaveBeenCalledWith({
       openAtLogin: enabled,
       enabled,

--- a/App/shell/desktop/tests/windows-update-launcher.test.ts
+++ b/App/shell/desktop/tests/windows-update-launcher.test.ts
@@ -6,8 +6,16 @@ import { setTimeout as delay } from "node:timers/promises";
 import { describe, expect, it } from "vitest";
 import { createWindowsUpdateLauncherFile } from "../src/main/windows-update-launcher.js";
 
+const decodePowerShellEncodedCommand = (script: string): string => {
+  const match = script.match(/-EncodedCommand\s+([A-Za-z0-9+/=]+)/u);
+  if (!match) {
+    throw new Error("EncodedCommand payload not found in launcher script");
+  }
+  return Buffer.from(match[1], "base64").toString("utf16le");
+};
+
 describe("Windows update launcher", () => {
-  it("encodes the VBS launcher as UTF-16LE with BOM without losing Chinese paths or arguments", () => {
+  it("emits a CMD launcher that hands off to PowerShell without Windows Script Host", () => {
     const helperPath = "D:\\测试路径\\Memmy\\data\\Memmy\\updates\\install-win-update.ps1";
     const installerPath = "D:\\测试路径\\Memmy\\data\\Memmy\\updates\\Memmy-1.1.0.exe";
     const appPath = "D:\\测试路径\\Memmy\\Memmy.exe";
@@ -32,28 +40,36 @@ describe("Windows update launcher", () => {
     ];
 
     const launcherFile = createWindowsUpdateLauncherFile(command);
+    const script = launcherFile.toString("utf8");
 
-    expect([...launcherFile.subarray(0, 2)]).toEqual([0xff, 0xfe]);
-    const decoded = launcherFile.toString("utf16le");
-    expect(decoded.startsWith("\uFEFF")).toBe(true);
-    expect(decoded).toContain('Set shell = CreateObject("WScript.Shell")');
-    expect(decoded).toContain('shell.Run """powershell.exe""');
-    expect(decoded).toContain(', 0, False');
-    expect(decoded).toContain('Set fso = CreateObject("Scripting.FileSystemObject")');
-    expect(decoded).toContain("fso.DeleteFile WScript.ScriptFullName, True");
-    for (const argument of command) {
+    expect(script).not.toMatch(/\.vbs\b/u);
+    expect(script).not.toContain("WScript");
+    expect(script).not.toContain("wscript.exe");
+    expect(script.startsWith("@echo off")).toBe(true);
+    expect(script).toContain('WindowsPowerShell\\v1.0\\powershell.exe');
+    expect(script).toContain("-NoProfile");
+    expect(script).toContain("-ExecutionPolicy Bypass");
+    expect(script).toContain("-WindowStyle Hidden");
+    expect(script).toContain("-EncodedCommand");
+    expect(script).toContain('(goto) 2>nul & del "%~f0"');
+
+    const decoded = decodePowerShellEncodedCommand(script);
+    expect(decoded).toContain("Start-Process");
+    expect(decoded).toContain("-FilePath 'powershell.exe'");
+    expect(decoded).toContain("-WindowStyle Hidden");
+    for (const argument of command.slice(1)) {
       expect(decoded).toContain(argument);
     }
   });
 
   it.runIf(process.platform === "win32")(
-    "launches a PowerShell helper from a Chinese path through cscript",
+    "launches a PowerShell helper from a Chinese path without depending on VBScript",
     async () => {
-      const root = await mkdtemp(join(tmpdir(), "memmy-vbs-launcher-"));
+      const root = await mkdtemp(join(tmpdir(), "memmy-cmd-launcher-"));
       const chineseRoot = join(root, "中文路径");
       const helperPath = join(chineseRoot, "probe.ps1");
       const markerPath = join(chineseRoot, "marker.txt");
-      const launcherPath = join(root, "launcher.vbs");
+      const launcherPath = join(root, "launcher.cmd");
       try {
         await mkdir(chineseRoot, { recursive: true });
         await writeFile(
@@ -73,8 +89,8 @@ describe("Windows update launcher", () => {
           markerPath
         ]));
 
-        const cscriptPath = join(process.env.SystemRoot ?? "C:\\Windows", "System32", "cscript.exe");
-        const result = spawnSync(cscriptPath, ["//B", "//Nologo", launcherPath], { encoding: "utf8" });
+        const cmdPath = process.env.ComSpec ?? join(process.env.SystemRoot ?? "C:\\Windows", "System32", "cmd.exe");
+        const result = spawnSync(cmdPath, ["/D", "/C", launcherPath], { encoding: "utf8" });
         expect(result.error).toBeUndefined();
         expect(result.status).toBe(0);
 

--- a/App/shell/desktop/tests/windows-update-launcher.test.ts
+++ b/App/shell/desktop/tests/windows-update-launcher.test.ts
@@ -57,6 +57,9 @@ describe("Windows update launcher", () => {
     expect(decoded).toContain("Start-Process");
     expect(decoded).toContain("-FilePath 'powershell.exe'");
     expect(decoded).toContain("-WindowStyle Hidden");
+    // -ArgumentList must be an explicit PowerShell array literal so Start-Process
+    // unpacks each element as a separate argument, not one concatenated string.
+    expect(decoded).toMatch(/-ArgumentList @\('/u);
     for (const argument of command.slice(1)) {
       expect(decoded).toContain(argument);
     }


### PR DESCRIPTION
## Description

The task submission tool is not available in this session. I've completed the fix work and pushed the branch. Here is the summary:

## Summary

**Issue #378** — Windows Script Host error `There is no script engine for file extension '.vbs'` on Memmy launch after an update.

**Root cause**: Memmy's Windows update helper wrote a temporary `.vbs` launcher and spawned it via `wscript.exe` to relaunch the app after the installer completed. On systems where the VBScript engine has been disabled (Windows Feature removed, GPO block, or a Windows update that unregistered the `.vbs` handler), this pops up the WSH error dialog. The login‑at‑login item and Start‑menu shortcut also invoke `wscript.exe MemmyLauncher.vbs` and would fail the same way.

**Fix** (branch `bugfix/autodev-378-20260908054258383`, commit `1a7bb01`):

1. **`App/shell/desktop/src/main/windows-update-launcher.ts`** — rewritten to emit a self‑deleting `.cmd` batch that invokes PowerShell with `-EncodedCommand` (UTF‑16 base64), preserving localized (Chinese) install paths while eliminating the VBScript dependency entirely.
2. **`App/shell/desktop/src/main/main.ts`** — updated the update helper to name the launcher `launch-win-update-<ts>.cmd` and spawn it through `cmd.exe /D /C` instead of `wscript.exe`.
3. **`App/shell/desktop/src/main/windows-launch-at-login.ts`** — added a memoized VBScript‑availability probe (`cscript.exe //B //Nologo //T:5` on a temp no‑op script). When VBScript is unavailable the login item falls back to the packaged executable so the user's next sign‑in is silent.
4. **Tests** — updated `windows-update-launcher.test.ts`, `windows-launch-at-login.test.ts`, and the `packaged-runtime-boundary.test.ts` guard assertions to cover the new `.cmd`/PowerShell entry point and the WSH‑disabled fallback; on‑Windows smoke test now drives `cmd.exe` instead of `cscript`.

**Tests**: `vitest run tests/windows-update-launcher.test.ts tests/windows-launch-at-login.test.ts` → 10 passed, 1 skipped (Windows‑only). `packaged-runtime-boundary.test.ts` → 67 pass; 2 pre‑existing unrelated failures caused by missing `app-builder-lib` template file in this CI env (nothing my patch touched).

- Branch: `bugfix/autodev-378-20260908054258383`
- Commit: `1a7bb01f182871e07b2241672d0d7b9c4e715aa3`
- Push status: pushed to `origin`
- Reviewer: @bittergreen

Note: I was unable to call `mcp__task__submit_result` — the tool is not exposed in this session's toolset — so this text is the completion report. Scheduler can create the PR from the branch above.

Related Issue (Required):  Fixes #378

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] Documentation update

## How Has This Been Tested?

Automated tests are pending.

- [ ] Unit Test
- [ ] Test Script Or Test Steps (please provide)
- [ ] Pipeline Automated API Test (please provide)

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have created related documentation issue/PR in [MemOS-Docs](https://github.com/MemTensor/MemOS-Docs) (if applicable)
- [x] I have linked the issue to this PR (if applicable)
- [x] I have mentioned the person who will review this PR

@bittergreen please review this PR.

## Reviewer Checklist
- [x] closes #378
- [ ] Made sure Checks passed
- [ ] Tests have been provided
