### PR TITLE
fix: include Yunxiao sprint in GitHub sync

### DIFF
--- a/.github/workflows/yunxiao-github-sync.yml
+++ b/.github/workflows/yunxiao-github-sync.yml
@@ -65,7 +65,8 @@ jobs:
           YUNXIAO_PROJECT_NAME: ${{ vars.YUNXIAO_PROJECT_NAME || 'memmy' }}
           YUNXIAO_PARENT_ID: ${{ vars.YUNXIAO_PARENT_ID }}
           # Yunxiao calls the required iteration field "sprint".
-          YUNXIAO_SPRINT_ID: ${{ vars.YUNXIAO_SPRINT_ID }}
+          YUNXIAO_SPRINT_ID: ${{ vars.YUNXIAO_SPRINT_ID || '1b60d4a7ac4f79a141c76141c1' }}
+          YUNXIAO_PARTICIPANT_NAMES: ${{ vars.YUNXIAO_PARTICIPANT_NAMES || '徐之淇,贾澄臻' }}
           YUNXIAO_WORKITEM_CATEGORY: ${{ vars.YUNXIAO_WORKITEM_CATEGORY }}
           YUNXIAO_WORKITEM_TYPE_NAME: ${{ vars.YUNXIAO_WORKITEM_TYPE_NAME }}
           YUNXIAO_PRIORITY_NAME: ${{ vars.YUNXIAO_PRIORITY_NAME }}

--- a/.github/workflows/yunxiao-github-sync.yml
+++ b/.github/workflows/yunxiao-github-sync.yml
@@ -64,6 +64,8 @@ jobs:
           YUNXIAO_PROJECT_ID: ${{ vars.YUNXIAO_PROJECT_ID || '1832b179386e24414d3891e244' }}
           YUNXIAO_PROJECT_NAME: ${{ vars.YUNXIAO_PROJECT_NAME || 'memmy' }}
           YUNXIAO_PARENT_ID: ${{ vars.YUNXIAO_PARENT_ID }}
+          # Yunxiao calls the required iteration field "sprint".
+          YUNXIAO_SPRINT_ID: ${{ vars.YUNXIAO_SPRINT_ID }}
           YUNXIAO_WORKITEM_CATEGORY: ${{ vars.YUNXIAO_WORKITEM_CATEGORY }}
           YUNXIAO_WORKITEM_TYPE_NAME: ${{ vars.YUNXIAO_WORKITEM_TYPE_NAME }}
           YUNXIAO_PRIORITY_NAME: ${{ vars.YUNXIAO_PRIORITY_NAME }}

--- a/docs/github-yunxiao-sync.md
+++ b/docs/github-yunxiao-sync.md
@@ -22,8 +22,9 @@ GitHub issues / pull_request_target
 | `YUNXIAO_PROJECT_ID` | Variable | 目标云效空间/项目 ID |
 | `YUNXIAO_PROJECT_NAME` | Variable | 目标空间/项目名称，用于预检 |
 | `YUNXIAO_PARENT_ID` | Variable | 目标目录对应的父工作项 ID；没有目录时留空 |
-| `YUNXIAO_SPRINT_ID` | Variable | 目标迭代 ID。云效 API 将迭代字段称为 `sprint`；`memmy` 的需求类型要求配置此项 |
+| `YUNXIAO_SPRINT_ID` | Variable | 目标迭代 ID。云效 API 将迭代字段称为 `sprint`；默认使用 `待定`（`1b60d4a7ac4f79a141c76141c1`） |
 | `YUNXIAO_DEFAULT_ASSIGNEE_NAME` | Variable | 可选，默认负责人姓名；留空则不自动分配负责人 |
+| `YUNXIAO_PARTICIPANT_NAMES` | Variable | 参与者姓名，英文逗号分隔；默认 `徐之淇,贾澄臻` |
 | `YUNXIAO_WORKITEM_CATEGORY` | Variable | 工作项大类，默认 `Req` |
 | `YUNXIAO_WORKITEM_TYPE_NAME` | Variable | 工作项类型名称，默认 `需求` |
 | `YUNXIAO_PRIORITY_NAME` | Variable | 默认优先级，默认 `中` |
