### PR TITLE
fix(scan): migrate stale idempotency keys

### DIFF
--- a/App/backend/src/services/agent-source-service.ts
+++ b/App/backend/src/services/agent-source-service.ts
@@ -864,7 +864,7 @@ async function ingestPersistentSource(
     // out into hundreds of near-empty tool-call fragments, so an oversized turn
     // is clipped to the wire budget instead of being fanned out.
     try {
-      const added = await options.memoryClient.addMemory({
+      const added = await addMemoryWithIdempotencyMigration(options.memoryClient, {
         requestId: legacyTurnRequestId(turn),
         adapterId: `agent-source:${sourceId}`,
         content: renderTurnClipped(turn.messages),
@@ -1161,7 +1161,7 @@ async function ingestSourceSkills(
   for (const skill of skills) {
     scanOptions.signal?.throwIfAborted();
     try {
-      const added = await options.memoryClient.addMemory({
+      const added = await addMemoryWithIdempotencyMigration(options.memoryClient, {
         requestId: `agent-source-skill:${sourceId}:${skill.sourceSkillId}:${skill.sourceContentHash}`,
         adapterId: `agent-source:${sourceId}`,
         content: skill.content,
@@ -1190,6 +1190,28 @@ async function ingestSourceSkills(
     }
   }
   return { errors, errorCount, memoryIdCount };
+}
+
+async function addMemoryWithIdempotencyMigration(
+  memoryClient: Pick<MemoryClient, "addMemory">,
+  input: Parameters<MemoryClient["addMemory"]>[0]
+): ReturnType<MemoryClient["addMemory"]> {
+  try {
+    return await memoryClient.addMemory(input);
+  } catch (error) {
+    if (!isIdempotencyBodyMismatch(error)) throw error;
+    const requestId = createHash("sha256")
+      .update(`agent-source-request-v2\u0000${JSON.stringify({ ...input, requestId: undefined })}`)
+      .digest("hex");
+    return await memoryClient.addMemory({ ...input, requestId });
+  }
+}
+
+function isIdempotencyBodyMismatch(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  const code = "code" in error && typeof error.code === "string" ? error.code : "";
+  return code === "idempotency_body_mismatch"
+    || error.message.includes("idempotency key reused with different request body");
 }
 
 function filterCheckpointedConversations(

--- a/App/backend/src/services/tests/agent-source-service.test.ts
+++ b/App/backend/src/services/tests/agent-source-service.test.ts
@@ -77,6 +77,49 @@ describe("agent source service", () => {
       expect(replay.memoryIdCount).toBe(0);
     });
 
+    it("migrates stale conversation and skill idempotency keys without failing the scan", async () => {
+      tempDir = mkdtempSync(join(tmpdir(), "memmy-idempotency-migration-"));
+      const messages = createCompleteMemoryMessages("codex", 1, "2026-05-28T10:00:00.000Z");
+      const memoryClient = createMockMemoryClient();
+      const added: Parameters<MemoryClient["addMemory"]>[0][] = [];
+      const service = createService({
+        scanStoreDirectory: tempDir,
+        adapters: [createFakeAdapter("codex", messages)],
+        memoryClient: {
+          ...memoryClient,
+          async addMemory(input) {
+            added.push(input);
+            if (added.length === 1 || added.length === 3) {
+              throw Object.assign(new Error("idempotency key reused with different request body"), {
+                code: "idempotency_body_mismatch"
+              });
+            }
+            return { ...await memoryClient.addMemory(input), id: `memory-${added.length}` };
+          },
+          async getMemoryProcessingStatus(ids) {
+            return { items: ids.map((memoryId) => ({ memoryId, state: "ready" as const, attemptCount: 0, manualRetryCount: 0, retryAction: "retry" as const, updatedAt: "2026-05-28T10:00:00.000Z" })), serverTime: "2026-05-28T10:00:00.000Z" };
+          }
+        },
+        skillDistributionService: {
+          async listSkills() {
+            return [{
+              sourceAgentId: "codex", sourceSkillId: "review-code", sourceSkillPath: "/tmp/codex/skills/review-code/SKILL.md",
+              sourceSkillVersion: "v1", sourceContentHash: "same-content", title: "review-code",
+              content: "Review changed code.", updatedAt: "2026-05-28T09:00:00.000Z"
+            }];
+          },
+          async install() {}, async uninstall() {}, async installPlugin() {}, async uninstallPlugin() {}
+        }
+      });
+
+      const result = await service.scanOne("codex", { mode: "full" });
+
+      expect(result.errors).toEqual([]);
+      expect(added).toHaveLength(4);
+      expect(added[1]?.requestId).not.toBe(added[0]?.requestId);
+      expect(added[3]?.requestId).not.toBe(added[2]?.requestId);
+    });
+
     it.each([
       ["after the watermark", "2026-05-28T10:01:53.000Z", ["query 1"]],
       ["ending exactly at the watermark", "2026-05-28T10:01:52.000Z", ["query 2", "query 1"]],

--- a/Memory/src/agent-source/runtime.ts
+++ b/Memory/src/agent-source/runtime.ts
@@ -789,7 +789,7 @@ async function ingestStagedMessages(
     // out into hundreds of near-empty tool-call fragments, so an oversized turn
     // is clipped to the wire budget instead of being fanned out.
     try {
-      const added = service.addMemory({
+      const added = addMemoryWithIdempotencyMigration(service, {
         requestId: legacyTurnRequestId(turn), adapterId: `agent-source:${sourceId}`,
         content: renderTurnClipped(turn.messages), layer: "L1",
         title: titleForTurn(sourceId, turn.messages), tags: ["agent-source", sourceId], source: sourceId,
@@ -960,7 +960,7 @@ async function ingestAgentSkills(
     const requestId = `agent-source-skill:${sourceId}:${sourceSkillId}:${contentHash}`;
     const fileStat = await stat(filePath);
     try {
-      const added = service.addMemory({
+      const added = addMemoryWithIdempotencyMigration(service, {
         requestId,
         adapterId: `agent-source:${sourceId}`,
         content,
@@ -993,6 +993,25 @@ async function ingestAgentSkills(
   }
   flush(true);
   return { written, memoryIdCount, errorCount, errors };
+}
+
+function addMemoryWithIdempotencyMigration(
+  service: Pick<MemoryService, "addMemory">,
+  input: Parameters<MemoryService["addMemory"]>[0]
+): ReturnType<MemoryService["addMemory"]> {
+  try {
+    return service.addMemory(input);
+  } catch (error) {
+    if (!(error instanceof MemoryServiceError)
+      || error.code !== "conflict"
+      || !error.message.includes("idempotency key reused with different request body")) {
+      throw error;
+    }
+    const requestId = createHash("sha256")
+      .update(`agent-source-request-v2\u0000${JSON.stringify({ ...input, requestId: undefined })}`)
+      .digest("hex");
+    return service.addMemory({ ...input, requestId });
+  }
 }
 
 async function* findSkillFiles(root: string): AsyncGenerator<string> {


### PR DESCRIPTION
## Problem
Repeated Codex scans can reuse a legacy idempotency key after the request body changes. The memory service correctly rejects the mismatch, causing the desktop scan to finish with errors. Skill file mtimes can trigger the same failure even when content is unchanged.

## Fix
Retry only confirmed idempotency-body mismatches with a v2 key derived from the exact add-memory payload. Other errors still fail closed. Apply the same migration behavior to the desktop backend and bundled Memory runtime.

## Verification
- Backend agent-source service: 44 tests passed
- Backend TypeScript typecheck passed
- Memory TypeScript typecheck passed
- Memory agent-source runtime: 17 tests passed