### PR TITLE
fix(memory): declare uiConversation inject in DeepSeek Harness client…

### DIFF
--- a/App/backend/src/adapters/outbound/skill-writer/deepseek-harness/tests/target.test.ts
+++ b/App/backend/src/adapters/outbound/skill-writer/deepseek-harness/tests/target.test.ts
@@ -125,7 +125,7 @@ describe("DeepSeek Harness skill target", () => {
 
     let definition: Record<string, any> | undefined;
     const client = handoff?.factory();
-    expect(client?.inject).toEqual([]);
+    expect(client?.inject).toEqual(["uiConversation"]);
     client?.apply({
       get(name: string) {
         return name === "conversationEvents"

--- a/App/backend/src/adapters/outbound/skill-writer/templates/memmy-deepseek-harness-plugin.ts
+++ b/App/backend/src/adapters/outbound/skill-writer/templates/memmy-deepseek-harness-plugin.ts
@@ -527,7 +527,7 @@ export const DEEPSEEK_HARNESS_PLUGIN_CLIENT = String.raw`window.__ModuleLoader__
     const exports = module.exports;
 
     const name = "memmy-memory-client";
-    const inject = [];
+    const inject = ["uiConversation"];
 
     function resolveConversationEventRegistry(ctx) {
       const uiConversation = ctx.get("uiConversation");

--- a/Memory/src/agent-source/integration/templates/memmy-deepseek-harness-plugin.ts
+++ b/Memory/src/agent-source/integration/templates/memmy-deepseek-harness-plugin.ts
@@ -527,7 +527,7 @@ export const DEEPSEEK_HARNESS_PLUGIN_CLIENT = String.raw`window.__ModuleLoader__
     const exports = module.exports;
 
     const name = "memmy-memory-client";
-    const inject = [];
+    const inject = ["uiConversation"];
 
     function resolveConversationEventRegistry(ctx) {
       const uiConversation = ctx.get("uiConversation");


### PR DESCRIPTION
… plugin

The generated @memmy/memmy-memory client module declared an empty inject array, so cordis applied it before the uiConversation service was ready. resolveConversationEventRegistry then found neither uiConversation.events nor conversationEvents, threw, and the whole plugin tree failed to load:

  Failed to load plugins

  @memmy/memmy-memory: memmy-memory requires uiConversation.events or conversationEvents

dsh 0.1.2-rc.1 / 0.1.5 expose the conversation event registry as the uiConversation service (provided by @deepseek-ai/dsh-client-ui-conversation), and dsh's own client plugins (e.g. dsh-client-ui-goal) wait for it by listing uiConversation in their exported inject. Adding it here makes cordis defer apply until the service exists, so the optimistic user bubble registers normally instead of aborting plugin activation.

Also update the client inject assertion in the DeepSeek Harness target test.