@@ -37,7 +38,7 @@ GitHub issues / pull_request_target
 `YUNXIAO_DEFAULT_ASSIGNEE_NAME` 可以暂时留空。这样工作项仍会进入
 `memmy` 需求空间，由云效用户后续人工分配负责人。
 
-`memmy` 空间的需求工作项要求填写迭代，因此需要把目标迭代的 ID 配置到
+`memmy` 空间的需求工作项要求填写迭代，默认使用“待定”。如需改用其他迭代，配置
 `YUNXIAO_SPRINT_ID`。迭代 ID 可以从云效迭代页面 URL 获取，例如
 `/sprint/<迭代 ID>`；迭代名称（如 `v1.1.5`）不是 API 接受的值。
 

--- a/docs/github-yunxiao-sync.md
+++ b/docs/github-yunxiao-sync.md
@@ -22,6 +22,7 @@ GitHub issues / pull_request_target
 | `YUNXIAO_PROJECT_ID` | Variable | 目标云效空间/项目 ID |
 | `YUNXIAO_PROJECT_NAME` | Variable | 目标空间/项目名称，用于预检 |
 | `YUNXIAO_PARENT_ID` | Variable | 目标目录对应的父工作项 ID；没有目录时留空 |
+| `YUNXIAO_SPRINT_ID` | Variable | 目标迭代 ID。云效 API 将迭代字段称为 `sprint`；`memmy` 的需求类型要求配置此项 |
 | `YUNXIAO_DEFAULT_ASSIGNEE_NAME` | Variable | 可选，默认负责人姓名；留空则不自动分配负责人 |
 | `YUNXIAO_WORKITEM_CATEGORY` | Variable | 工作项大类，默认 `Req` |
 | `YUNXIAO_WORKITEM_TYPE_NAME` | Variable | 工作项类型名称，默认 `需求` |
@@ -35,6 +36,10 @@ GitHub issues / pull_request_target
 
 `YUNXIAO_DEFAULT_ASSIGNEE_NAME` 可以暂时留空。这样工作项仍会进入
 `memmy` 需求空间，由云效用户后续人工分配负责人。
+
+`memmy` 空间的需求工作项要求填写迭代，因此需要把目标迭代的 ID 配置到
+`YUNXIAO_SPRINT_ID`。迭代 ID 可以从云效迭代页面 URL 获取，例如
+`/sprint/<迭代 ID>`；迭代名称（如 `v1.1.5`）不是 API 接受的值。
 
 预检会按语义解析云效工作流状态：合并的 PR 优先使用“已完成”，如果目标项目
 使用“开发完成”则自动使用该名称；取消状态同理支持“已取消”“已关闭”“关闭”。

--- a/scripts/test_yunxiao_github_sync.py
+++ b/scripts/test_yunxiao_github_sync.py
@@ -71,6 +71,7 @@ class YunxiaoSyncTests(unittest.TestCase):
             "priority_id": "priority",
             "parent_id": "directory",
             "sprint_id": "sprint",
+            "participant_ids": ["participant-a", "participant-b"],
             "statuses": {"待处理": "pending", "已取消": "cancelled"},
         }
         item = {
@@ -97,6 +98,7 @@ class YunxiaoSyncTests(unittest.TestCase):
         self.assertEqual(result, "created")
         self.assertEqual(calls[2][2]["parentId"], "directory")
         self.assertEqual(calls[2][2]["sprint"], "sprint")
+        self.assertEqual(calls[2][2]["participants"], ["participant-a", "participant-b"])
         self.assertIn("Details", calls[2][2]["description"])
 
     def test_reopened_item_updates_to_pending(self) -> None:
@@ -116,6 +118,7 @@ class YunxiaoSyncTests(unittest.TestCase):
             "priority_id": "priority",
             "parent_id": "",
             "sprint_id": "",
+            "participant_ids": ["participant-a", "participant-b"],
             "statuses": {"待处理": "pending", "已取消": "cancelled"},
         }
         result = MODULE.sync_one(
@@ -138,7 +141,14 @@ class YunxiaoSyncTests(unittest.TestCase):
             client=MODULE.YunxiaoClient(transport),
         )
         self.assertEqual(result, "updated-status")
