### PR TITLE
fix(scan): keep one agent-source turn as one memory

### DIFF
--- a/AgentSourceCore/src/index.test.ts
+++ b/AgentSourceCore/src/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { conversationContentHash, estimateTokens, orderedTurns, splitTurn, type ConversationMessage } from "./index.js";
+import { TURN_CONTENT_MAX_BYTES, conversationContentHash, orderedTurns, renderTurnClipped, type ConversationMessage } from "./index.js";
 
 const message = (id: string, role: ConversationMessage["role"], content: string, createdAt: string): ConversationMessage => ({
   messageId: id, sourceId: "fixture", conversationId: "conversation", role, content, createdAt,
@@ -21,38 +21,28 @@ describe("agent source core", () => {
     expect(turns.map((turn) => turn.messages[0]?.messageId)).toEqual(["u1", "u2"]);
   });
 
-  it("splits oversized content with unique part hashes", () => {
+  it("keeps one turn as one memory instead of splitting it", () => {
     const turn = { sourceId: "fixture", conversationId: "conversation", turnIndex: 0, messages: [message("u", "user", "x".repeat(30_000), "2026-01-01T00:00:00Z"), message("a", "assistant", "ok", "2026-01-01T00:00:01Z")] };
-    const parts = splitTurn(turn, 4000, 1_000_000);
-    expect(parts.length).toBeGreaterThan(1);
-    expect(new Set(parts.map((part) => part.contentHash)).size).toBe(parts.length);
-    expect(parts.every((part) => Buffer.byteLength(part.content) <= 1_000_000)).toBe(true);
+    const content = renderTurnClipped(turn.messages);
+    expect(content).toContain("x".repeat(30_000));
+    expect(content).toContain("## assistant");
+    expect(content).not.toContain("truncated");
     expect(conversationContentHash(turn.messages)).toHaveLength(64);
   });
 
-  it("does not re-emit flushed text when splitting multi-line content", () => {
-    const lines = Array.from({ length: 350 }, (_, index) => `line ${index} ${"y".repeat(40)}`);
-    const content = lines.join("\n");
-    const turn = { sourceId: "fixture", conversationId: "conversation", turnIndex: 0, messages: [message("u", "user", content, "2026-01-01T00:00:00Z"), message("a", "assistant", "ok", "2026-01-01T00:00:01Z")] };
-    const parts = splitTurn(turn, 4000, 1_000_000);
-    const emitted = parts.reduce((total, part) => total + part.content.length, 0);
-    expect(emitted).toBeLessThan(content.length * 2);
-    for (const line of lines) expect(parts.filter((part) => part.content.includes(line))).toHaveLength(1);
+  it("clips an oversized turn on a UTF-8 boundary rather than fanning it out", () => {
+    const messages = [message("u", "user", "问题", "2026-01-01T00:00:00Z")];
+    for (let index = 0; index < 200; index += 1) {
+      messages.push(message(`t${index}`, "tool", Array.from({ length: 200 }, () => "汉字测试").join("\n\n"), "2026-01-01T00:00:01Z"));
+    }
+    const content = renderTurnClipped(messages, 4096);
+    expect(Buffer.byteLength(content)).toBeLessThanOrEqual(4096);
+    expect(content).toMatch(/\[\.\.\. truncated \d+ bytes of tool output \.\.\.\]$/u);
+    expect(content.startsWith("## user\n\n问题")).toBe(true);
   });
 
-  it("keeps every multi-line part within the token budget", () => {
-    const content = Array.from({ length: 350 }, (_, index) => `line ${index} ${"y".repeat(40)}`).join("\n");
-    const turn = { sourceId: "fixture", conversationId: "conversation", turnIndex: 0, messages: [message("u", "user", content, "2026-01-01T00:00:00Z"), message("a", "assistant", "ok", "2026-01-01T00:00:01Z")] };
-    const parts = splitTurn(turn, 4000, 1_000_000);
-    expect(parts.every((part) => estimateTokens(part.content) <= 4000)).toBe(true);
-  });
-
-  it("splits multibyte content on byte boundaries without losing characters", () => {
-    const content = Array.from({ length: 200 }, () => "汉字测试").join("\n");
-    const turn = { sourceId: "fixture", conversationId: "conversation", turnIndex: 0, messages: [message("u", "user", content, "2026-01-01T00:00:00Z"), message("a", "assistant", "ok", "2026-01-01T00:00:01Z")] };
-    const parts = splitTurn(turn, 1_000_000, 512);
-    expect(parts.every((part) => Buffer.byteLength(part.content) <= 512)).toBe(true);
-    const emitted = parts.reduce((total, part) => total + (part.content.match(/汉/gu) ?? []).length, 0);
-    expect(emitted).toBe(200);
+  it("leaves the turn untouched when it already fits the byte budget", () => {
+    const messages = [message("u", "user", "hello", "2026-01-01T00:00:00Z"), message("a", "assistant", "world", "2026-01-01T00:00:01Z")];
+    expect(renderTurnClipped(messages, TURN_CONTENT_MAX_BYTES)).toBe("## user\n\nhello\n\n## assistant\n\nworld");
   });
 });

--- a/AgentSourceCore/src/index.ts
+++ b/AgentSourceCore/src/index.ts
@@ -137,14 +137,6 @@ export interface ImportedTurn {
   messages: ConversationMessage[];
 }
 
-export interface TurnPart extends ImportedTurn {
-  parentTurnId: string;
-  partIndex: number;
-  partCount: number;
-  content: string;
-  contentHash: string;
-}
-
 export function compareMessageOrder(left: ConversationMessage, right: ConversationMessage): number {
   return left.conversationId.localeCompare(right.conversationId)
     || Date.parse(left.createdAt) - Date.parse(right.createdAt)
@@ -237,154 +229,35 @@ export function legacyTurnId(turn: ImportedTurn): string {
   return `${turn.sourceId}:${createHash("sha256").update(stableTurnIdentity(turn)).digest("hex").slice(0, 24)}`;
 }
 
-export function splitTurn(turn: ImportedTurn, maxTokens = 4000, maxBytes = 1024 * 1024): TurnPart[] {
-  const chunks: ConversationMessage[][] = [];
-  let current: ConversationMessage[] = [];
-  const fits = (candidate: readonly ConversationMessage[]) => {
-    const content = renderTurn(candidate);
-    return estimateTokens(content) <= maxTokens && Buffer.byteLength(content) <= maxBytes;
-  };
-  for (const message of turn.messages) {
-    if (fits([...current, message])) {
-      current.push(message);
-      continue;
-    }
-    if (current.length > 0) { chunks.push(current); current = []; }
-    const pieces = splitMessage(message, maxTokens, maxBytes);
-    if (current.length === 0 && chunks.length > 0) {
-      // A user prefix followed by an oversized assistant/tool message should
-      // remain one logical part whenever the prefix can share any content.
-      const previous = chunks[chunks.length - 1];
-      if (previous && !isCompleteTurn(previous)) {
-        const combined = combinePrefix(previous, pieces[0]!, maxTokens, maxBytes);
-        if (combined) {
-          chunks[chunks.length - 1] = combined.messages;
-          if (combined.remainder) chunks.push(...splitMessage(combined.remainder, maxTokens, maxBytes).map((piece) => [piece]));
-          for (const piece of pieces.slice(1)) chunks.push([piece]);
-          continue;
-        }
-      }
-    }
-    for (const piece of pieces) chunks.push([piece]);
-  }
-  if (current.length > 0) chunks.push(current);
-  if (chunks.length === 0) chunks.push([...turn.messages]);
-  const parentTurnId = createHash("sha256").update(stableTurnIdentity(turn)).digest("hex").slice(0, 24);
-  return chunks.map((messages, partIndex) => {
-    const content = renderTurn(messages);
-    return {
-      ...turn,
-      messages,
-      parentTurnId,
-      partIndex,
-      partCount: chunks.length,
-      content,
-      contentHash: createHash("sha256").update(content).digest("hex")
-    };
-  });
+/** Leaves ample room for JSON escaping and the add-memory envelope. */
+export const TURN_CONTENT_MAX_BYTES = 512 * 1024;
+
+/**
+ * Renders a whole turn as one memory body. Agent-source scans deliberately keep
+ * one turn == one memory: splitting an agentic turn fans a single exchange out
+ * into hundreds of near-empty tool-call fragments. Oversized turns are clipped
+ * on a UTF-8 boundary instead so the add-memory request stays under the wire
+ * limit without inventing extra memories.
+ */
+export function renderTurnClipped(messages: readonly ConversationMessage[], maxBytes = TURN_CONTENT_MAX_BYTES): string {
+  const content = renderTurn(messages);
+  const bytes = Buffer.byteLength(content);
+  if (bytes <= maxBytes) return content;
+  const marker = `\n\n[... truncated ${bytes - maxBytes} bytes of tool output ...]`;
+  const budget = Math.max(0, maxBytes - Buffer.byteLength(marker));
+  return `${clipUtf8(content, budget)}${marker}`;
 }
 
-function combinePrefix(
-  prefix: readonly ConversationMessage[],
-  piece: ConversationMessage,
-  maxTokens: number,
-  maxBytes: number
-): { messages: ConversationMessage[]; remainder?: ConversationMessage } | null {
-  const fits = (content: string) => {
-    const candidate = [...prefix, { ...piece, content }];
-    const rendered = renderTurn(candidate);
-    return estimateTokens(rendered) <= maxTokens && Buffer.byteLength(rendered) <= maxBytes;
-  };
-  if (fits(piece.content)) return { messages: [...prefix, piece] };
-  const characters = Array.from(piece.content);
-  let low = 0;
-  let high = characters.length;
-  let best = 0;
-  while (low <= high) {
-    const middle = Math.floor((low + high) / 2);
-    if (fits(characters.slice(0, middle).join(""))) {
-      best = middle;
-      low = middle + 1;
-    } else {
-      high = middle - 1;
-    }
-  }
-  if (best === 0) return null;
-  const content = characters.slice(0, best).join("");
-  const remainder = characters.slice(best).join("");
-  return {
-    messages: [...prefix, { ...piece, content }],
-    ...(remainder ? { remainder: { ...piece, content: remainder } } : {})
-  };
-}
-
-function splitMessage(message: ConversationMessage, maxTokens: number, maxBytes: number): ConversationMessage[] {
-  const emptyRendered = renderTurn([{ ...message, content: "" }]);
-  const bodyTokenLimit = Math.max(1, maxTokens - estimateTokens(emptyRendered));
-  const bodyByteLimit = Math.max(1, maxBytes - Buffer.byteLength(emptyRendered));
-  const fitsContent = (content: string) => {
-    const rendered = renderTurn([{ ...message, content }]);
-    return estimateTokens(rendered) <= maxTokens && Buffer.byteLength(rendered) <= maxBytes;
-  };
-  if (fitsContent(message.content)) return [message];
-  const pieces: string[] = [];
-  for (const paragraph of message.content.split(/\n\s*\n/)) {
-    if (!paragraph) continue;
-    if (paragraph && estimateTokens(paragraph) <= bodyTokenLimit && Buffer.byteLength(paragraph) <= bodyByteLimit && fitsContent(paragraph)) {
-      pieces.push(paragraph);
-    } else {
-      pieces.push(...splitText(paragraph, bodyTokenLimit, bodyByteLimit));
-    }
-  }
-  return (pieces.length > 0 ? pieces : [""]).map((content) => ({ ...message, content }));
-}
-
-function splitText(value: string, maxTokens: number, maxBytes: number): string[] {
-  const maxChars = Math.max(1, maxTokens * 4);
-  const chunks: string[] = [];
-  let current = "";
-  for (const line of value.split(/\r?\n/u)) {
-    const candidate = current ? `${current}\n${line}` : line;
-    if (current && (estimateTokens(candidate) > maxTokens || Buffer.byteLength(candidate) > maxBytes)) {
-      chunks.push(...splitUtf8(current, maxBytes));
-      current = "";
-    }
-    if (line.length > maxChars || Buffer.byteLength(line) > maxBytes) {
-      if (current) { chunks.push(...splitUtf8(current, maxBytes)); current = ""; }
-      let part = "";
-      for (const character of line) {
-        if (part && (part.length >= maxChars || Buffer.byteLength(part + character) > maxBytes)) {
-          chunks.push(part);
-          part = "";
-        }
-        part += character;
-      }
-      if (part) chunks.push(part);
-    } else {
-      current = current ? candidate : line;
-    }
-  }
-  if (current) chunks.push(...splitUtf8(current, maxBytes));
-  return chunks.length > 0 ? chunks : [""];
-}
-
-function splitUtf8(value: string, maxBytes: number): string[] {
-  const parts: string[] = [];
-  let current = "";
-  let currentBytes = 0;
+function clipUtf8(value: string, maxBytes: number): string {
+  let bytes = 0;
+  let end = 0;
   for (const character of value) {
     const characterBytes = Buffer.byteLength(character);
-    if (current && currentBytes + characterBytes > maxBytes) {
-      parts.push(current);
-      current = character;
-      currentBytes = characterBytes;
-    } else {
-      current += character;
-      currentBytes += characterBytes;
-    }
+    if (bytes + characterBytes > maxBytes) break;
+    bytes += characterBytes;
+    end += character.length;
   }
-  if (current) parts.push(current);
-  return parts.length > 0 ? parts : [""];
+  return value.slice(0, end);
 }
 
 export function estimateTokens(value: string): number { return Math.ceil(value.length / 4); }

--- a/App/backend/src/services/agent-source-service.ts
+++ b/App/backend/src/services/agent-source-service.ts
@@ -46,7 +46,7 @@ import {
 } from "./managed-agent-history.js";
 import {
   orderedTurns,
-  splitTurn,
+  renderTurnClipped,
   stableTurnIdentity,
   isCompleteTurn,
   legacyTurnId,
@@ -860,52 +860,45 @@ async function ingestPersistentSource(
     const selectedTurn = store.getTurnMeta(sourceId, turn.conversationId, stableTurnIdentity(turn));
     if (selectedTurn && !selectedTurn.selected) continue;
     let turnSucceeded = true;
-    // Leave ample room for JSON escaping and the add-memory envelope while
-    // keeping every request below the 1 MiB wire limit.
-    const parts = splitTurn(turn, 4000, 512 * 1024);
-    for (const part of parts) {
-      const contentHash = createHash("sha256").update(part.content).digest("hex");
-      const requestId = parts.length === 1
-        ? legacyTurnRequestId(turn)
-        : createHash("sha256").update([stableTurnIdentity(turn), String(part.partIndex), contentHash].join("\u0000")).digest("hex");
-      const turnId = parts.length === 1 ? legacyTurnId(turn) : `${sourceId}:${part.parentTurnId}:${part.partIndex}`;
-      try {
-        const added = await options.memoryClient.addMemory({
-          requestId,
-          adapterId: `agent-source:${sourceId}`,
-          content: part.content,
-          layer: "L1",
-          title: firstTurnLine(part.messages) ?? `${sourceId} conversation`,
-          tags: ["agent-source", sourceId],
-          source: sourceId,
-          turnId,
-          createdAt: part.messages[0]!.createdAt,
-          deferProcessing: true
-        });
-        if (added.duplicate) deduped += part.messages.length;
-        else {
-          memoryIdCount += 1;
-          if (memoryIds.length < 1000) memoryIds.push(added.id);
-          pendingIds.push(added.id);
-          if (pendingIds.length >= IMPORT_PROCESSING_COHORT_SIZE) {
-            const cohort = pendingIds.splice(0, pendingIds.length);
-            const failures = await processPendingImportSummaries(options, cohort, { ...scanOptions, progressSourceId: sourceId });
-            if (failures.length > 0) activeConversationFailed = true;
-            const mapped = failures.map((failure) => ({ conversationId: failure.memoryId, reason: failure.reason }));
-            errorCount += mapped.length;
-            errors.push(...mapped.slice(0, Math.max(0, 1000 - errors.length)));
-            for (const failure of failures) store.saveResult({ sourceId, conversationId: failure.memoryId, error: failure.reason });
-          }
+    // One turn is one memory. Splitting an agentic turn fans a single exchange
+    // out into hundreds of near-empty tool-call fragments, so an oversized turn
+    // is clipped to the wire budget instead of being fanned out.
+    try {
+      const added = await options.memoryClient.addMemory({
+        requestId: legacyTurnRequestId(turn),
+        adapterId: `agent-source:${sourceId}`,
+        content: renderTurnClipped(turn.messages),
+        layer: "L1",
+        title: firstTurnLine(turn.messages) ?? `${sourceId} conversation`,
+        tags: ["agent-source", sourceId],
+        source: sourceId,
+        turnId: legacyTurnId(turn),
+        createdAt: turn.messages[0]!.createdAt,
+        deferProcessing: true
+      });
+      if (added.duplicate) deduped += turn.messages.length;
+      else {
+        memoryIdCount += 1;
+        if (memoryIds.length < 1000) memoryIds.push(added.id);
+        pendingIds.push(added.id);
+        if (pendingIds.length >= IMPORT_PROCESSING_COHORT_SIZE) {
+          const cohort = pendingIds.splice(0, pendingIds.length);
+          const failures = await processPendingImportSummaries(options, cohort, { ...scanOptions, progressSourceId: sourceId });
+          if (failures.length > 0) activeConversationFailed = true;
+          const mapped = failures.map((failure) => ({ conversationId: failure.memoryId, reason: failure.reason }));
+          errorCount += mapped.length;
+          errors.push(...mapped.slice(0, Math.max(0, 1000 - errors.length)));
+          for (const failure of failures) store.saveResult({ sourceId, conversationId: failure.memoryId, error: failure.reason });
         }
-        store.saveResult({ sourceId, conversationId: turn.conversationId, memoryId: added.id });
-      } catch (error) {
-        turnSucceeded = false;
-        activeConversationFailed = true;
-        const reason = error instanceof Error ? error.message : "Agent source ingestion failed";
-        errorCount += 1;
-        if (errors.length < 1000) errors.push({ conversationId: turn.conversationId, reason });
-        store.saveResult({ sourceId, conversationId: turn.conversationId, error: reason });
       }
+      store.saveResult({ sourceId, conversationId: turn.conversationId, memoryId: added.id });
+    } catch (error) {
+      turnSucceeded = false;
+      activeConversationFailed = true;
+      const reason = error instanceof Error ? error.message : "Agent source ingestion failed";
+      errorCount += 1;
+      if (errors.length < 1000) errors.push({ conversationId: turn.conversationId, reason });
+      store.saveResult({ sourceId, conversationId: turn.conversationId, error: reason });
     }
     if (!turnSucceeded) activeConversationFailed = true;
     emitProgress(scanOptions, { sourceId, phase: "add", current: memoryIds.length + deduped, total: store.count(sourceId), message: "Adding raw memories" });

--- a/Memory/src/agent-source/runtime.ts
+++ b/Memory/src/agent-source/runtime.ts
@@ -34,7 +34,7 @@ import type { ConversationMessage, ScanProgress, SourceAdapter } from "./adapter
 import {
   isCompleteTurn,
   orderedTurns,
-  splitTurn,
+  renderTurnClipped,
   stableTurnIdentity,
   legacyTurnId,
   legacyTurnRequestId,
@@ -785,30 +785,25 @@ async function ingestStagedMessages(
     const selectedTurn = store.getTurnMeta(sourceId, turn.conversationId, stableTurnIdentity(turn));
     if (selectedTurn && !selectedTurn.selected) continue;
     let succeeded = true;
-    // Leave ample room for JSON escaping and the add-memory envelope while
-    // keeping every request below the 1 MiB wire limit.
-    const parts = splitTurn(turn, 4000, 512 * 1024);
-    for (const part of parts) {
-      const requestId = parts.length === 1
-        ? legacyTurnRequestId(turn)
-        : createHash("sha256").update([stableTurnIdentity(turn), String(part.partIndex), part.contentHash].join("\u0000")).digest("hex");
-      const turnId = parts.length === 1 ? legacyTurnId(turn) : `${sourceId}:${part.parentTurnId}:${part.partIndex}`;
-      try {
-        const added = service.addMemory({
-          requestId, adapterId: `agent-source:${sourceId}`, content: part.content, layer: "L1",
-          title: titleForTurn(sourceId, part.messages), tags: ["agent-source", sourceId], source: sourceId,
-          turnId, createdAt: part.messages[0]!.createdAt, deferProcessing: true
-        });
-        if (added.duplicate) store.saveResult({ sourceId, conversationId: turn.conversationId, memoryId: added.id });
-        else { store.saveResult({ sourceId, conversationId: turn.conversationId, memoryId: added.id }); memoryIds.push(added.id); written += 1; }
-      } catch (error) {
-        succeeded = false;
-        activeConversationFailed = true;
-        const reason = error instanceof Error ? error.message : String(error);
-        errorCount += 1;
-        if (errors.length < 1000) errors.push(`${turn.conversationId}: ${reason}`);
-        store.saveResult({ sourceId, conversationId: turn.conversationId, error: reason });
-      }
+    // One turn is one memory. Splitting an agentic turn fans a single exchange
+    // out into hundreds of near-empty tool-call fragments, so an oversized turn
+    // is clipped to the wire budget instead of being fanned out.
+    try {
+      const added = service.addMemory({
+        requestId: legacyTurnRequestId(turn), adapterId: `agent-source:${sourceId}`,
+        content: renderTurnClipped(turn.messages), layer: "L1",
+        title: titleForTurn(sourceId, turn.messages), tags: ["agent-source", sourceId], source: sourceId,
+        turnId: legacyTurnId(turn), createdAt: turn.messages[0]!.createdAt, deferProcessing: true
+      });
+      store.saveResult({ sourceId, conversationId: turn.conversationId, memoryId: added.id });
+      if (!added.duplicate) { memoryIds.push(added.id); written += 1; }
+    } catch (error) {
+      succeeded = false;
+      activeConversationFailed = true;
+      const reason = error instanceof Error ? error.message : String(error);
+      errorCount += 1;
+      if (errors.length < 1000) errors.push(`${turn.conversationId}: ${reason}`);
+      store.saveResult({ sourceId, conversationId: turn.conversationId, error: reason });
     }
     if (succeeded) {
       messageCount += turn.messages.length;

--- a/scripts/internal/mac/build-dmg.sh
+++ b/scripts/internal/mac/build-dmg.sh
@@ -347,6 +347,18 @@ const memoryPackage = JSON.parse(await readFile(join(memoryDir, "package.json"),
 const runtimeVersion = memoryPackage.version;
 const rootLock = JSON.parse(await readFile(join(rootDir, "package-lock.json"), "utf8"));
 const dependencies = { ...(memoryPackage.dependencies ?? {}) };
+const workspacePackageDirs = new Map();
+for (const [packageKey, packageInfo] of Object.entries(rootLock.packages ?? {})) {
+  if (packageKey && !packageKey.startsWith("node_modules/") && packageInfo.name) {
+    workspacePackageDirs.set(packageInfo.name, packageKey);
+  }
+}
+for (const dependencyName of Object.keys(dependencies)) {
+  const workspaceDir = workspacePackageDirs.get(dependencyName);
+  if (workspaceDir) {
+    dependencies[dependencyName] = `file:../../../../../../${workspaceDir}`;
+  }
+}
 const runtimePackage = {
   name: runtimeName,
   version: runtimeVersion,
@@ -410,6 +422,9 @@ function addPackage(packageKey) {
   const packageInfo = sourcePackages[packageKey];
   if (!packageInfo) {
     throw new Error(`Missing package-lock entry for ${packageKey}`);
+  }
+  if (packageInfo.link) {
+    return;
   }
 
   selectedPackageKeys.add(packageKey);
@@ -804,6 +819,11 @@ mkdir -p "$MIGRATIONS_STAGING_DIR"
 cp "$MIGRATIONS_DIR/package.json" "$MIGRATIONS_STAGING_DIR/package.json"
 cp -R "$MIGRATIONS_DIR/dist" "$MIGRATIONS_STAGING_DIR/dist"
 mkdir -p "$RUNTIME_DIR/memory/dist"
+if [ -d "$ROOT_DIR/AgentSourceCore/dist/src" ]; then
+  mkdir -p "$RUNTIME_DIR/memory/AgentSourceCore/dist/src"
+  cp -R "$ROOT_DIR/AgentSourceCore/dist/src/." "$RUNTIME_DIR/memory/AgentSourceCore/dist/src/"
+  cp "$ROOT_DIR/AgentSourceCore/package.json" "$RUNTIME_DIR/memory/AgentSourceCore/package.json"
+fi
 cp -R "$MEMORY_DIR/dist/src" "$RUNTIME_DIR/memory/dist/src"
 cp -R "$MEMORY_DIR/dist/viewer" "$RUNTIME_DIR/memory/dist/viewer"
 cp -R "$MEMORY_DIR/adapters" "$RUNTIME_DIR/memory/adapters"
@@ -811,9 +831,9 @@ cp -R "$AGENT_DIR/dist" "$RUNTIME_DIR/memmy-agent/dist"
 package_step_start "Create Memory runtime manifest"
 create_memory_runtime_manifest "$RUNTIME_DIR/memory"
 package_step_start "Resolve Memory runtime lockfile"
-npm install --prefix "$RUNTIME_DIR/memory" --package-lock-only --ignore-scripts --os=darwin --cpu="$TARGET_CPU"
+npm install --prefix "$RUNTIME_DIR/memory" --package-lock-only --ignore-scripts --install-links --os=darwin --cpu="$TARGET_CPU"
 package_step_start "Install Memory runtime production dependencies"
-npm ci --prefix "$RUNTIME_DIR/memory" --omit=dev --os=darwin --cpu="$TARGET_CPU"
+npm ci --prefix "$RUNTIME_DIR/memory" --omit=dev --install-links --os=darwin --cpu="$TARGET_CPU"
 package_step_start "Rebuild Memory native modules for Electron"
 ELECTRON_VERSION="$(node -p "require('./App/shell/desktop/node_modules/electron/package.json').version")"
 node_modules/.bin/electron-rebuild \


### PR DESCRIPTION
splitTurn cut a turn on every blank line without repacking, so a single agentic turn fanned out into hundreds of near-empty tool-call fragments (one observed turn produced 640 parts, 639 of them a 67-character "Tool calls: - tool_1"). A codex scan of 1,000 selected turns wrote 19,413 memories.

Restore one turn == one memory. Oversized turns are now clipped on a UTF-8 boundary via renderTurnClipped so the add-memory request stays under the wire limit instead of inventing extra memories. Both ingest call sites (memory runtime and desktop backend) use the same helper and keep the pre-split legacyTurnRequestId / legacyTurnId idempotency keys, so watermarks and dedup stay aligned with pre-4eea5f52 memories.

Also bundles AgentSourceCore/dist into the packaged memory runtime and rewrites workspace deps to file: with --install-links, so the packaged runtime can resolve @memmy/agent-source-core.