### PR TITLE
fix(desktop): avoid Windows environment toolbar overlap

### DIFF
--- a/App/frontend/desktop/src/pages/app-frame.tsx
+++ b/App/frontend/desktop/src/pages/app-frame.tsx
@@ -75,6 +75,7 @@ export interface AppFrameProps {
   reserveTopBar?: boolean;
   topBar?: ReactNode;
   topBarBorder?: boolean;
+  windowsTitlebarSafe?: boolean;
   /** When set, replaces the main app sidebar with settings section navigation. */
   settingsNav?: SettingsSidebarNav;
   children: ReactNode;
@@ -1569,7 +1570,7 @@ export function AppFrame(props: AppFrameProps) {
         onResizeBy={sidebarResize.resizeBy}
       />
 
-      <main className={`relative min-w-0 flex-1 overflow-hidden flex flex-col bg-content-bg${sidebarHidden ? " app-frame-main--sidebar-hidden" : ""}`} aria-label={props.title}>
+      <main className={`app-frame-main relative min-w-0 flex-1 overflow-hidden flex flex-col bg-content-bg${sidebarHidden ? " app-frame-main--sidebar-hidden" : ""}${props.windowsTitlebarSafe ? " app-frame-main--windows-titlebar-safe" : ""}`} aria-label={props.title}>
         {props.reserveTopBar !== false && (
           <header className={`app-frame-content-topbar${props.topBarBorder ? " app-frame-content-topbar--bordered" : ""}`}>
             {props.topBar}
@@ -1580,7 +1581,7 @@ export function AppFrame(props: AppFrameProps) {
           className={`min-h-0 h-full flex-1 overflow-hidden${
             sidebarHidden && !props.topBarBorder ? " app-frame-content-body--sidebar-hidden" : ""
           }`}
-          style={props.topBarBorder ? { paddingTop: "var(--codex-toolbar-height)" } : undefined}
+          style={props.topBarBorder ? { paddingTop: "calc(var(--codex-toolbar-height) + var(--app-frame-topbar-offset, 0px))" } : undefined}
         >
           {props.children}
         </div>

--- a/App/frontend/desktop/src/pages/home-page.tsx
+++ b/App/frontend/desktop/src/pages/home-page.tsx
@@ -2658,6 +2658,7 @@ export function HomePage() {
         </div>
       ) : null}
       topBarBorder={Boolean(hasActiveConversation || environmentScope)}
+      windowsTitlebarSafe={Boolean(hasActiveConversation || environmentScope)}
     >
       <div className={`agent-workspace-layout${environmentPanelOpen ? " agent-workspace-layout--environment-open" : ""}`}>
         {!hasActiveConversation ? (

--- a/App/frontend/desktop/src/pages/tests/home-environment-titlebar.interaction.test.tsx
+++ b/App/frontend/desktop/src/pages/tests/home-environment-titlebar.interaction.test.tsx
@@ -1,0 +1,146 @@
+// @vitest-environment happy-dom
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { act, useEffect } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AgentRuntimeBridge } from "../../app/agent-runtime-bridge.js";
+import { AppProviders } from "../../app/providers.js";
+import { agentActions } from "../../state/app-actions.js";
+import { useAppState } from "../../state/app-state.js";
+import { applyWindowFullScreenClass, applyWindowPlatformClass } from "../../utils/window-fullscreen.js";
+import { HomePage } from "../home-page.js";
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const tokens = readFileSync(resolve(process.cwd(), "src/theme/tokens.css"), "utf8");
+const styles = readFileSync(resolve(process.cwd(), "src/styles.css"), "utf8")
+  .replace(/^@import[^;]*;\s*/gm, "");
+const appFrameSource = readFileSync(resolve(process.cwd(), "src/pages/app-frame.tsx"), "utf8");
+
+describe("HomePage environment titlebar", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let stylesheet: HTMLStyleElement;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    Object.defineProperty(window, "localStorage", { configurable: true, value: createMemoryStorage() });
+    Object.defineProperty(window, "sessionStorage", { configurable: true, value: createMemoryStorage() });
+    stylesheet = document.createElement("style");
+    stylesheet.textContent = `${tokens}\n${styles}`;
+    document.head.append(stylesheet);
+    container = document.createElement("div");
+    document.body.append(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    vi.clearAllTimers();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    stylesheet.remove();
+    document.body.replaceChildren();
+    applyWindowPlatformClass(null);
+    applyWindowFullScreenClass(false);
+  });
+
+  it.each([
+    { name: "Windows", platform: "win32", fullscreen: false },
+    { name: "Mac", platform: "darwin", fullscreen: false },
+    { name: "Windows fullscreen", platform: "win32", fullscreen: true }
+  ])("keeps $name environment controls reachable while the sidebar is toggled", ({ platform, fullscreen }) => {
+    act(() => {
+      root.render(
+        <AppProviders>
+          <AgentRuntimeBridge>
+            <CompletedConversationSeeder />
+            <HomePage />
+          </AgentRuntimeBridge>
+        </AppProviders>
+      );
+    });
+    applyWindowPlatformClass(platform);
+    applyWindowFullScreenClass(fullscreen);
+
+    const assertToolbarSpacing = () => {
+      const toolbar = container.querySelector<HTMLElement>(".app-frame-content-topbar");
+      expect(toolbar).not.toBeNull();
+      const content = toolbar!.nextElementSibling as HTMLElement;
+      expect(window.getComputedStyle(toolbar!).minHeight).toBe("46px");
+      expect(toolbar!.style.top).toBe("");
+      if (platform === "win32" && !fullscreen) {
+        expect(styles).toMatch(/body\.memmy-platform-windows:not\(\.memmy-window-fullscreen\) \.app-frame-main--windows-titlebar-safe\s*{[^}]*--app-frame-topbar-offset:\s*var\(--codex-toolbar-height\);/s);
+        expect(styles).toMatch(/\.app-frame-main--windows-titlebar-safe \.app-frame-content-topbar\s*{[^}]*top:\s*var\(--app-frame-topbar-offset, 0px\);/s);
+        expect(appFrameSource).toContain('paddingTop: "calc(var(--codex-toolbar-height) + var(--app-frame-topbar-offset, 0px))"');
+      } else {
+        expect(appFrameSource).toContain('paddingTop: "calc(var(--codex-toolbar-height) + var(--app-frame-topbar-offset, 0px))"');
+      }
+      const environmentButton = container.querySelector<HTMLButtonElement>("[data-agent-environment-toggle]");
+      expect(environmentButton).not.toBeNull();
+      expect(environmentButton!.disabled).toBe(false);
+      expect(window.getComputedStyle(environmentButton!).pointerEvents).toBe("auto");
+      expect(window.getComputedStyle(environmentButton!).getPropertyValue("-webkit-app-region")).toBe("no-drag");
+      return environmentButton!;
+    };
+
+    const environmentButton = assertToolbarSpacing();
+    expect(container.querySelector(".agent-environment-panel")).toBeNull();
+    act(() => environmentButton.click());
+    expect(environmentButton.getAttribute("aria-pressed")).toBe("true");
+    expect(container.querySelector(".agent-environment-panel")).not.toBeNull();
+
+    const hideSidebarButton = container.querySelector<HTMLButtonElement>(".sidebar-toolbar-button");
+    expect(hideSidebarButton).not.toBeNull();
+    act(() => hideSidebarButton!.click());
+    expect(container.querySelector(".app-frame-sidebar")?.getAttribute("aria-hidden")).toBe("true");
+    expect(container.querySelector(".agent-environment-panel")).not.toBeNull();
+    assertToolbarSpacing();
+
+    const showSidebarButton = container.querySelector<HTMLButtonElement>(".sidebar-restore-button");
+    expect(showSidebarButton).not.toBeNull();
+    act(() => showSidebarButton!.click());
+    expect(container.querySelector(".app-frame-sidebar")?.getAttribute("aria-hidden")).toBeNull();
+    expect(container.querySelector(".sidebar-restore-button")).toBeNull();
+    expect(container.querySelector(".agent-environment-panel")).not.toBeNull();
+    act(() => assertToolbarSpacing().click());
+    expect(container.querySelector(".agent-environment-panel")).toBeNull();
+  });
+});
+
+function CompletedConversationSeeder() {
+  const { dispatch } = useAppState();
+
+  useEffect(() => {
+    const requestId = "environment-titlebar-request";
+    dispatch(agentActions.historyLoading("websocket:environment-titlebar", "environment-titlebar", requestId));
+    dispatch(agentActions.historyLoaded({
+      schemaVersion: 1,
+      sessionKey: "websocket:environment-titlebar",
+      last_turn_closed: true,
+      messages: [
+        { role: "user", content: "Show the environment" },
+        { role: "assistant", content: "The conversation is ready." }
+      ]
+    }, requestId));
+  }, [dispatch]);
+
+  return null;
+}
+
+function createMemoryStorage(): Storage {
+  const values = new Map<string, string>();
+  return {
+    get length() {
+      return values.size;
+    },
+    clear: () => values.clear(),
+    getItem: (key) => values.get(key) ?? null,
+    key: (index) => Array.from(values.keys())[index] ?? null,
+    removeItem: (key) => values.delete(key),
+    setItem: (key, value) => values.set(key, value)
+  };
+}

--- a/App/frontend/desktop/src/styles.css
+++ b/App/frontend/desktop/src/styles.css
@@ -1609,6 +1609,15 @@ body:has(.memory-drawer) .window-drag-region {
   padding-right: var(--codex-content-padding-x);
 }
 
+/* Keep the home toolbar below Windows native controls; fullscreen has no overlay. */
+body.memmy-platform-windows:not(.memmy-window-fullscreen) .app-frame-main--windows-titlebar-safe {
+  --app-frame-topbar-offset: var(--codex-toolbar-height);
+}
+
+.app-frame-main--windows-titlebar-safe .app-frame-content-topbar {
+  top: var(--app-frame-topbar-offset, 0px);
+}
+
 .app-frame-content-topbar {
   position: absolute;
   top: 0;


### PR DESCRIPTION
## Problem

On Windows, the home page environment information and Git entry can overlap the native titlebar controls when the 46px `titleBarOverlay` is present.

## Fix

- Add an explicit Windows titlebar-safe layout offset for the home toolbar.
- Apply it only when the home topbar is present and skip it in fullscreen.
- Preserve the existing Mac layout.
- Add deterministic interaction coverage for the 46px overlay, environment button and panel, sidebar expand/collapse, and platform behavior.

## Validation

- Standard Project Harness: passed
- Affected workspace tests: 164 files, 1548 tests passed
- Focused desktop tests: 4 files, 154 tests passed
- No Windows hardware was available for local execution.

Issue: MEMMY-391
