### PR TITLE
fix(memory): render world model detail markdown

### DIFF
--- a/App/frontend/desktop/src/pages/memory/tests/world-model-sub-page.test.tsx
+++ b/App/frontend/desktop/src/pages/memory/tests/world-model-sub-page.test.tsx
@@ -78,7 +78,7 @@ const worldDetailV2: GetMemoryOutput = {
       summary: "项目场域摘要",
       generalRulesAndSafetyConstraints: null,
       projectEnvironmentProfile: "语言：TypeScript\n测试入口：npm test",
-      projectContract: "修改后必须运行测试。",
+      projectContract: "## 提交要求\n- 修改后必须运行 `npm test`。",
       domainKnowledge: "Alpine 使用 musl libc。"
     }
   },
@@ -256,7 +256,10 @@ describe("WorldModelSubPage", () => {
     expect(html).toContain("项目环境画像");
     expect(html).toContain("语言：TypeScript");
     expect(html).toContain("项目契约");
-    expect(html).toContain("修改后必须运行测试。");
+    expect(html).toContain("修改后必须运行");
+    expect(html).toContain('<h4 class="memory-markdown__heading">提交要求</h4>');
+    expect(html).toContain('<ul class="memory-markdown__list">');
+    expect(html).toContain('<code class="memory-markdown__code">npm test</code>');
     expect(html).toContain("领域知识");
     expect(html).toContain("Alpine 使用 musl libc。");
     expect(html).not.toContain("通用规则与安全约束");

--- a/App/frontend/desktop/src/pages/memory/world-model-sub-page.tsx
+++ b/App/frontend/desktop/src/pages/memory/world-model-sub-page.tsx
@@ -22,6 +22,7 @@ import { MemoryDrawerDeleteAction } from "./memory-delete-action.js";
 import { toMemoryDetailErrorMessage } from "./memory-detail-error.js";
 import { cleanMemoryBody, cleanMemoryText, drawerEyebrow } from "./memory-display.js";
 import { displayMemoryId } from "./memory-id.js";
+import { MemoryMarkdown } from "./memory-markdown.js";
 import {
   MemoryReferenceTags,
   type MemoryReferenceOpenRequest,
@@ -453,7 +454,9 @@ function DetailTextSection(props: { title: string; body?: string }) {
   return (
     <section className="memory-detail-card">
       <h5 className="memory-detail-card__label">{props.title}</h5>
-      <div className="memory-policy-section-body">{cleanMemoryBody(props.body) || "-"}</div>
+      <div className="memory-policy-section-body">
+        <MemoryMarkdown text={cleanMemoryBody(props.body) || "-"} />
+      </div>
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- render world model detail text with the existing safe Markdown component
- cover legacy body/summary and v2 world model fields through the shared detail section
- add regression coverage for headings, lists, and inline code

## Validation
- `npm test -w @memmy/frontend-desktop -- src/pages/memory/tests/world-model-sub-page.test.tsx` (9/9 passed)
- `npm run typecheck -w @memmy/frontend-desktop`
- `npm run build -w @memmy/frontend-desktop`
- `git diff --check`
- manually verified in the running desktop UI with an L3 Markdown record