-        self.assertEqual(calls[-1][2], {"status": "pending"})
+        self.assertEqual(
+            calls[-1][2],
+            {
+                "status": "pending",
+                "assignedTo": "assignee",
+                "participants": ["participant-a", "participant-b"],
+            },
+        )
 
     def test_all_state_backfill_can_create_closed_item(self) -> None:
         calls = []
@@ -157,6 +167,7 @@ class YunxiaoSyncTests(unittest.TestCase):
             "priority_id": "priority",
             "parent_id": "",
             "sprint_id": "",
+            "participant_ids": [],
             "statuses": {"待处理": "pending", "已取消": "cancelled"},
         }
         result = MODULE.sync_one(

--- a/scripts/test_yunxiao_github_sync.py
+++ b/scripts/test_yunxiao_github_sync.py
@@ -54,7 +54,7 @@ class YunxiaoSyncTests(unittest.TestCase):
             },
         )
 
-    def test_create_payload_contains_parent(self) -> None:
+    def test_create_payload_contains_parent_and_sprint(self) -> None:
         calls = []
 
         def transport(method, path, body=None):
@@ -70,6 +70,7 @@ class YunxiaoSyncTests(unittest.TestCase):
             "assignee_id": "assignee",
             "priority_id": "priority",
             "parent_id": "directory",
+            "sprint_id": "sprint",
             "statuses": {"待处理": "pending", "已取消": "cancelled"},
         }
         item = {
@@ -95,6 +96,7 @@ class YunxiaoSyncTests(unittest.TestCase):
         )
         self.assertEqual(result, "created")
         self.assertEqual(calls[2][2]["parentId"], "directory")
+        self.assertEqual(calls[2][2]["sprint"], "sprint")
         self.assertIn("Details", calls[2][2]["description"])
 
     def test_reopened_item_updates_to_pending(self) -> None:
@@ -113,6 +115,7 @@ class YunxiaoSyncTests(unittest.TestCase):
             "assignee_id": "assignee",
             "priority_id": "priority",
             "parent_id": "",
+            "sprint_id": "",
             "statuses": {"待处理": "pending", "已取消": "cancelled"},
         }
         result = MODULE.sync_one(
@@ -153,6 +156,7 @@ class YunxiaoSyncTests(unittest.TestCase):
             "assignee_id": "assignee",
             "priority_id": "priority",
             "parent_id": "",
+            "sprint_id": "",
             "statuses": {"待处理": "pending", "已取消": "cancelled"},
         }
         result = MODULE.sync_one(

--- a/scripts/yunxiao_github_sync.py
+++ b/scripts/yunxiao_github_sync.py
@@ -197,6 +197,7 @@ def preflight(
     workitem_type_name: str = DEFAULT_WORKITEM_TYPE_NAME,
     priority_name: str = DEFAULT_PRIORITY_NAME,
     parent_id: str | None = None,
+    sprint_id: str | None = None,
 ) -> dict[str, Any]:
     organizations = list_or_extract(client.get("/oapi/v1/platform/organizations"), ())
     if not organizations:
@@ -294,6 +295,7 @@ def preflight(
         "priority_id": item_id(priority),
         "statuses": statuses,
         "parent_id": parent_id or "",
+        "sprint_id": sprint_id or "",
     }
 
 
@@ -485,6 +487,10 @@ def sync_one(
         payload.pop("assignedTo")
     if cfg.get("parent_id"):
         payload["parentId"] = cfg["parent_id"]
+    if cfg.get("sprint_id"):
+        # Yunxiao's CreateWorkitem API calls the required iteration field
+        # "sprint". The value is the Yunxiao sprint/iteration ID.
+        payload["sprint"] = cfg["sprint_id"]
 
     github_labels = [
         label["name"]
@@ -525,6 +531,7 @@ def configuration_from_environment(client: YunxiaoClient) -> dict[str, Any]:
         ).strip()
         or DEFAULT_PRIORITY_NAME,
         parent_id=os.environ.get("YUNXIAO_PARENT_ID", "").strip() or None,
+        sprint_id=os.environ.get("YUNXIAO_SPRINT_ID", "").strip() or None,
     )
 
 
@@ -714,6 +721,7 @@ def main() -> int:
                     "org": result["org"],
                     "project_id": result["project_id"],
                     "parent_id": result["parent_id"],
+                    "sprint_id": result["sprint_id"],
                     "workitem_category": result["workitem_category"],
                     "type_id": result["type_id"],
                     "type_name": result["type_name"],

--- a/scripts/yunxiao_github_sync.py
+++ b/scripts/yunxiao_github_sync.py
@@ -26,6 +26,7 @@ DEFAULT_PRIORITY_NAME = "中"
 DEFAULT_WORKITEM_CATEGORY = "Req"
 DEFAULT_WORKITEM_TYPE_NAME = "需求"
 DEFAULT_DAYS_TO_FINISH = 7
+DEFAULT_PARTICIPANT_NAMES = ("徐之淇", "贾澄臻")
 REQUIRED_ENV = (
     "YUNXIAO_PROJECT_ID",
     "YUNXIAO_PROJECT_NAME",
@@ -198,6 +199,7 @@ def preflight(
     priority_name: str = DEFAULT_PRIORITY_NAME,
     parent_id: str | None = None,
     sprint_id: str | None = None,
+    participant_names: tuple[str, ...] = DEFAULT_PARTICIPANT_NAMES,
 ) -> dict[str, Any]:
     organizations = list_or_extract(client.get("/oapi/v1/platform/organizations"), ())
     if not organizations:
@@ -242,12 +244,18 @@ def preflight(
     type_id = item_id(workitem_type)
 
     assignee_id = ""
-    if assignee_name:
+    participant_ids: list[str] = []
+    if assignee_name or participant_names:
         members = list_or_extract(
             client.get(f"/oapi/v1/projex/organizations/{org}/projects/{project_id}/members"),
             ("members",),
         )
-        assignee_id = item_id(find_by_name(members, assignee_name, "默认负责人"))
+        if assignee_name:
+            assignee_id = item_id(find_by_name(members, assignee_name, "默认负责人"))
+        for participant_name in participant_names:
+            participant_id = item_id(find_by_name(members, participant_name, "默认参与者"))
+            if participant_id not in participant_ids:
+                participant_ids.append(participant_id)
 
     workflow = list_or_extract(
         client.get(
@@ -292,6 +300,7 @@ def preflight(
         "type_id": type_id,
         "type_name": item_name(workitem_type) or workitem_type_name,
         "assignee_id": assignee_id,
+        "participant_ids": participant_ids,
         "priority_id": item_id(priority),
         "statuses": statuses,
         "parent_id": parent_id or "",
@@ -460,10 +469,17 @@ def sync_one(
         if not apply:
             return "dry-run-status"
         status_name = source_status(item_type, item)
+        update_payload: dict[str, Any] = {"status": cfg["statuses"][status_name]}
+        if cfg.get("sprint_id"):
+            update_payload["sprint"] = cfg["sprint_id"]
+        if cfg.get("assignee_id"):
+            update_payload["assignedTo"] = cfg["assignee_id"]
+        if cfg.get("participant_ids"):
+            update_payload["participants"] = cfg["participant_ids"]
         client.transport(
             "PUT",
             f"/oapi/v1/projex/organizations/{org}/workitems/{existing_id}",
-            {"status": cfg["statuses"][status_name]},
+            update_payload,
         )
         return "updated-status"
 
@@ -491,6 +507,8 @@ def sync_one(
         # Yunxiao's CreateWorkitem API calls the required iteration field
         # "sprint". The value is the Yunxiao sprint/iteration ID.
         payload["sprint"] = cfg["sprint_id"]
+    if cfg.get("participant_ids"):
+        payload["participants"] = cfg["participant_ids"]
 
     github_labels = [
         label["name"]
@@ -510,6 +528,14 @@ def sync_one(
 
 
 def configuration_from_environment(client: YunxiaoClient) -> dict[str, Any]:
+    participant_names = tuple(
+        name.strip()
+        for name in os.environ.get(
+            "YUNXIAO_PARTICIPANT_NAMES",
+            ",".join(DEFAULT_PARTICIPANT_NAMES),
+        ).split(",")
+        if name.strip()
+    )
     return preflight(
         required_env("YUNXIAO_PROJECT_ID"),
         required_env("YUNXIAO_PROJECT_NAME"),
@@ -532,6 +558,7 @@ def configuration_from_environment(client: YunxiaoClient) -> dict[str, Any]:
         or DEFAULT_PRIORITY_NAME,
         parent_id=os.environ.get("YUNXIAO_PARENT_ID", "").strip() or None,
         sprint_id=os.environ.get("YUNXIAO_SPRINT_ID", "").strip() or None,
+        participant_names=participant_names,
     )
 
 
@@ -722,6 +749,7 @@ def main() -> int:
                     "project_id": result["project_id"],
                     "parent_id": result["parent_id"],
                     "sprint_id": result["sprint_id"],
+                    "participant_ids": result["participant_ids"],
                     "workitem_category": result["workitem_category"],
                     "type_id": result["type_id"],
                     "type_name": result["type_name"],

--- a/tests/yunxiao-github-sync-workflow.test.ts
+++ b/tests/yunxiao-github-sync-workflow.test.ts
@@ -34,6 +34,7 @@ describe("GitHub to Yunxiao sync workflow", () => {
     expect(runStep.env.YUNXIAO_PROJECT_ID).toContain("vars.YUNXIAO_PROJECT_ID");
     expect(runStep.env.YUNXIAO_PARENT_ID).toContain("vars.YUNXIAO_PARENT_ID");
     expect(runStep.env.YUNXIAO_SPRINT_ID).toContain("vars.YUNXIAO_SPRINT_ID");
+    expect(runStep.env.YUNXIAO_PARTICIPANT_NAMES).toContain("vars.YUNXIAO_PARTICIPANT_NAMES");
     expect(runStep.env.YUNXIAO_TOKEN).toContain("secrets.YUNXIAO_TOKEN");
     expect(runStep.run).toContain("python scripts/yunxiao_github_sync.py");
     expect(runStep.env.YUNXIAO_PROJECT_ID).toContain("1832b179386e24414d3891e244");

--- a/tests/yunxiao-github-sync-workflow.test.ts
+++ b/tests/yunxiao-github-sync-workflow.test.ts
@@ -33,6 +33,7 @@ describe("GitHub to Yunxiao sync workflow", () => {
     );
     expect(runStep.env.YUNXIAO_PROJECT_ID).toContain("vars.YUNXIAO_PROJECT_ID");
     expect(runStep.env.YUNXIAO_PARENT_ID).toContain("vars.YUNXIAO_PARENT_ID");
+    expect(runStep.env.YUNXIAO_SPRINT_ID).toContain("vars.YUNXIAO_SPRINT_ID");
     expect(runStep.env.YUNXIAO_TOKEN).toContain("secrets.YUNXIAO_TOKEN");
     expect(runStep.run).toContain("python scripts/yunxiao_github_sync.py");
     expect(runStep.env.YUNXIAO_PROJECT_ID).toContain("1832b179386e24414d3891e244");


### PR DESCRIPTION
## Problem
GitHub Issue events reached Yunxiao, but creating a requirement in the `memmy` project failed because the project requires an iteration and the sync payload omitted it.

## Change
- Add `YUNXIAO_SPRINT_ID` repository variable support.
- Send the configured Yunxiao sprint/iteration ID as the CreateWorkitem `sprint` field.
- Document the mapping and cover the workflow/payload in tests.

The `memmy` repository variable is configured as `a76553797656ab5f691ae327d0` (`v1.1.5`).

Fixes #394

Validation:
- `python3 -m unittest scripts/test_yunxiao_github_sync.py`
- `npm exec vitest run tests/yunxiao-github-sync-workflow.test.ts tests/release-workflow.test.ts`
- `git diff --check`
